### PR TITLE
Reya SDK Bugfix path to ABI

### DIFF
--- a/sdk/reya_rpc/actions/bridge_in.py
+++ b/sdk/reya_rpc/actions/bridge_in.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 from dataclasses import dataclass
 
 from web3 import Web3
@@ -17,10 +18,10 @@ class BridgeInParams:
 
 
 # Load contract ABI files
-with open("sdk/reya_rpc/abis/SocketVaultWithPayload.json", encoding="utf-8") as f:
+with open(pathlib.Path(__file__).parent.parent/"abis/SocketVaultWithPayload.json", encoding="utf-8") as f:
     vault_abi = json.load(f)
 
-with open("sdk/reya_rpc/abis/Erc20.json", encoding="utf-8") as f:
+with open(pathlib.Path(__file__).parent.parent/"abis/Erc20.json", encoding="utf-8") as f:
     erc20_abi = json.load(f)
 
 

--- a/sdk/reya_rpc/actions/bridge_out.py
+++ b/sdk/reya_rpc/actions/bridge_out.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 from dataclasses import dataclass
 
 from sdk.reya_rpc.exceptions import NetworkConfigurationError
@@ -14,10 +15,10 @@ class BridgeOutParams:
 
 
 # Load contract ABI files
-with open("sdk/reya_rpc/abis/SocketControllerWithPayload.json", encoding="utf-8") as f:
+with open(pathlib.Path(__file__).parent.parent/"abis/SocketControllerWithPayload.json", encoding="utf-8") as f:
     controller_abi = json.load(f)
 
-with open("sdk/reya_rpc/abis/Erc20.json", encoding="utf-8") as f:
+with open(pathlib.Path(__file__).parent.parent/"abis/Erc20.json", encoding="utf-8") as f:
     erc20_abi = json.load(f)
 
 


### PR DESCRIPTION
(cherry picked from commit 7349dbb751b40d99482f7eaf2a354f9a9d33e158)

the path to the ABI not works if the Reya SDK is included as a lib or a test is located into another directory.
the fix rebases the path, so it works from every location