### PR TITLE
test(perps): bump test_perp_gtc_rests_on_book retry budget to 6s

### DIFF
--- a/tests/test_perps/test_limit_orders.py
+++ b/tests/test_perps/test_limit_orders.py
@@ -106,11 +106,17 @@ async def test_perp_gtc_rests_on_book(perp_maker_tester: ReyaTester) -> None:
     )
     assert order_id is not None
 
-    # Indexer can lag the create-order response by a few hundred ms before
-    # the GTC shows up in `get_open_orders`. Retry briefly so we don't
-    # false-fail on propagation timing.
+    # The API pod's `OrdersProvider` stream consumer (in
+    # packages/common-backend/src/providers/redis-stream-reader.ts) calls
+    # `XREAD BLOCK 5000` against the `{orders}:changes` Redis Stream, and
+    # measurement showed the BLOCK isn't being woken up by new messages —
+    # propagation to `/v2/wallet/{address}/openOrders` is clamped at the
+    # 5,000 ms timeout. The 6 s retry budget below covers that worst case
+    # with a small margin; once the underlying lag is fixed (off-chain
+    # repo issue Reya-Labs/reya-off-chain-monorepo#2663) we can drop this
+    # back to ~500 ms.
     open_order = None
-    for _ in range(20):
+    for _ in range(60):
         open_order = await perp_maker_tester.data.open_order(order_id)
         if open_order is not None:
             break


### PR DESCRIPTION
## Summary

Workaround for a deterministic ~5 s propagation lag on the off-chain API's `/v2/wallet/{address}/openOrders` endpoint. Bumps the test's retry budget from 2 s → 6 s so it stops flaking while the underlying off-chain bug is fixed.

## Root cause (off-chain, not SDK)

Direct measurement against devnet1 showed the `OrdersProvider` Redis Stream consumer in `packages/common-backend/src/providers/redis-stream-reader.ts` is clamped at its `XREAD BLOCK 5000` timeout — new messages aren't waking up the BLOCK, so consumed messages only surface every 5 s.

| Trial | API create response | Propagation to `/openOrders` |
|-------|---------------------|------------------------------|
| 1 | 36 ms | 131 ms |
| 2 | 41 ms | 4,871 ms |
| 3 | 44 ms | 4,876 ms |
| 4 | 38 ms | 4,981 ms |
| 5 | 32 ms | 4,909 ms |

Previous 2 s budget caught the first ~40 % of the BLOCK cycle (Trial 1-style timing) but missed the rest → ~20 % flake.

## Tracking

- **Off-chain repo (the actual fix)**: [Reya-Labs/reya-off-chain-monorepo#2663](https://github.com/Reya-Labs/reya-off-chain-monorepo/issues/2663) — full diagnostic, candidate root causes (ioredis cluster routing / degraded streamClient / xreadBuffer BLOCK bug), suggested investigation steps, fallback workaround. Daniel tagged + Slack DM sent.
- **Linear**: [PRO-105](https://linear.app/reya-labs/issue/PRO-105) — assigned to Daniel, medium priority.

## When to revert

Once the off-chain `XREAD` wake-up is fixed, drop the budget back to ~500 ms (5 iterations × 100 ms). The comment in the test points to the issue so the connection isn't lost.

## Test plan

- [x] Re-run `poetry run pytest tests/test_perps` — expect `test_perp_gtc_rests_on_book` to pass reliably across multiple runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)