### PR TITLE
[codex] Fail loudly on missing spot/ws-exec prerequisites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,4 +184,6 @@ markers = [
     "post_only: Post-only (maker-only) order tests",
     "gtt: Good-Till-Time (auto-expiring resting order) tests",
     "offline: No-network tests (parity golden vectors + client guards) — safe without devnet/.env",
+    "strict_spot_prerequisites: Internal marker for tests that must fail on missing spot prerequisites",
+    "strict_ws_exec_prerequisites: Internal marker for tests that must fail on missing ws-exec prerequisites",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ from tests.helpers.spot_prerequisites import (  # noqa: E402
     spot_account_env_vars,
     spot_prerequisite_missing,
 )
+from tests.helpers.ws_exec_prerequisites import ws_exec_account_env_vars  # noqa: E402
 
 # Time delay between tests
 TEST_DELAY_SECONDS = 0.1
@@ -57,6 +58,16 @@ MIN_RUSD_BALANCE = 15.0
 
 # Default asset if not specified via CLI
 DEFAULT_SPOT_ASSET = "ETH"
+
+_STRICT_SPOT_PREREQUISITE_MARKER = "strict_spot_prerequisites"
+_STRICT_WS_EXEC_PREREQUISITE_MARKER = "strict_ws_exec_prerequisites"
+_STRICT_SPOT_ENV = spot_account_env_vars(1) + spot_account_env_vars(2)
+_STRICT_WS_EXEC_ENV = (
+    ("REYA_WS_EXEC_URL",)
+    + ws_exec_account_env_vars("SPOT", 1)
+    + ws_exec_account_env_vars("SPOT", 2)
+    + ws_exec_account_env_vars("PERP", 1)
+)
 
 
 class _ReyaEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
@@ -102,6 +113,12 @@ def pytest_collection_modifyitems(items):
             item.add_marker(pytest.mark.spot)
         elif market == "perp":
             item.add_marker(pytest.mark.perp)
+
+        item_path = str(item.path)
+        if "/tests/spot/" in item_path or item.get_closest_marker("spot") is not None:
+            item.add_marker(_STRICT_SPOT_PREREQUISITE_MARKER)
+        if "/tests/ws_exec/" in item_path or item_path.endswith("_ws_exec.py"):
+            item.add_marker(_STRICT_WS_EXEC_PREREQUISITE_MARKER)
 
 
 @pytest.fixture(scope="session")
@@ -179,6 +196,34 @@ def _busts_guard_api_url() -> str:
     else:
         default_api_url = "https://api-devnet.reya-cronos.network/v2"
     return os.environ.get("REYA_API_URL", default_api_url)
+
+
+def _unique_missing_env_vars(env_vars: tuple[str, ...]) -> list[str]:
+    """Return missing env var names once, preserving prerequisite order."""
+    missing: list[str] = []
+    seen: set[str] = set()
+    for name in env_vars:
+        if name not in seen and not os.environ.get(name):
+            missing.append(name)
+            seen.add(name)
+    return missing
+
+
+def _strict_prerequisite_missing_env(items) -> list[str]:
+    """Env gaps that should fail selected spot/ws-exec tests before any guard API call.
+
+    Market-definition and balance prerequisites are checked by the owning
+    fixtures after REST clients are intentionally configured. This helper only
+    covers environment prerequisites that can be decided without touching the
+    network, so the session-wide execution-bust guard cannot race those
+    controlled failures with unrelated read-only API calls.
+    """
+    env_vars: tuple[str, ...] = ()
+    if any(item.get_closest_marker(_STRICT_SPOT_PREREQUISITE_MARKER) for item in items):
+        env_vars += _STRICT_SPOT_ENV
+    if any(item.get_closest_marker(_STRICT_WS_EXEC_PREREQUISITE_MARKER) for item in items):
+        env_vars += _STRICT_WS_EXEC_ENV
+    return _unique_missing_env_vars(env_vars)
 
 
 _EXPECTED_EXECUTION_BUST_REASON_SNIPPETS = (
@@ -274,6 +319,15 @@ async def execution_busts_guard(request):
     if all(item.get_closest_marker("offline") for item in request.session.items):
         # Offline-only session (e.g. `pytest -m offline` / tests/parity) —
         # the guard's API calls are the only network traffic; stay silent.
+        yield
+        return
+
+    missing_strict_env = _strict_prerequisite_missing_env(request.session.items)
+    if missing_strict_env:
+        logger.info(
+            "Execution-busts guard inactive until strict test prerequisites are configured; missing env vars: "
+            f"{', '.join(missing_strict_env)}"
+        )
         yield
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,11 @@ from tests.helpers.market_config import (  # noqa: E402
 )
 from tests.helpers.reya_tester import logger  # noqa: E402
 from tests.helpers.settlement import make_settlement_probe  # noqa: E402
+from tests.helpers.spot_prerequisites import (  # noqa: E402
+    missing_env_vars,
+    spot_account_env_vars,
+    spot_prerequisite_missing,
+)
 
 # Time delay between tests
 TEST_DELAY_SECONDS = 0.1
@@ -385,12 +390,21 @@ async def maker_tester_session():
     """
     load_dotenv()
 
+    required_env = spot_account_env_vars(1)
+    missing = missing_env_vars(required_env)
+    if missing:
+        spot_prerequisite_missing(
+            "Missing Spot Account 1 configuration for spot tests",
+            missing_env=missing,
+        )
+
     # Maker uses Spot Account 1
     tester = ReyaTester(spot_account_number=1)
 
     if not tester.owner_wallet_address or not tester.account_id:
-        pytest.skip(
-            "Missing Spot Account 1 configuration (SPOT_ACCOUNT_ID_1, SPOT_PRIVATE_KEY_1, SPOT_WALLET_ADDRESS_1) for spot tests"
+        spot_prerequisite_missing(
+            "Missing Spot Account 1 configuration for spot tests",
+            missing_env=missing_env_vars(required_env),
         )
 
     logger.info(f"🔧 SESSION: Maker account initialized: {tester.account_id}")
@@ -425,12 +439,21 @@ async def taker_tester_session():
     """
     load_dotenv()
 
+    required_env = spot_account_env_vars(2)
+    missing = missing_env_vars(required_env)
+    if missing:
+        spot_prerequisite_missing(
+            "Missing Spot Account 2 configuration for spot tests",
+            missing_env=missing,
+        )
+
     # Taker uses Spot Account 2
     tester = ReyaTester(spot_account_number=2)
 
     if not tester.owner_wallet_address or not tester.account_id:
-        pytest.skip(
-            "Missing Spot Account 2 configuration (SPOT_ACCOUNT_ID_2, SPOT_PRIVATE_KEY_2, SPOT_WALLET_ADDRESS_2) for spot tests"
+        spot_prerequisite_missing(
+            "Missing Spot Account 2 configuration for spot tests",
+            missing_env=missing_env_vars(required_env),
         )
 
     logger.info(f"🔧 SESSION: Taker account initialized: {tester.account_id}")
@@ -653,9 +676,9 @@ async def _restore_to_baseline(  # pylint: disable=redefined-outer-name
 # ============================================================================
 # Any test (in any directory) can take `market_config` + `maker`/`taker` and
 # run once per market type. ALL resolution is lazy (request.getfixturevalue)
-# so an env configured for only one market never spins up the other market's
-# sessions — the missing-credential pytest.skip then applies only to that
-# market's param instances instead of tanking the suite.
+# so an env configured for only one market never spins up the other market's sessions.
+# Spot missing-prerequisite paths fail by default via spot_prerequisite_missing;
+# non-spot missing-prerequisite paths keep their existing skip behavior.
 
 _DEFAULT_MARKET_TYPES = ("spot", "perp")
 
@@ -1145,7 +1168,10 @@ async def spot_config(maker_tester_session, spot_market_configs, spot_asset):  #
     # Validate the selected asset is available
     if spot_asset not in spot_market_configs:
         available = sorted(spot_market_configs.keys())
-        pytest.skip(f"Asset '{spot_asset}' not available. Available assets: {', '.join(available)}")
+        spot_prerequisite_missing(
+            f"Asset '{spot_asset}' not available in /v2/spotMarketDefinitions. "
+            f"Available assets: {', '.join(available) or '<none>'}"
+        )
 
     selected_market: SpotMarketConfig = spot_market_configs[spot_asset]
 
@@ -1323,7 +1349,7 @@ async def spot_balance_guard(
         for msg in insufficient:
             logger.error(f"   - {msg}")
         logger.error(f"   Required minimums: {min_asset_balance} {base_asset}, {MIN_RUSD_BALANCE} RUSD per account")
-        pytest.skip(f"Insufficient balances for SPOT tests: {', '.join(insufficient)}")
+        spot_prerequisite_missing(f"Insufficient balances for SPOT tests: {', '.join(insufficient)}")
 
     logger.info("✅ Balance check passed - proceeding with SPOT tests")
     logger.info("=" * 60)
@@ -1454,7 +1480,12 @@ async def spot_balance_guard(
             if asset_needed > 0:
                 # Account needs more asset - buy from external asks
                 if not has_external_asks:
-                    logger.warning(f"⚠️ {account_name} needs {asset_needed} {base_asset} but no external asks available")
+                    logger.warning(
+                        "⚠️ %s needs %s %s but no external asks available",
+                        account_name,
+                        asset_needed,
+                        base_asset,
+                    )
                     return
 
                 qty = str(asset_needed.quantize(min_qty))

--- a/tests/engine/conftest.py
+++ b/tests/engine/conftest.py
@@ -16,8 +16,8 @@ from tests.helpers.ws_exec_market import WS_EXEC_MARKETS, build_ws_exec_market
 async def ws_exec_market(request):
     """Market-parametrized ([spot, perp]) connected ws-exec harness.
 
-    Every engine ws-exec test that takes this fixture runs once per market; a
-    market whose credentials (or the ws-exec URL) are absent is skipped, not
-    failed. Module-scoped so one connection set is shared across a suite."""
+    Every engine ws-exec test that takes this fixture runs once per market.
+    Missing ws-exec URL/account prerequisites fail by default. Module-scoped so
+    one connection set is shared across a suite."""
     async with build_ws_exec_market(request.param) as market:
         yield market

--- a/tests/engine/test_cod_ws_exec.py
+++ b/tests/engine/test_cod_ws_exec.py
@@ -24,8 +24,8 @@ tests/helpers/ws_exec_harness.py — the high-level client rejects an out-of-ran
 timeoutMs locally (and never builds a tampered signature), so the negative
 probes must go over a raw socket with a hand-built (correctly signed) payload;
 both sign over ``m.rest``'s account, so they run on each market unchanged. Each
-market is skipped independently if its credentials (or REYA_WS_EXEC_URL) are
-absent (see ``ws_exec_market``).
+missing ws-exec URL/account prerequisite fails by default (see
+``ws_exec_market``).
 """
 
 from __future__ import annotations

--- a/tests/engine/test_gtt_ws_exec.py
+++ b/tests/engine/test_gtt_ws_exec.py
@@ -17,8 +17,8 @@ over BOTH markets via the shared ``ws_exec_market`` fixture:
 
 ws-exec routes createOrder through the shared TIF-agnostic handler (it has no
 REST dispatcher order-class allow-list), so this also guards that a GTT is never
-misrouted on the ws-exec transport. Each market is skipped independently if its
-credentials (or REYA_WS_EXEC_URL) are absent (see ``ws_exec_market``).
+misrouted on the ws-exec transport. Missing ws-exec URL/account prerequisites
+fail by default (see ``ws_exec_market``).
 """
 
 from __future__ import annotations

--- a/tests/engine/test_modify_ws_exec.py
+++ b/tests/engine/test_modify_ws_exec.py
@@ -14,8 +14,8 @@ Error envelopes surface as :class:`WsExecOperationError` with the structured
 pinned only where the code alone doesn't discriminate the rule
 (INPUT_VALIDATION_ERROR), mirroring the REST suite.
 
-Each market is skipped independently if its credentials (or REYA_WS_EXEC_URL)
-are absent (see ``ws_exec_market``).
+Missing ws-exec URL/account prerequisites fail by default (see
+``ws_exec_market``).
 """
 
 from __future__ import annotations

--- a/tests/engine/test_post_only_ws_exec.py
+++ b/tests/engine/test_post_only_ws_exec.py
@@ -22,8 +22,8 @@ byte-identical signed envelopes on the wire):
   and a raw correctly-signed frame that bypasses the guard is rejected
   server-side with INPUT_VALIDATION_ERROR through the per-op error envelope.
 
-Each market is skipped independently if its credentials (or REYA_WS_EXEC_URL)
-are absent (see ``ws_exec_market``). The raw negative probe reuses the
+Spot missing-prerequisite paths fail by default (see ``ws_exec_market``); non-spot
+missing env keeps the existing skip behavior. The raw negative probe reuses the
 raw-WebSocket helpers from tests/helpers/ws_exec_harness.py.
 """
 
@@ -53,6 +53,7 @@ from sdk.reya_rest_api.models.orders import LimitOrderParameters
 from sdk.reya_ws_exec import ReyaWsExecClient, WsExecOperationError
 from tests.helpers.liquidity_detector import SAFE_NO_MATCH_SELL_PRICE, skip_if_external_liquidity
 from tests.helpers.reya_tester.data import DataOperations
+from tests.helpers.spot_prerequisites import missing_env_vars, spot_account_env_vars, spot_prerequisite_missing
 from tests.helpers.ws_exec_harness import assert_per_op_error, raw_connect, raw_recv_until, raw_send_envelope
 from tests.helpers.ws_exec_market import WsExecMarket
 
@@ -72,12 +73,8 @@ SPOT_SYMBOL = "WETHRUSD"
 WOULD_CROSS_PX = str(SAFE_NO_MATCH_SELL_PRICE)
 
 # The would-cross counterparty needs a second SPOT account to rest the
-# engineered ask (same optionality pattern as the ws_exec harness's spot creds).
-_COUNTERPARTY_ENV = (
-    "SPOT_PRIVATE_KEY_2",
-    "SPOT_ACCOUNT_ID_2",
-    "SPOT_WALLET_ADDRESS_2",
-)
+# engineered ask; missing SPOT_*_2 fails loudly by default.
+_COUNTERPARTY_ENV = spot_account_env_vars(2)
 
 
 async def _wait_for_open_order(rest: ReyaTradingClient, order_id: str, timeout_s: float = 10.0) -> Order:
@@ -131,11 +128,12 @@ class _RestDepthOps:
 @pytest_asyncio.fixture(loop_scope="session", scope="module")
 async def counterparty_rest():
     """A started REST client for SPOT account 2 — rests the engineered
-    counterparty ask for the would-cross probe. Skips when SPOT_*_2 is absent."""
-    missing = [_k for _k in _COUNTERPARTY_ENV if not os.environ.get(_k)]
+    counterparty ask for the would-cross probe."""
+    missing = missing_env_vars(_COUNTERPARTY_ENV)
     if missing:
-        pytest.skip(
-            "would-cross counterparty needs " + ", ".join(_COUNTERPARTY_ENV) + "; missing: " + ", ".join(missing)
+        spot_prerequisite_missing(
+            "would-cross counterparty needs Spot Account 2 configuration",
+            missing_env=missing,
         )
     rest2 = ReyaTradingClient(TradingConfig.from_env_spot(account_number=2))
     await rest2.start()
@@ -202,11 +200,14 @@ async def test_ws_exec_post_only_would_cross_error_envelope(  # pylint: disable=
     try:
         markets = {mkt.symbol: mkt for mkt in await rest.reference.get_spot_market_definitions()}
         if SPOT_SYMBOL not in markets:
-            pytest.skip(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
+            spot_prerequisite_missing(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
         min_qty = str(markets[SPOT_SYMBOL].min_order_qty)
         oracle_symbol = f"{markets[SPOT_SYMBOL].base_asset}RUSDPERP"
         if not os.environ.get("REYA_WS_EXEC_URL"):
-            pytest.skip("ws-exec post-only would-cross needs REYA_WS_EXEC_URL")
+            spot_prerequisite_missing(
+                "ws-exec post-only would-cross spot probe needs REYA_WS_EXEC_URL",
+                missing_env=["REYA_WS_EXEC_URL"],
+            )
         ws = ReyaWsExecClient(rest_client=rest, ws_url=os.environ["REYA_WS_EXEC_URL"])
         await ws.connect()
 

--- a/tests/engine/test_post_only_ws_exec.py
+++ b/tests/engine/test_post_only_ws_exec.py
@@ -73,7 +73,18 @@ WOULD_CROSS_PX = str(SAFE_NO_MATCH_SELL_PRICE)
 
 # The would-cross counterparty needs a second SPOT account to rest the
 # engineered ask; missing SPOT_*_2 fails loudly by default.
+_PROBER_ENV = ws_exec_account_env_vars("SPOT", 1)
 _COUNTERPARTY_ENV = ws_exec_account_env_vars("SPOT", 2)
+_WOULD_CROSS_ENV = ("REYA_WS_EXEC_URL",) + _PROBER_ENV + _COUNTERPARTY_ENV
+
+
+def _preflight_would_cross_prerequisites() -> None:
+    missing = missing_env_vars(_WOULD_CROSS_ENV)
+    if missing:
+        ws_exec_prerequisite_missing(
+            "ws-exec post-only would-cross spot probe needs REYA_WS_EXEC_URL, Spot Account 1, and Spot Account 2",
+            missing_env=missing,
+        )
 
 
 async def _wait_for_open_order(rest: ReyaTradingClient, order_id: str, timeout_s: float = 10.0) -> Order:
@@ -128,12 +139,7 @@ class _RestDepthOps:
 async def counterparty_rest():
     """A started REST client for SPOT account 2 — rests the engineered
     counterparty ask for the would-cross probe."""
-    missing = missing_env_vars(_COUNTERPARTY_ENV)
-    if missing:
-        ws_exec_prerequisite_missing(
-            "would-cross counterparty needs Spot Account 2 configuration",
-            missing_env=missing,
-        )
+    _preflight_would_cross_prerequisites()
     rest2 = ReyaTradingClient(TradingConfig.from_env_spot(account_number=2))
     await rest2.start()
     try:
@@ -192,12 +198,7 @@ async def test_ws_exec_post_only_would_cross_error_envelope(  # pylint: disable=
     (test_post_only_rejection.py); this pins only the ws-exec error-envelope
     mapping, which is transport-uniform across markets.
     """
-    if not os.environ.get("REYA_WS_EXEC_URL"):
-        ws_exec_prerequisite_missing(
-            "ws-exec post-only would-cross spot probe needs REYA_WS_EXEC_URL",
-            missing_env=["REYA_WS_EXEC_URL"],
-        )
-
+    _preflight_would_cross_prerequisites()
     config = TradingConfig.from_env_spot(account_number=1)
     rest = ReyaTradingClient(config)
     await rest.start()

--- a/tests/engine/test_post_only_ws_exec.py
+++ b/tests/engine/test_post_only_ws_exec.py
@@ -22,9 +22,8 @@ byte-identical signed envelopes on the wire):
   and a raw correctly-signed frame that bypasses the guard is rejected
   server-side with INPUT_VALIDATION_ERROR through the per-op error envelope.
 
-Spot missing-prerequisite paths fail by default (see ``ws_exec_market``); non-spot
-missing env keeps the existing skip behavior. The raw negative probe reuses the
-raw-WebSocket helpers from tests/helpers/ws_exec_harness.py.
+WS exec URL/credential gaps fail by default (see ``ws_exec_market``). The raw
+negative probe reuses the raw-WebSocket helpers from tests/helpers/ws_exec_harness.py.
 """
 
 from __future__ import annotations
@@ -53,9 +52,9 @@ from sdk.reya_rest_api.models.orders import LimitOrderParameters
 from sdk.reya_ws_exec import ReyaWsExecClient, WsExecOperationError
 from tests.helpers.liquidity_detector import SAFE_NO_MATCH_SELL_PRICE, skip_if_external_liquidity
 from tests.helpers.reya_tester.data import DataOperations
-from tests.helpers.spot_prerequisites import missing_env_vars, spot_account_env_vars, spot_prerequisite_missing
 from tests.helpers.ws_exec_harness import assert_per_op_error, raw_connect, raw_recv_until, raw_send_envelope
 from tests.helpers.ws_exec_market import WsExecMarket
+from tests.helpers.ws_exec_prerequisites import missing_env_vars, ws_exec_account_env_vars, ws_exec_prerequisite_missing
 
 load_dotenv()
 
@@ -74,7 +73,7 @@ WOULD_CROSS_PX = str(SAFE_NO_MATCH_SELL_PRICE)
 
 # The would-cross counterparty needs a second SPOT account to rest the
 # engineered ask; missing SPOT_*_2 fails loudly by default.
-_COUNTERPARTY_ENV = spot_account_env_vars(2)
+_COUNTERPARTY_ENV = ws_exec_account_env_vars("SPOT", 2)
 
 
 async def _wait_for_open_order(rest: ReyaTradingClient, order_id: str, timeout_s: float = 10.0) -> Order:
@@ -131,7 +130,7 @@ async def counterparty_rest():
     counterparty ask for the would-cross probe."""
     missing = missing_env_vars(_COUNTERPARTY_ENV)
     if missing:
-        spot_prerequisite_missing(
+        ws_exec_prerequisite_missing(
             "would-cross counterparty needs Spot Account 2 configuration",
             missing_env=missing,
         )
@@ -193,6 +192,12 @@ async def test_ws_exec_post_only_would_cross_error_envelope(  # pylint: disable=
     (test_post_only_rejection.py); this pins only the ws-exec error-envelope
     mapping, which is transport-uniform across markets.
     """
+    if not os.environ.get("REYA_WS_EXEC_URL"):
+        ws_exec_prerequisite_missing(
+            "ws-exec post-only would-cross spot probe needs REYA_WS_EXEC_URL",
+            missing_env=["REYA_WS_EXEC_URL"],
+        )
+
     config = TradingConfig.from_env_spot(account_number=1)
     rest = ReyaTradingClient(config)
     await rest.start()
@@ -200,14 +205,9 @@ async def test_ws_exec_post_only_would_cross_error_envelope(  # pylint: disable=
     try:
         markets = {mkt.symbol: mkt for mkt in await rest.reference.get_spot_market_definitions()}
         if SPOT_SYMBOL not in markets:
-            spot_prerequisite_missing(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
+            ws_exec_prerequisite_missing(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
         min_qty = str(markets[SPOT_SYMBOL].min_order_qty)
         oracle_symbol = f"{markets[SPOT_SYMBOL].base_asset}RUSDPERP"
-        if not os.environ.get("REYA_WS_EXEC_URL"):
-            spot_prerequisite_missing(
-                "ws-exec post-only would-cross spot probe needs REYA_WS_EXEC_URL",
-                missing_env=["REYA_WS_EXEC_URL"],
-            )
         ws = ReyaWsExecClient(rest_client=rest, ws_url=os.environ["REYA_WS_EXEC_URL"])
         await ws.connect()
 

--- a/tests/helpers/spot_prerequisites.py
+++ b/tests/helpers/spot_prerequisites.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Sequence
+
+import pytest
+
+ALLOW_SPOT_TEST_SKIPS_ENV = "ALLOW_SPOT_TEST_SKIPS"
+
+
+def spot_account_env_vars(account_number: int) -> tuple[str, str, str]:
+    return (
+        f"SPOT_PRIVATE_KEY_{account_number}",
+        f"SPOT_ACCOUNT_ID_{account_number}",
+        f"SPOT_WALLET_ADDRESS_{account_number}",
+    )
+
+
+def missing_env_vars(env_vars: Iterable[str]) -> list[str]:
+    return [name for name in env_vars if not os.environ.get(name)]
+
+
+def spot_prerequisite_missing(reason: str, *, missing_env: Sequence[str] = ()) -> None:
+    details = f"Spot test prerequisites missing: {reason}"
+    if missing_env:
+        details += f"; missing env vars: {', '.join(missing_env)}"
+    details += f". Set {ALLOW_SPOT_TEST_SKIPS_ENV}=1 only when this is an intentionally non-spot environment."
+
+    if os.environ.get(ALLOW_SPOT_TEST_SKIPS_ENV) == "1":
+        pytest.skip(details)
+    pytest.fail(details, pytrace=False)

--- a/tests/helpers/spot_prerequisites.py
+++ b/tests/helpers/spot_prerequisites.py
@@ -5,8 +5,6 @@ from collections.abc import Iterable, Sequence
 
 import pytest
 
-ALLOW_SPOT_TEST_SKIPS_ENV = "ALLOW_SPOT_TEST_SKIPS"
-
 
 def spot_account_env_vars(account_number: int) -> tuple[str, str, str]:
     return (
@@ -24,8 +22,5 @@ def spot_prerequisite_missing(reason: str, *, missing_env: Sequence[str] = ()) -
     details = f"Spot test prerequisites missing: {reason}"
     if missing_env:
         details += f"; missing env vars: {', '.join(missing_env)}"
-    details += f". Set {ALLOW_SPOT_TEST_SKIPS_ENV}=1 only when this is an intentionally non-spot environment."
 
-    if os.environ.get(ALLOW_SPOT_TEST_SKIPS_ENV) == "1":
-        pytest.skip(details)
     pytest.fail(details, pytrace=False)

--- a/tests/helpers/ws_exec_market.py
+++ b/tests/helpers/ws_exec_market.py
@@ -7,8 +7,8 @@ ws-exec client reuses the REST ``build_*_payload`` signing path verbatim, so the
 two transports put byte-identical signed envelopes on the wire). This builder
 yields a connected ws-exec client for a given market plus the symbol / min_qty /
 passive resting price the transport tests need. Spot missing-prerequisite paths
-fail by default so coverage cannot silently disappear; non-spot missing env keeps
-the existing skip behavior.
+and ws-exec URL/credential gaps fail by default so coverage cannot silently
+disappear.
 """
 
 from __future__ import annotations
@@ -18,13 +18,12 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
-import pytest
 from dotenv import load_dotenv
 
 from sdk.reya_rest_api import ReyaTradingClient
 from sdk.reya_rest_api.config import TradingConfig
 from sdk.reya_ws_exec import ReyaWsExecClient
-from tests.helpers.spot_prerequisites import missing_env_vars, spot_account_env_vars, spot_prerequisite_missing
+from tests.helpers.ws_exec_prerequisites import missing_env_vars, ws_exec_account_env_vars, ws_exec_prerequisite_missing
 
 load_dotenv()
 
@@ -39,8 +38,8 @@ _PERP_REST_BUY_PX = "100"
 
 # Both markets need the ws-exec URL; each market needs its own account creds.
 _COMMON_ENV = ("REYA_WS_EXEC_URL",)
-_SPOT_ENV = spot_account_env_vars(1)
-_PERP_ENV = ("PERP_PRIVATE_KEY_1", "PERP_ACCOUNT_ID_1", "PERP_WALLET_ADDRESS_1")
+_SPOT_ENV = ws_exec_account_env_vars("SPOT", 1)
+_PERP_ENV = ws_exec_account_env_vars("PERP", 1)
 
 WS_EXEC_MARKETS = ("spot", "perp")
 
@@ -61,9 +60,9 @@ class WsExecMarket:
 async def build_ws_exec_market(market_type: str) -> AsyncIterator[WsExecMarket]:
     """Build a connected ws-exec client + market metadata for ``market_type``.
 
-    Spot missing-prerequisite paths fail by default; perp missing env still skips.
-    Cleans up the REST + ws clients on exit even when a test fails. Mirrors the
-    per-suite spot harnesses it replaces."""
+    Missing ws-exec URL/account prerequisites fail by default. Cleans up the
+    REST + ws clients on exit even when a test fails. Mirrors the per-suite spot
+    harnesses it replaces."""
     if market_type not in WS_EXEC_MARKETS:
         raise ValueError(f"unknown ws-exec market: {market_type!r}")
 
@@ -71,9 +70,7 @@ async def build_ws_exec_market(market_type: str) -> AsyncIterator[WsExecMarket]:
     missing = missing_env_vars(_COMMON_ENV + market_env)
     if missing:
         reason = f"ws-exec {market_type} tests need {', '.join(_COMMON_ENV + market_env)}"
-        if market_type == "spot":
-            spot_prerequisite_missing(reason, missing_env=missing)
-        pytest.skip(f"{reason}; missing: {', '.join(missing)}")
+        ws_exec_prerequisite_missing(reason, missing_env=missing)
 
     if market_type == "spot":
         config = TradingConfig.from_env_spot(account_number=1)
@@ -91,12 +88,12 @@ async def build_ws_exec_market(market_type: str) -> AsyncIterator[WsExecMarket]:
         if market_type == "spot":
             spot_defs = {d.symbol: d for d in await rest.reference.get_spot_market_definitions()}
             if symbol not in spot_defs:
-                spot_prerequisite_missing(f"{symbol} not found in /v2/spotMarketDefinitions")
+                ws_exec_prerequisite_missing(f"{symbol} not found in /v2/spotMarketDefinitions")
             min_qty = str(spot_defs[symbol].min_order_qty)
         else:
             perp_defs = {d.symbol: d for d in await rest.reference.get_perp_market_definitions()}
             if symbol not in perp_defs:
-                pytest.skip(f"{symbol} not found in perp market definitions")
+                ws_exec_prerequisite_missing(f"{symbol} not found in /v2/perpMarketDefinitions")
             min_qty = str(perp_defs[symbol].min_order_qty)
         ws = ReyaWsExecClient(rest_client=rest, ws_url=os.environ["REYA_WS_EXEC_URL"])
         await ws.connect()

--- a/tests/helpers/ws_exec_market.py
+++ b/tests/helpers/ws_exec_market.py
@@ -6,8 +6,9 @@ transport-independently by the REST ``[spot, perp]``-parametrized suites (the
 ws-exec client reuses the REST ``build_*_payload`` signing path verbatim, so the
 two transports put byte-identical signed envelopes on the wire). This builder
 yields a connected ws-exec client for a given market plus the symbol / min_qty /
-passive resting price the transport tests need, skipping cleanly when that
-market's credentials (or the ws-exec URL) are absent.
+passive resting price the transport tests need. Spot missing-prerequisite paths
+fail by default so coverage cannot silently disappear; non-spot missing env keeps
+the existing skip behavior.
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ from dotenv import load_dotenv
 from sdk.reya_rest_api import ReyaTradingClient
 from sdk.reya_rest_api.config import TradingConfig
 from sdk.reya_ws_exec import ReyaWsExecClient
+from tests.helpers.spot_prerequisites import missing_env_vars, spot_account_env_vars, spot_prerequisite_missing
 
 load_dotenv()
 
@@ -37,7 +39,7 @@ _PERP_REST_BUY_PX = "100"
 
 # Both markets need the ws-exec URL; each market needs its own account creds.
 _COMMON_ENV = ("REYA_WS_EXEC_URL",)
-_SPOT_ENV = ("SPOT_PRIVATE_KEY_1", "SPOT_ACCOUNT_ID_1", "SPOT_WALLET_ADDRESS_1")
+_SPOT_ENV = spot_account_env_vars(1)
 _PERP_ENV = ("PERP_PRIVATE_KEY_1", "PERP_ACCOUNT_ID_1", "PERP_WALLET_ADDRESS_1")
 
 WS_EXEC_MARKETS = ("spot", "perp")
@@ -55,26 +57,23 @@ class WsExecMarket:
     rest_buy_px: str  # a passive, far-from-touch buy price that rests (never crosses)
 
 
-def _missing(env: tuple[str, ...]) -> list[str]:
-    return [k for k in env if not os.environ.get(k)]
-
-
 @asynccontextmanager
 async def build_ws_exec_market(market_type: str) -> AsyncIterator[WsExecMarket]:
     """Build a connected ws-exec client + market metadata for ``market_type``.
 
-    ``pytest.skip``s if that market's credentials (or the ws-exec URL) are absent,
-    so spot and perp gate independently. Cleans up the REST + ws clients on exit
-    even when a test fails. Mirrors the per-suite spot harnesses it replaces."""
+    Spot missing-prerequisite paths fail by default; perp missing env still skips.
+    Cleans up the REST + ws clients on exit even when a test fails. Mirrors the
+    per-suite spot harnesses it replaces."""
     if market_type not in WS_EXEC_MARKETS:
         raise ValueError(f"unknown ws-exec market: {market_type!r}")
 
     market_env = _SPOT_ENV if market_type == "spot" else _PERP_ENV
-    missing = _missing(_COMMON_ENV + market_env)
+    missing = missing_env_vars(_COMMON_ENV + market_env)
     if missing:
-        pytest.skip(
-            f"ws-exec {market_type} tests need {', '.join(_COMMON_ENV + market_env)}; missing: {', '.join(missing)}"
-        )
+        reason = f"ws-exec {market_type} tests need {', '.join(_COMMON_ENV + market_env)}"
+        if market_type == "spot":
+            spot_prerequisite_missing(reason, missing_env=missing)
+        pytest.skip(f"{reason}; missing: {', '.join(missing)}")
 
     if market_type == "spot":
         config = TradingConfig.from_env_spot(account_number=1)
@@ -92,7 +91,7 @@ async def build_ws_exec_market(market_type: str) -> AsyncIterator[WsExecMarket]:
         if market_type == "spot":
             spot_defs = {d.symbol: d for d in await rest.reference.get_spot_market_definitions()}
             if symbol not in spot_defs:
-                pytest.skip(f"{symbol} not found in spot market definitions")
+                spot_prerequisite_missing(f"{symbol} not found in /v2/spotMarketDefinitions")
             min_qty = str(spot_defs[symbol].min_order_qty)
         else:
             perp_defs = {d.symbol: d for d in await rest.reference.get_perp_market_definitions()}

--- a/tests/helpers/ws_exec_prerequisites.py
+++ b/tests/helpers/ws_exec_prerequisites.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Sequence
+
+import pytest
+
+ALLOW_WS_EXEC_TEST_SKIPS_ENV = "ALLOW_WS_EXEC_TEST_SKIPS"
+
+
+def ws_exec_account_env_vars(prefix: str, account_number: int) -> tuple[str, str, str]:
+    return (
+        f"{prefix}_PRIVATE_KEY_{account_number}",
+        f"{prefix}_ACCOUNT_ID_{account_number}",
+        f"{prefix}_WALLET_ADDRESS_{account_number}",
+    )
+
+
+def missing_env_vars(env_vars: Iterable[str]) -> list[str]:
+    return [name for name in env_vars if not os.environ.get(name)]
+
+
+def ws_exec_prerequisite_missing(reason: str, *, missing_env: Sequence[str] = ()) -> None:
+    details = f"WS exec test prerequisites missing: {reason}"
+    if missing_env:
+        details += f"; missing env vars: {', '.join(missing_env)}"
+    details += f". Set {ALLOW_WS_EXEC_TEST_SKIPS_ENV}=1 only when this is an intentionally non-WS-exec environment."
+
+    if os.environ.get(ALLOW_WS_EXEC_TEST_SKIPS_ENV) == "1":
+        pytest.skip(details)
+    pytest.fail(details, pytrace=False)

--- a/tests/helpers/ws_exec_prerequisites.py
+++ b/tests/helpers/ws_exec_prerequisites.py
@@ -5,8 +5,6 @@ from collections.abc import Iterable, Sequence
 
 import pytest
 
-ALLOW_WS_EXEC_TEST_SKIPS_ENV = "ALLOW_WS_EXEC_TEST_SKIPS"
-
 
 def ws_exec_account_env_vars(prefix: str, account_number: int) -> tuple[str, str, str]:
     return (
@@ -24,8 +22,5 @@ def ws_exec_prerequisite_missing(reason: str, *, missing_env: Sequence[str] = ()
     details = f"WS exec test prerequisites missing: {reason}"
     if missing_env:
         details += f"; missing env vars: {', '.join(missing_env)}"
-    details += f". Set {ALLOW_WS_EXEC_TEST_SKIPS_ENV}=1 only when this is an intentionally non-WS-exec environment."
 
-    if os.environ.get(ALLOW_WS_EXEC_TEST_SKIPS_ENV) == "1":
-        pytest.skip(details)
     pytest.fail(details, pytrace=False)

--- a/tests/spot/test_pretrade_checks.py
+++ b/tests/spot/test_pretrade_checks.py
@@ -17,6 +17,7 @@ from tests.helpers import ReyaTester
 from tests.helpers.builders import OrderBuilder
 from tests.helpers.market_config import SpotTestConfig
 from tests.helpers.reya_tester import logger
+from tests.helpers.spot_prerequisites import spot_prerequisite_missing
 
 
 @pytest.mark.spot
@@ -44,7 +45,7 @@ async def test_spot_ioc_insufficient_balance_buy(spot_config: SpotTestConfig, sp
             break
 
     if rusd_balance is None or rusd_balance <= 0:
-        pytest.skip("No RUSD balance available for this test")
+        spot_prerequisite_missing("No RUSD balance available for spot pre-trade buy coverage")
     assert rusd_balance is not None  # narrow after the skip above
 
     logger.info(f"Current RUSD balance: {rusd_balance}")
@@ -104,7 +105,7 @@ async def test_spot_ioc_insufficient_balance_sell(spot_config: SpotTestConfig, s
             break
 
     if asset_balance is None or asset_balance <= 0:
-        pytest.skip(f"No {base_asset} balance available for this test")
+        spot_prerequisite_missing(f"No {base_asset} balance available for spot pre-trade sell coverage")
     assert asset_balance is not None  # narrow after the skip above
 
     logger.info(f"Current {base_asset} balance: {asset_balance}")

--- a/tests/validation/test_spot_prerequisite_guard.py
+++ b/tests/validation/test_spot_prerequisite_guard.py
@@ -1,0 +1,41 @@
+import pytest
+
+from tests.helpers.spot_prerequisites import ALLOW_SPOT_TEST_SKIPS_ENV, missing_env_vars, spot_prerequisite_missing
+
+
+def test_spot_prerequisite_missing_fails_by_default(monkeypatch):
+    monkeypatch.delenv(ALLOW_SPOT_TEST_SKIPS_ENV, raising=False)
+
+    with pytest.raises(pytest.fail.Exception) as exc_info:
+        spot_prerequisite_missing(
+            "Asset 'ETH' not available",
+            missing_env=["SPOT_PRIVATE_KEY_1", "SPOT_ACCOUNT_ID_1"],
+        )
+
+    message = str(exc_info.value)
+    assert "Spot test prerequisites missing: Asset 'ETH' not available" in message
+    assert "SPOT_PRIVATE_KEY_1, SPOT_ACCOUNT_ID_1" in message
+    assert ALLOW_SPOT_TEST_SKIPS_ENV in message
+
+
+def test_spot_prerequisite_missing_can_explicitly_skip(monkeypatch):
+    monkeypatch.setenv(ALLOW_SPOT_TEST_SKIPS_ENV, "1")
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        spot_prerequisite_missing("Insufficient balances for SPOT tests")
+
+    assert "Insufficient balances for SPOT tests" in str(exc_info.value)
+
+
+def test_missing_env_vars_reports_names_without_values(monkeypatch):
+    monkeypatch.setenv("SPOT_PRIVATE_KEY_1", "secret-value")
+    monkeypatch.delenv("SPOT_ACCOUNT_ID_1", raising=False)
+
+    assert missing_env_vars(("SPOT_PRIVATE_KEY_1", "SPOT_ACCOUNT_ID_1")) == ["SPOT_ACCOUNT_ID_1"]
+
+
+def test_regular_product_gap_skip_remains_a_skip():
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        pytest.skip("TP/SL is a server-side facade, not a live feature yet (PRO-150)")
+
+    assert "PRO-150" in str(exc_info.value)

--- a/tests/validation/test_spot_prerequisite_guard.py
+++ b/tests/validation/test_spot_prerequisite_guard.py
@@ -1,11 +1,10 @@
 import pytest
 
-from tests.helpers.spot_prerequisites import ALLOW_SPOT_TEST_SKIPS_ENV, missing_env_vars, spot_prerequisite_missing
+import tests.helpers.spot_prerequisites as spot_prerequisites
+from tests.helpers.spot_prerequisites import missing_env_vars, spot_prerequisite_missing
 
 
-def test_spot_prerequisite_missing_fails_by_default(monkeypatch):
-    monkeypatch.delenv(ALLOW_SPOT_TEST_SKIPS_ENV, raising=False)
-
+def test_spot_prerequisite_missing_always_fails():
     with pytest.raises(pytest.fail.Exception) as exc_info:
         spot_prerequisite_missing(
             "Asset 'ETH' not available",
@@ -15,16 +14,10 @@ def test_spot_prerequisite_missing_fails_by_default(monkeypatch):
     message = str(exc_info.value)
     assert "Spot test prerequisites missing: Asset 'ETH' not available" in message
     assert "SPOT_PRIVATE_KEY_1, SPOT_ACCOUNT_ID_1" in message
-    assert ALLOW_SPOT_TEST_SKIPS_ENV in message
 
 
-def test_spot_prerequisite_missing_can_explicitly_skip(monkeypatch):
-    monkeypatch.setenv(ALLOW_SPOT_TEST_SKIPS_ENV, "1")
-
-    with pytest.raises(pytest.skip.Exception) as exc_info:
-        spot_prerequisite_missing("Insufficient balances for SPOT tests")
-
-    assert "Insufficient balances for SPOT tests" in str(exc_info.value)
+def test_spot_prerequisite_guard_has_no_escape_hatch():
+    assert not any(name.startswith("ALLOW_") for name in dir(spot_prerequisites))
 
 
 def test_missing_env_vars_reports_names_without_values(monkeypatch):

--- a/tests/validation/test_spot_prerequisite_guard.py
+++ b/tests/validation/test_spot_prerequisite_guard.py
@@ -1,6 +1,6 @@
 import pytest
 
-import tests.helpers.spot_prerequisites as spot_prerequisites
+from tests.helpers import spot_prerequisites
 from tests.helpers.spot_prerequisites import missing_env_vars, spot_prerequisite_missing
 
 

--- a/tests/validation/test_strict_prerequisite_preflight.py
+++ b/tests/validation/test_strict_prerequisite_preflight.py
@@ -53,4 +53,4 @@ def test_missing_spot_env_is_detected_before_execution_busts_guard_api_calls(mon
 def test_non_strict_items_do_not_disable_execution_busts_guard(monkeypatch):
     monkeypatch.delenv("REYA_WS_EXEC_URL", raising=False)
 
-    assert _strict_prerequisite_missing_env([_Item(set())]) == []
+    assert not _strict_prerequisite_missing_env([_Item(set())])

--- a/tests/validation/test_strict_prerequisite_preflight.py
+++ b/tests/validation/test_strict_prerequisite_preflight.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tests.conftest import _strict_prerequisite_missing_env
+
+
+@dataclass
+class _Item:
+    markers: set[str]
+
+    def get_closest_marker(self, name: str):
+        return object() if name in self.markers else None
+
+
+def _clear_env(monkeypatch, names: tuple[str, ...]) -> None:
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_missing_ws_exec_env_is_detected_before_execution_busts_guard_api_calls(monkeypatch):
+    required = (
+        "REYA_WS_EXEC_URL",
+        "SPOT_PRIVATE_KEY_1",
+        "SPOT_ACCOUNT_ID_1",
+        "SPOT_WALLET_ADDRESS_1",
+        "SPOT_PRIVATE_KEY_2",
+        "SPOT_ACCOUNT_ID_2",
+        "SPOT_WALLET_ADDRESS_2",
+        "PERP_PRIVATE_KEY_1",
+        "PERP_ACCOUNT_ID_1",
+        "PERP_WALLET_ADDRESS_1",
+    )
+    _clear_env(monkeypatch, required)
+
+    assert _strict_prerequisite_missing_env([_Item({"strict_ws_exec_prerequisites"})]) == list(required)
+
+
+def test_missing_spot_env_is_detected_before_execution_busts_guard_api_calls(monkeypatch):
+    required = (
+        "SPOT_PRIVATE_KEY_1",
+        "SPOT_ACCOUNT_ID_1",
+        "SPOT_WALLET_ADDRESS_1",
+        "SPOT_PRIVATE_KEY_2",
+        "SPOT_ACCOUNT_ID_2",
+        "SPOT_WALLET_ADDRESS_2",
+    )
+    _clear_env(monkeypatch, required)
+
+    assert _strict_prerequisite_missing_env([_Item({"strict_spot_prerequisites"})]) == list(required)
+
+
+def test_non_strict_items_do_not_disable_execution_busts_guard(monkeypatch):
+    monkeypatch.delenv("REYA_WS_EXEC_URL", raising=False)
+
+    assert _strict_prerequisite_missing_env([_Item(set())]) == []

--- a/tests/validation/test_ws_exec_prerequisite_guard.py
+++ b/tests/validation/test_ws_exec_prerequisite_guard.py
@@ -1,0 +1,39 @@
+import pytest
+
+from tests.helpers.ws_exec_prerequisites import (
+    ALLOW_WS_EXEC_TEST_SKIPS_ENV,
+    ws_exec_account_env_vars,
+    ws_exec_prerequisite_missing,
+)
+
+
+def test_ws_exec_prerequisite_missing_fails_by_default(monkeypatch):
+    monkeypatch.delenv(ALLOW_WS_EXEC_TEST_SKIPS_ENV, raising=False)
+
+    with pytest.raises(pytest.fail.Exception) as exc_info:
+        ws_exec_prerequisite_missing(
+            "ws-exec live tests need REYA_WS_EXEC_URL and PERP_*_1",
+            missing_env=["REYA_WS_EXEC_URL", "PERP_PRIVATE_KEY_1"],
+        )
+
+    message = str(exc_info.value)
+    assert "WS exec test prerequisites missing" in message
+    assert "REYA_WS_EXEC_URL, PERP_PRIVATE_KEY_1" in message
+    assert ALLOW_WS_EXEC_TEST_SKIPS_ENV in message
+
+
+def test_ws_exec_prerequisite_missing_can_explicitly_skip(monkeypatch):
+    monkeypatch.setenv(ALLOW_WS_EXEC_TEST_SKIPS_ENV, "1")
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        ws_exec_prerequisite_missing("ws-exec disabled in this environment")
+
+    assert "ws-exec disabled in this environment" in str(exc_info.value)
+
+
+def test_ws_exec_account_env_vars_for_perp_account():
+    assert ws_exec_account_env_vars("PERP", 1) == (
+        "PERP_PRIVATE_KEY_1",
+        "PERP_ACCOUNT_ID_1",
+        "PERP_WALLET_ADDRESS_1",
+    )

--- a/tests/validation/test_ws_exec_prerequisite_guard.py
+++ b/tests/validation/test_ws_exec_prerequisite_guard.py
@@ -1,15 +1,10 @@
 import pytest
 
-from tests.helpers.ws_exec_prerequisites import (
-    ALLOW_WS_EXEC_TEST_SKIPS_ENV,
-    ws_exec_account_env_vars,
-    ws_exec_prerequisite_missing,
-)
+import tests.helpers.ws_exec_prerequisites as ws_exec_prerequisites
+from tests.helpers.ws_exec_prerequisites import ws_exec_account_env_vars, ws_exec_prerequisite_missing
 
 
-def test_ws_exec_prerequisite_missing_fails_by_default(monkeypatch):
-    monkeypatch.delenv(ALLOW_WS_EXEC_TEST_SKIPS_ENV, raising=False)
-
+def test_ws_exec_prerequisite_missing_always_fails():
     with pytest.raises(pytest.fail.Exception) as exc_info:
         ws_exec_prerequisite_missing(
             "ws-exec live tests need REYA_WS_EXEC_URL and PERP_*_1",
@@ -19,16 +14,10 @@ def test_ws_exec_prerequisite_missing_fails_by_default(monkeypatch):
     message = str(exc_info.value)
     assert "WS exec test prerequisites missing" in message
     assert "REYA_WS_EXEC_URL, PERP_PRIVATE_KEY_1" in message
-    assert ALLOW_WS_EXEC_TEST_SKIPS_ENV in message
 
 
-def test_ws_exec_prerequisite_missing_can_explicitly_skip(monkeypatch):
-    monkeypatch.setenv(ALLOW_WS_EXEC_TEST_SKIPS_ENV, "1")
-
-    with pytest.raises(pytest.skip.Exception) as exc_info:
-        ws_exec_prerequisite_missing("ws-exec disabled in this environment")
-
-    assert "ws-exec disabled in this environment" in str(exc_info.value)
+def test_ws_exec_prerequisite_guard_has_no_escape_hatch():
+    assert not any(name.startswith("ALLOW_") for name in dir(ws_exec_prerequisites))
 
 
 def test_ws_exec_account_env_vars_for_perp_account():

--- a/tests/validation/test_ws_exec_prerequisite_guard.py
+++ b/tests/validation/test_ws_exec_prerequisite_guard.py
@@ -1,6 +1,6 @@
 import pytest
 
-import tests.helpers.ws_exec_prerequisites as ws_exec_prerequisites
+from tests.helpers import ws_exec_prerequisites
 from tests.helpers.ws_exec_prerequisites import ws_exec_account_env_vars, ws_exec_prerequisite_missing
 
 

--- a/tests/ws_exec/test_ws_exec.py
+++ b/tests/ws_exec/test_ws_exec.py
@@ -3,9 +3,9 @@
 Exercises every supported operation and variant of the ws-exec WebSocket
 order-entry service, plus the highest-signal error modes, against a live
 deployment. These are *integration* tests: the whole module is skipped
-unless `REYA_WS_EXEC_URL` (+ SPOT_*_1 / PERP_*_1 credentials) is set, so a
-normal `pytest` run on a machine without ws-exec access collects-and-skips
-cleanly. Point `REYA_WS_EXEC_URL` at the target relayer to run them, e.g.
+unless `REYA_WS_EXEC_URL` and PERP_*_1 credentials are set. Spot credential,
+market-definition, and second-account gaps fail by default so spot coverage
+cannot silently disappear. Point `REYA_WS_EXEC_URL` at the target relayer, e.g.
 `REYA_WS_EXEC_URL=wss://ws-exec-devnet.reya-cronos.network`.
 
 Happy paths (11) — all driven via :class:`ReyaWsExecClient`:
@@ -60,6 +60,7 @@ from sdk.reya_rest_api import ReyaTradingClient
 from sdk.reya_rest_api.config import TradingConfig
 from sdk.reya_rest_api.models.orders import LimitOrderParameters, TriggerOrderParameters
 from sdk.reya_ws_exec import ReyaWsExecClient
+from tests.helpers.spot_prerequisites import missing_env_vars, spot_account_env_vars, spot_prerequisite_missing
 from tests.helpers.ws_exec_harness import (
     assert_per_op_error,
     assert_top_level_error,
@@ -70,24 +71,24 @@ from tests.helpers.ws_exec_harness import (
 
 load_dotenv()
 
-# Live ws-exec integration tests are gated on a relayer URL + signing creds.
-# Without them the whole module collects-and-skips so CI stays green on
-# machines that can't reach a ws-exec deployment.
-_REQUIRED_ENV = (
+# Live ws-exec integration tests are gated on a relayer URL + perp signing creds.
+# Spot signing creds are checked inside the harness so missing SPOT_* fails
+# loudly instead of collecting as a green module-level skip.
+_MODULE_SKIP_ENV = (
     "REYA_WS_EXEC_URL",
     "PERP_PRIVATE_KEY_1",
     "PERP_ACCOUNT_ID_1",
-    "SPOT_PRIVATE_KEY_1",
-    "SPOT_ACCOUNT_ID_1",
 )
-_MISSING_ENV = [_k for _k in _REQUIRED_ENV if not os.environ.get(_k)]
+_SPOT_ACCOUNT_1_ENV = spot_account_env_vars(1)
+_SPOT_ACCOUNT_2_ENV = spot_account_env_vars(2)
+_MISSING_ENV = missing_env_vars(_MODULE_SKIP_ENV)
 
 pytestmark = [
     pytest.mark.skipif(
         bool(_MISSING_ENV),
         reason=(
-            "ws-exec live tests need " + ", ".join(_REQUIRED_ENV) + " in the environment "
-            "(set REYA_WS_EXEC_URL + SPOT_*_1/PERP_*_1 to run); missing: " + ", ".join(_MISSING_ENV)
+            "ws-exec live tests need " + ", ".join(_MODULE_SKIP_ENV) + " in the environment "
+            "(set REYA_WS_EXEC_URL + PERP_*_1 to run); missing: " + ", ".join(_MISSING_ENV)
         ),
     ),
     pytest.mark.asyncio(loop_scope="function"),
@@ -618,6 +619,7 @@ class _WsExecHarness:
     spot_rest: ReyaTradingClient
     perp_rest: ReyaTradingClient
     spot_rest_2: ReyaTradingClient | None
+    spot_account_2_missing_env: list[str]
     spot_qty: Decimal
     perp_qty: Decimal
 
@@ -629,19 +631,23 @@ async def harness():
     Module-scoped: one set of clients shared across every ws-exec flow. The
     module-level skipif guarantees the required env is present before we get
     here, so a missing-creds path would be a real error, not a skip."""
+    missing_spot_1 = missing_env_vars(_SPOT_ACCOUNT_1_ENV)
+    if missing_spot_1:
+        spot_prerequisite_missing("ws-exec spot tests need Spot Account 1 configuration", missing_env=missing_spot_1)
+
     ws_url = os.environ.get("REYA_WS_EXEC_URL", DEFAULT_WS_EXEC_URL)
     spot_rest = await _build_rest_client(perp=False, account_number=1)
     perp_rest = await _build_rest_client(perp=True)
-    try:
-        spot_rest_2: ReyaTradingClient | None = await _build_rest_client(perp=False, account_number=2)
-    except (RuntimeError, ValueError):
-        spot_rest_2 = None  # SPOT_*_2 absent -> E6 signer-mismatch test skips.
+    spot_account_2_missing_env = missing_env_vars(_SPOT_ACCOUNT_2_ENV)
+    spot_rest_2: ReyaTradingClient | None = None
+    if not spot_account_2_missing_env:
+        spot_rest_2 = await _build_rest_client(perp=False, account_number=2)
 
     try:
         spot_markets = {m.symbol: m for m in await spot_rest.reference.get_spot_market_definitions()}
         perp_markets = {m.symbol: m for m in await perp_rest.reference.get_perp_market_definitions()}
         if SPOT_SYMBOL not in spot_markets:
-            raise RuntimeError(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
+            spot_prerequisite_missing(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
         if PERP_SYMBOL not in perp_markets:
             raise RuntimeError(f"{PERP_SYMBOL} not found in /perpMarketDefinitions")
         yield _WsExecHarness(
@@ -649,6 +655,7 @@ async def harness():
             spot_rest=spot_rest,
             perp_rest=perp_rest,
             spot_rest_2=spot_rest_2,
+            spot_account_2_missing_env=spot_account_2_missing_env,
             spot_qty=Decimal(str(spot_markets[SPOT_SYMBOL].min_order_qty)),
             perp_qty=Decimal(str(perp_markets[PERP_SYMBOL].min_order_qty)),
         )
@@ -797,7 +804,10 @@ async def test_err_order_deadline_passed(harness):  # pylint: disable=redefined-
 async def test_err_unauthorized_signature(harness):  # pylint: disable=redefined-outer-name
     """E6: declared signerWallet != recovered signer -> rejected. Requires SPOT_*_2."""
     if harness.spot_rest_2 is None:
-        pytest.skip("SPOT_*_2 not set in .env; signer-mismatch test needs a second account")
+        spot_prerequisite_missing(
+            "SPOT_*_2 not set in .env; signer-mismatch spot test needs a second account",
+            missing_env=harness.spot_account_2_missing_env,
+        )
     flow_err_unauthorized_signature(harness.ws_url, harness.spot_rest, harness.spot_rest_2, qty=harness.spot_qty)
 
 

--- a/tests/ws_exec/test_ws_exec.py
+++ b/tests/ws_exec/test_ws_exec.py
@@ -2,10 +2,9 @@
 
 Exercises every supported operation and variant of the ws-exec WebSocket
 order-entry service, plus the highest-signal error modes, against a live
-deployment. These are *integration* tests: the whole module is skipped
-unless `REYA_WS_EXEC_URL` and PERP_*_1 credentials are set. Spot credential,
-market-definition, and second-account gaps fail by default so spot coverage
-cannot silently disappear. Point `REYA_WS_EXEC_URL` at the target relayer, e.g.
+deployment. These are *integration* tests: missing `REYA_WS_EXEC_URL`, account
+credentials, or market definitions fail by default so WS exec coverage cannot
+silently disappear. Point `REYA_WS_EXEC_URL` at the target relayer, e.g.
 `REYA_WS_EXEC_URL=wss://ws-exec-devnet.reya-cronos.network`.
 
 Happy paths (11) — all driven via :class:`ReyaWsExecClient`:
@@ -60,7 +59,6 @@ from sdk.reya_rest_api import ReyaTradingClient
 from sdk.reya_rest_api.config import TradingConfig
 from sdk.reya_rest_api.models.orders import LimitOrderParameters, TriggerOrderParameters
 from sdk.reya_ws_exec import ReyaWsExecClient
-from tests.helpers.spot_prerequisites import missing_env_vars, spot_account_env_vars, spot_prerequisite_missing
 from tests.helpers.ws_exec_harness import (
     assert_per_op_error,
     assert_top_level_error,
@@ -68,31 +66,19 @@ from tests.helpers.ws_exec_harness import (
     raw_recv_until,
     raw_send_envelope,
 )
+from tests.helpers.ws_exec_prerequisites import missing_env_vars, ws_exec_account_env_vars, ws_exec_prerequisite_missing
 
 load_dotenv()
 
-# Live ws-exec integration tests are gated on a relayer URL + perp signing creds.
-# Spot signing creds are checked inside the harness so missing SPOT_* fails
-# loudly instead of collecting as a green module-level skip.
-_MODULE_SKIP_ENV = (
-    "REYA_WS_EXEC_URL",
-    "PERP_PRIVATE_KEY_1",
-    "PERP_ACCOUNT_ID_1",
-)
-_SPOT_ACCOUNT_1_ENV = spot_account_env_vars(1)
-_SPOT_ACCOUNT_2_ENV = spot_account_env_vars(2)
-_MISSING_ENV = missing_env_vars(_MODULE_SKIP_ENV)
+# Live ws-exec integration tests require a relayer URL plus spot/perp signing
+# credentials. Check inside the harness so missing env fails loudly instead of
+# collecting as a green module-level skip.
+_REQUIRED_WS_EXEC_ENV = ("REYA_WS_EXEC_URL",)
+_SPOT_ACCOUNT_1_ENV = ws_exec_account_env_vars("SPOT", 1)
+_SPOT_ACCOUNT_2_ENV = ws_exec_account_env_vars("SPOT", 2)
+_PERP_ACCOUNT_1_ENV = ws_exec_account_env_vars("PERP", 1)
 
-pytestmark = [
-    pytest.mark.skipif(
-        bool(_MISSING_ENV),
-        reason=(
-            "ws-exec live tests need " + ", ".join(_MODULE_SKIP_ENV) + " in the environment "
-            "(set REYA_WS_EXEC_URL + PERP_*_1 to run); missing: " + ", ".join(_MISSING_ENV)
-        ),
-    ),
-    pytest.mark.asyncio(loop_scope="function"),
-]
+pytestmark = [pytest.mark.asyncio(loop_scope="function")]
 
 # ---- Test parameters --------------------------------------------------------
 
@@ -126,7 +112,6 @@ PERP_REDUCE_ONLY_LIMIT_PX = "1"
 PERP_TP_TRIGGER_PX = "1000000"
 PERP_SL_TRIGGER_PX = "1"
 
-DEFAULT_WS_EXEC_URL = "wss://ws-exec-testnet.reya.xyz"
 RECV_TIMEOUT_S = 15.0
 
 
@@ -628,14 +613,16 @@ class _WsExecHarness:
 async def harness():
     """Build REST clients, resolve market min-qtys, expose the ws-exec URL.
 
-    Module-scoped: one set of clients shared across every ws-exec flow. The
-    module-level skipif guarantees the required env is present before we get
-    here, so a missing-creds path would be a real error, not a skip."""
-    missing_spot_1 = missing_env_vars(_SPOT_ACCOUNT_1_ENV)
-    if missing_spot_1:
-        spot_prerequisite_missing("ws-exec spot tests need Spot Account 1 configuration", missing_env=missing_spot_1)
+    One set of clients is shared across every ws-exec flow. Missing env fails
+    here instead of collecting as a green module-level skip."""
+    missing_required = missing_env_vars(_REQUIRED_WS_EXEC_ENV + _SPOT_ACCOUNT_1_ENV + _PERP_ACCOUNT_1_ENV)
+    if missing_required:
+        ws_exec_prerequisite_missing(
+            "ws-exec live tests need REYA_WS_EXEC_URL, Spot Account 1, and Perp Account 1 configuration",
+            missing_env=missing_required,
+        )
 
-    ws_url = os.environ.get("REYA_WS_EXEC_URL", DEFAULT_WS_EXEC_URL)
+    ws_url = os.environ["REYA_WS_EXEC_URL"]
     spot_rest = await _build_rest_client(perp=False, account_number=1)
     perp_rest = await _build_rest_client(perp=True)
     spot_account_2_missing_env = missing_env_vars(_SPOT_ACCOUNT_2_ENV)
@@ -647,9 +634,9 @@ async def harness():
         spot_markets = {m.symbol: m for m in await spot_rest.reference.get_spot_market_definitions()}
         perp_markets = {m.symbol: m for m in await perp_rest.reference.get_perp_market_definitions()}
         if SPOT_SYMBOL not in spot_markets:
-            spot_prerequisite_missing(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
+            ws_exec_prerequisite_missing(f"{SPOT_SYMBOL} not found in /spotMarketDefinitions")
         if PERP_SYMBOL not in perp_markets:
-            raise RuntimeError(f"{PERP_SYMBOL} not found in /perpMarketDefinitions")
+            ws_exec_prerequisite_missing(f"{PERP_SYMBOL} not found in /perpMarketDefinitions")
         yield _WsExecHarness(
             ws_url=ws_url,
             spot_rest=spot_rest,
@@ -804,7 +791,7 @@ async def test_err_order_deadline_passed(harness):  # pylint: disable=redefined-
 async def test_err_unauthorized_signature(harness):  # pylint: disable=redefined-outer-name
     """E6: declared signerWallet != recovered signer -> rejected. Requires SPOT_*_2."""
     if harness.spot_rest_2 is None:
-        spot_prerequisite_missing(
+        ws_exec_prerequisite_missing(
             "SPOT_*_2 not set in .env; signer-mismatch spot test needs a second account",
             missing_env=harness.spot_account_2_missing_env,
         )


### PR DESCRIPTION
## What changed
- Spot prerequisite gaps now fail unconditionally: missing spot env, missing selected spot market definitions, missing required spot balances, and spot ws-exec account gaps.
- WS exec prerequisite gaps now fail unconditionally: missing WS exec URL, required spot/perp account env, and ws-exec market definitions.
- Removed env-based skip opt-outs from the strict spot and WS exec prerequisite helpers, tests, and error messages.
- Marked strict spot/ws-exec test selections during collection so the session-wide execution-bust guard does not make unrelated preflight API calls before a controlled prerequisite failure.
- Preflighted the spot-pinned post-only WS exec would-cross test before either account REST client is started.
- Kept unrelated documented skips for product gaps and controlled-book/external-liquidity cases.

## Why
The live suite could previously look green while hiding spot or WS exec coverage behind setup skips. These are coverage prerequisites, so missing setup should produce an actionable failure, not a skipped test.

## Validation
- `poetry run pytest -q tests/validation/test_spot_prerequisite_guard.py tests/validation/test_ws_exec_prerequisite_guard.py tests/validation/test_strict_prerequisite_preflight.py` -> 10 passed
- Forced missing spot account env against `tests/spot/test_market_data.py::test_spot_market_definitions` -> expected strict spot prerequisite setup error; execution-bust guard stayed inactive, no API-unreachable warning
- Forced missing WS exec URL/perp env against `tests/ws_exec/test_ws_exec.py::test_ping` -> expected strict WS exec prerequisite setup error; execution-bust guard stayed inactive, no API-unreachable warning
- Forced missing post-only would-cross spot/ws-exec env against `tests/engine/test_post_only_ws_exec.py::test_ws_exec_post_only_would_cross_error_envelope` -> expected strict WS exec prerequisite setup error before side-effectful setup
- `poetry run black --check tests/helpers/spot_prerequisites.py tests/helpers/ws_exec_prerequisites.py tests/validation/test_spot_prerequisite_guard.py tests/validation/test_ws_exec_prerequisite_guard.py tests/validation/test_strict_prerequisite_preflight.py tests/conftest.py tests/spot/test_pretrade_checks.py tests/engine/test_post_only_ws_exec.py` -> passed
- `poetry run isort --check-only tests/helpers/spot_prerequisites.py tests/helpers/ws_exec_prerequisites.py tests/validation/test_spot_prerequisite_guard.py tests/validation/test_ws_exec_prerequisite_guard.py tests/validation/test_strict_prerequisite_preflight.py tests/conftest.py tests/spot/test_pretrade_checks.py tests/engine/test_post_only_ws_exec.py` -> passed
- `poetry run flake8 --max-line-length=120 tests/helpers/spot_prerequisites.py tests/helpers/ws_exec_prerequisites.py tests/validation/test_spot_prerequisite_guard.py tests/validation/test_ws_exec_prerequisite_guard.py tests/validation/test_strict_prerequisite_preflight.py tests/conftest.py tests/spot/test_pretrade_checks.py tests/engine/test_post_only_ws_exec.py` -> passed
- Source/text search for the removed env skip opt-out names -> no matches in the worktree or shared memory note