### PR TITLE
Fix devnet1 OrdersGateway address (stale default broke EIP-712 signing)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,17 @@ CHAIN_ID=89346162
 REYA_WS_URL="wss://websocket-devnet.reya-cronos.network/"
 REYA_WS_EXEC_URL="wss://ws-exec-devnet.reya-cronos.network"
 REYA_API_URL="https://api-devnet.reya-cronos.network/v2"
+# OrdersGateway proxy = the EIP-712 verifyingContract. Set this on devnet1: the
+# baked-in fallback is stale here, so leaving it unset makes the matching engine
+# reject every order with an opaque "invalid signature" error.
+REYA_ORDERS_GATEWAY="0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
 
 ### Reya Network (mainnet)
 #CHAIN_ID=1729
 #REYA_WS_URL="wss://ws.reya.xyz/"
 #REYA_WS_EXEC_URL="wss://ws-exec.reya.xyz"
 #REYA_API_URL="https://api.reya.xyz/v2"
+#REYA_ORDERS_GATEWAY="0xfc8c96be87da63cecddbf54abfa7b13ee8044739"
 
 ### Staging (uses mainnet chain ID 1729)
 #CHAIN_ID=1729

--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,8 @@ CHAIN_ID=89346162
 REYA_WS_URL="wss://websocket-devnet.reya-cronos.network/"
 REYA_WS_EXEC_URL="wss://ws-exec-devnet.reya-cronos.network"
 REYA_API_URL="https://api-devnet.reya-cronos.network/v2"
-# OrdersGateway proxy = the EIP-712 verifyingContract (defaults to the devnet1
-# value, so you don't need to set it for devnet1).
-#REYA_ORDERS_GATEWAY="0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
+# OrdersGateway proxy = the EIP-712 verifyingContract.
+REYA_ORDERS_GATEWAY="0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
 
 ### Cronos testnet (same chain id as devnet1, different deployment)
 #CHAIN_ID=89346162

--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,10 @@ CHAIN_ID=89346162
 REYA_WS_URL="wss://websocket-devnet.reya-cronos.network/"
 REYA_WS_EXEC_URL="wss://ws-exec-devnet.reya-cronos.network"
 REYA_API_URL="https://api-devnet.reya-cronos.network/v2"
-# OrdersGateway proxy = the EIP-712 verifyingContract. Set this on devnet1: the
-# baked-in fallback is stale here, so leaving it unset makes the matching engine
-# reject every order with an opaque "invalid signature" error.
-REYA_ORDERS_GATEWAY="0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
+# OrdersGateway proxy = the EIP-712 verifyingContract. Defaults to the devnet1
+# gateway, so you don't need to set this for devnet1. Uncomment to override —
+# e.g. to target the legacy cronos testnet (0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5).
+#REYA_ORDERS_GATEWAY="0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
 
 ### Reya Network (mainnet)
 #CHAIN_ID=1729

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,19 @@
-### Devnet1 (testnet — perpOB-enabled, replaces cronos)
+### Devnet1 (perpOB testnet)
 CHAIN_ID=89346162
 REYA_WS_URL="wss://websocket-devnet.reya-cronos.network/"
 REYA_WS_EXEC_URL="wss://ws-exec-devnet.reya-cronos.network"
 REYA_API_URL="https://api-devnet.reya-cronos.network/v2"
-# OrdersGateway proxy = the EIP-712 verifyingContract. Defaults to the devnet1
-# gateway, so you don't need to set this for devnet1. Uncomment to override —
-# e.g. to target the legacy cronos testnet (0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5).
+# OrdersGateway proxy = the EIP-712 verifyingContract (defaults to the devnet1
+# value, so you don't need to set it for devnet1).
 #REYA_ORDERS_GATEWAY="0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
+
+### Cronos testnet (same chain id as devnet1, different deployment)
+#CHAIN_ID=89346162
+#REYA_WS_URL="wss://websocket-testnet.reya.xyz/"
+#REYA_WS_EXEC_URL="wss://ws-exec-testnet.reya.xyz"
+#REYA_API_URL="https://api-cronos.reya.xyz/v2"
+# Cronos shares devnet1's chain id, so set the gateway explicitly to target it:
+#REYA_ORDERS_GATEWAY="0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5"
 
 ### Reya Network (mainnet)
 #CHAIN_ID=1729

--- a/sdk/reya_rest_api/config.py
+++ b/sdk/reya_rest_api/config.py
@@ -64,11 +64,11 @@ class TradingConfig:
         if self.orders_gateway_address:
             return self.orders_gateway_address
         # OrdersGateway proxy = the EIP-712 verifyingContract, per deployment.
-        # NOTE: devnet1 (the perpOB testnet) and the legacy cronos testnet share
-        # chain id 89346162 but use different proxy deployments, so they cannot
-        # be distinguished by chain id alone. Non-mainnet defaults to devnet1
-        # (the current perpOB target); set REYA_ORDERS_GATEWAY to the cronos
-        # value to target the legacy cronos deployment instead.
+        # NOTE: devnet1 (the perpOB testnet) and the cronos testnet share chain
+        # id 89346162 but use different proxy deployments, so they cannot be
+        # distinguished by chain id alone. Non-mainnet defaults to devnet1 (the
+        # current perpOB target); set REYA_ORDERS_GATEWAY to the cronos value to
+        # target the cronos deployment instead.
         orders_gateway_by_env = {
             "mainnet": "0xfc8c96be87da63cecddbf54abfa7b13ee8044739",
             "cronos_testnet": "0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5",

--- a/sdk/reya_rest_api/config.py
+++ b/sdk/reya_rest_api/config.py
@@ -69,9 +69,7 @@ class TradingConfig:
         """
         if self.orders_gateway_address:
             return self.orders_gateway_address
-        return (
-            MAINNET_ORDERS_GATEWAY if self.is_mainnet else DEVNET1_ORDERS_GATEWAY
-        )
+        return MAINNET_ORDERS_GATEWAY if self.is_mainnet else DEVNET1_ORDERS_GATEWAY
 
     @classmethod
     def from_env(cls) -> "TradingConfig":

--- a/sdk/reya_rest_api/config.py
+++ b/sdk/reya_rest_api/config.py
@@ -11,6 +11,14 @@ from dotenv import load_dotenv
 
 MAINNET_CHAIN_ID = 1729
 
+# OrdersGateway proxy = the EIP-712 verifyingContract, per deployment. devnet1
+# (the perpOB testnet) and the cronos testnet share chain id 89346162 but use
+# different proxies, so REYA_ORDERS_GATEWAY selects between them (set per
+# environment in .env.example). Cronos is reachable only via that override.
+MAINNET_ORDERS_GATEWAY = "0xfc8c96be87da63cecddbf54abfa7b13ee8044739"
+DEVNET1_ORDERS_GATEWAY = "0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
+CRONOS_ORDERS_GATEWAY = "0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5"
+
 # Default exchange id resolved at import time. Set REYA_DEX_ID in the
 # environment to override (e.g., devnet1 only registers exchange id 1).
 # `TradingConfig.dex_id_override` still wins per-instance if set.
@@ -54,27 +62,16 @@ class TradingConfig:
     def default_orders_gateway_address(self) -> str:
         """OrdersGateway proxy contract address used as the EIP-712 verifyingContract.
 
-        Resolution order: explicit ``orders_gateway_address`` (set via the
-        ``REYA_ORDERS_GATEWAY`` env var in ``from_env``/``from_env_spot``) wins,
-        otherwise fall back to the chain-id default. The override exists because
-        non-mainnet deployments (devnet1, future testnets) redeploy the
-        OrdersGateway proxy and a stale baked-in address makes the matching
-        engine reject every signature.
+        Set ``REYA_ORDERS_GATEWAY`` per environment (see ``.env.example``); it
+        wins when present and is required to target cronos, which shares
+        devnet1's chain id. When unset, fall back to the mainnet or devnet1
+        default by chain id.
         """
         if self.orders_gateway_address:
             return self.orders_gateway_address
-        # OrdersGateway proxy = the EIP-712 verifyingContract, per deployment.
-        # NOTE: devnet1 (the perpOB testnet) and the cronos testnet share chain
-        # id 89346162 but use different proxy deployments, so they cannot be
-        # distinguished by chain id alone. Non-mainnet defaults to devnet1 (the
-        # current perpOB target); set REYA_ORDERS_GATEWAY to the cronos value to
-        # target the cronos deployment instead.
-        orders_gateway_by_env = {
-            "mainnet": "0xfc8c96be87da63cecddbf54abfa7b13ee8044739",
-            "cronos_testnet": "0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5",
-            "devnet1": "0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D",
-        }
-        return orders_gateway_by_env["mainnet" if self.is_mainnet else "devnet1"]
+        return (
+            MAINNET_ORDERS_GATEWAY if self.is_mainnet else DEVNET1_ORDERS_GATEWAY
+        )
 
     @classmethod
     def from_env(cls) -> "TradingConfig":

--- a/sdk/reya_rest_api/config.py
+++ b/sdk/reya_rest_api/config.py
@@ -63,10 +63,18 @@ class TradingConfig:
         """
         if self.orders_gateway_address:
             return self.orders_gateway_address
-        if self.is_mainnet:
-            return "0xfc8c96be87da63cecddbf54abfa7b13ee8044739"  # Mainnet address
-        else:
-            return "0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"  # devnet1 (perpOB testnet)
+        # OrdersGateway proxy = the EIP-712 verifyingContract, per deployment.
+        # NOTE: devnet1 (the perpOB testnet) and the legacy cronos testnet share
+        # chain id 89346162 but use different proxy deployments, so they cannot
+        # be distinguished by chain id alone. Non-mainnet defaults to devnet1
+        # (the current perpOB target); set REYA_ORDERS_GATEWAY to the cronos
+        # value to target the legacy cronos deployment instead.
+        orders_gateway_by_env = {
+            "mainnet": "0xfc8c96be87da63cecddbf54abfa7b13ee8044739",
+            "cronos_testnet": "0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5",
+            "devnet1": "0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D",
+        }
+        return orders_gateway_by_env["mainnet" if self.is_mainnet else "devnet1"]
 
     @classmethod
     def from_env(cls) -> "TradingConfig":

--- a/sdk/reya_rest_api/config.py
+++ b/sdk/reya_rest_api/config.py
@@ -66,7 +66,7 @@ class TradingConfig:
         if self.is_mainnet:
             return "0xfc8c96be87da63cecddbf54abfa7b13ee8044739"  # Mainnet address
         else:
-            return "0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5"  # Testnet address
+            return "0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"  # devnet1 (perpOB testnet)
 
     @classmethod
     def from_env(cls) -> "TradingConfig":


### PR DESCRIPTION
## Problem

The SDK's non-mainnet default `verifyingContract` was `0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5` — the older `reya_cronos` deployment, **stale for devnet1**. With `REYA_ORDERS_GATEWAY` unset (as in `.env.example`), the SDK signed EIP-712 orders against the wrong contract and the matching engine rejected **every** order with an opaque "invalid signature" error.

## Correct address

devnet1 `OrdersGateway` / verifyingContract = **`0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D`**, confirmed by:
- `reya-devops`: `ORDERS_GATEWAY_PROXY_ADDRESS=0x7Ec8…` on every devnet1 service, including `ws-exec` (the signing/order-entry service).
- `reya-deployments` `reya_devnet` fork test (fresh proxies on chain 89346162).

## Fix

- `config.py`: point the non-mainnet baked-in default at the devnet1 gateway.
- `.env.example`: set `REYA_ORDERS_GATEWAY` for devnet1 (+ a commented mainnet value) so following the example works out of the box.

Surfaced during the MM integration docs work (PRO-93). Tracked in PRO-164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)