### PR TITLE
fix: allow negative values in balance regex validators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reya-python-sdk"
-version = "2.1.3.5"
+version = "2.1.3.6"
 description = "SDK for interacting with Reya Labs APIs"
 authors = [
     {name = "Reya Labs"}

--- a/sdk/open_api/models/account_balance.py
+++ b/sdk/open_api/models/account_balance.py
@@ -44,15 +44,15 @@ class AccountBalance(BaseModel):
     @field_validator('real_balance')
     def real_balance_validate_regular_expression(cls, value):
         """Validates the regular expression"""
-        if not re.match(r"^\d+(\.\d+)?([eE][+-]?\d+)?$", value):
-            raise ValueError(r"must validate the regular expression /^\d+(\.\d+)?([eE][+-]?\d+)?$/")
+        if not re.match(r"^-?\d+(\.\d+)?([eE][+-]?\d+)?$", value):
+            raise ValueError(r"must validate the regular expression /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/")
         return value
 
     @field_validator('balance_deprecated')
     def balance_deprecated_validate_regular_expression(cls, value):
         """Validates the regular expression"""
-        if not re.match(r"^\d+(\.\d+)?([eE][+-]?\d+)?$", value):
-            raise ValueError(r"must validate the regular expression /^\d+(\.\d+)?([eE][+-]?\d+)?$/")
+        if not re.match(r"^-?\d+(\.\d+)?([eE][+-]?\d+)?$", value):
+            raise ValueError(r"must validate the regular expression /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/")
         return value
 
     model_config = ConfigDict(


### PR DESCRIPTION
The balanceDEPRECATED and realBalance regex validators rejected negative balance strings (e.g. '-0.012829'). Updated regex from ^\d+ to ^-?\d+ to accept an optional leading minus sign.