### PR TITLE
fix: update Prices channel and handle subscribed message type

### DIFF
--- a/examples/consume_data_feed.py
+++ b/examples/consume_data_feed.py
@@ -57,7 +57,8 @@ def on_message_prices(ws: ReyaSocket, message: dict):
         print("Connected")
         for price_stream in market_price_streams:
             ws.prices.subscribe(id=price_stream)
-    if message["type"] == "channel_data":
+    
+    if message["type"] == "subscribed":
         print(message)
 
         prices[message["id"]] = message["contents"]

--- a/reya_data_feed/consumer.py
+++ b/reya_data_feed/consumer.py
@@ -34,7 +34,7 @@ class Candles(Channel):
 
 
 class Prices(Channel):
-    channel = "prices"
+    channel = "/api/trading/markets/data"
 
     def subscribe(self, id, batched=False) -> Self:
         return super().subscribe(id=id, batched=batched)


### PR DESCRIPTION
- Updated Prices WebSocket channel to `/api/trading/markets/data`
- Handled the `subscribed` message instead of `channel_data`
- Ensures prices get populated properly after subscription