### PR TITLE
Replace deprecated price endpoint usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This ensures the SDK version always reflects compatibility with the underlying A
 - **Market Data Resource**
     - Get all perp markets summary via `/v2/perpMarkets/summary`
     - Get perp market summary via `/v2/perpMarket/{symbol}/summary`
+    - Get all spot markets summary via `/v2/spotMarkets/summary`
+    - Get spot market summary via `/v2/spotMarket/{symbol}/summary`
     - Get market perpetual executions via `/v2/market/{symbol}/perpExecutions`
     - Get historical candles via `/v2/candleHistory/{symbol}/{resolution}`
 
@@ -43,14 +45,14 @@ This ensures the SDK version always reflects compatibility with the underlying A
 
 - **Prices Resource**
     - Get asset oracle prices via `/v2/assetOraclePrices`
-    - Get legacy market/collateral prices via `/v2/prices` (deprecated)
-    - Get legacy price by symbol via `/v2/prices/{symbol}` (deprecated)
 
 ### WebSocket API Client (Resource-Oriented)
 
 - **Market Resources**
     - Subscribe to all perp markets summary via `/v2/perpMarkets/summary`
     - Subscribe to specific perp market summary via `/v2/perpMarket/{symbol}/summary`
+    - Subscribe to all spot markets summary via `/v2/spotMarkets/summary`
+    - Subscribe to specific spot market summary via `/v2/spotMarket/{symbol}/summary`
     - Monitor market perpetual executions via `/v2/market/{symbol}/perpExecutions`
 
 - **Wallet Resources**
@@ -60,8 +62,6 @@ This ensures the SDK version always reflects compatibility with the underlying A
 
 - **Price Resources**
     - Track asset oracle prices via `/v2/assetOraclePrices`
-    - Track legacy market/collateral prices via `/v2/prices` (deprecated)
-    - Track legacy price by symbol via `/v2/prices/{symbol}` (deprecated)
 
 ## API Specifications
 
@@ -200,11 +200,11 @@ ReyaTradingClient
 ├── markets                          # Market Data resource
 │   ├── get_perp_markets_summary()   # /v2/perpMarkets/summary
 │   ├── get_perp_market_summary()    # /v2/perpMarket/{symbol}/summary
+│   ├── get_spot_markets_summary()   # /v2/spotMarkets/summary
+│   ├── get_spot_market_summary()    # /v2/spotMarket/{symbol}/summary
 │   ├── get_market_perp_executions() # /v2/market/{symbol}/perpExecutions
 │   ├── get_candles()                # /v2/candleHistory/{symbol}/{resolution}
-│   ├── get_asset_oracle_prices()      # /v2/assetOraclePrices
-│   ├── get_prices()                 # /v2/prices (deprecated)
-│   └── get_price()                  # /v2/prices/{symbol} (deprecated)
+│   └── get_asset_oracle_prices()    # /v2/assetOraclePrices
 ├── reference                        # Reference Data resource
 │   ├── get_perp_market_definitions() # /v2/perpMarketDefinitions
 │   ├── get_asset_definitions()      # /v2/assetDefinitions
@@ -225,6 +225,12 @@ ReyaSocket
 │   ├── market_summary(symbol)          # /v2/perpMarket/{symbol}/summary
 │   │   ├── subscribe()
 │   │   └── unsubscribe()
+│   ├── all_spot_markets_summary        # /v2/spotMarkets/summary
+│   │   ├── subscribe()
+│   │   └── unsubscribe()
+│   ├── spot_summary(symbol)            # /v2/spotMarket/{symbol}/summary
+│   │   ├── subscribe()
+│   │   └── unsubscribe()
 │   └── market_perp_executions(symbol)  # /v2/market/{symbol}/perpExecutions
 │       ├── subscribe()
 │       └── unsubscribe()
@@ -242,12 +248,6 @@ ReyaSocket
 │   ├── asset_oracle_prices             # /v2/assetOraclePrices
 │   │   ├── subscribe()
 │   │   └── unsubscribe()
-│   ├── all_prices                      # /v2/prices (deprecated)
-│   │   ├── subscribe()
-│   │   └── unsubscribe()
-│   └── price(symbol)                   # /v2/prices/{symbol} (deprecated)
-│       ├── subscribe()
-│       └── unsubscribe()
 └── ping                                # /ping (heartbeat)
     ├── send_pong()
     └── receive_ping()

--- a/examples/rest_api/perps/prices_example.py
+++ b/examples/rest_api/perps/prices_example.py
@@ -44,9 +44,10 @@ async def main():
             oracle_price = float(sample_price.oracle_price)
             print(f"Oracle price in USD: ${oracle_price:.2f}")
 
-        # Legacy /v2/prices remains available for existing consumers but is deprecated.
-        legacy_prices = await client.markets.get_prices()
-        print(f"\n--- Deprecated legacy prices feed returned {len(legacy_prices)} entries ---")
+        print("\n--- Getting perp market mark/mid prices ---")
+        market_summary = await client.markets.get_perp_market_summary("ETHRUSDPERP")
+        print(f"ETHRUSDPERP mark price: {market_summary.mark_price}")
+        print(f"ETHRUSDPERP throttled mid price: {market_summary.throttled_mid_price}")
 
 
 if __name__ == "__main__":

--- a/examples/rest_api/spot/spot_transfer.py
+++ b/examples/rest_api/spot/spot_transfer.py
@@ -59,11 +59,11 @@ ASSET_TO_SYMBOL = {
 }
 
 # Mapping from asset to oracle symbol (perp symbol) for fetching oracle prices
-ASSET_TO_ORACLE_SYMBOL = {
-    "ETH": "ETHRUSDPERP",
-    "WETH": "ETHRUSDPERP",
-    "BTC": "BTCRUSDPERP",
-    "WBTC": "BTCRUSDPERP",
+ASSET_TO_PRICE_ASSET = {
+    "ETH": "ETH",
+    "WETH": "ETH",
+    "BTC": "BTC",
+    "WBTC": "BTC",
     "REYA": "REYA",
 }
 
@@ -87,9 +87,8 @@ async def get_account_balance(client: ReyaTradingClient, account_id: int, asset:
 
 async def get_oracle_price(client: ReyaTradingClient, asset: str) -> Decimal:
     """
-    Fetch the current oracle price for an asset from the v2/prices API.
+    Fetch the current oracle price for an asset from the v2/assetOraclePrices API.
 
-    The oracle price is fetched from the corresponding perp market (e.g., ETHRUSDPERP for ETH).
     This ensures transfers happen at a price within the ±5% circuit breaker limit.
 
     Args:
@@ -102,21 +101,19 @@ async def get_oracle_price(client: ReyaTradingClient, asset: str) -> Decimal:
     Raises:
         SystemExit: If oracle price cannot be fetched
     """
-    oracle_symbol = ASSET_TO_ORACLE_SYMBOL.get(asset.upper())
+    price_asset = ASSET_TO_PRICE_ASSET.get(asset.upper())
 
-    if not oracle_symbol:
-        logger.error(f"❌ No oracle symbol mapping for {asset}. Supported: {list(ASSET_TO_ORACLE_SYMBOL.keys())}")
+    if not price_asset:
+        logger.error(f"❌ No oracle asset mapping for {asset}. Supported: {list(ASSET_TO_PRICE_ASSET.keys())}")
         sys.exit(1)
 
     try:
-        price_data = await client.markets.get_price(symbol=oracle_symbol)
-        # Pydantic models have no ``__bool__``, so guard on the field directly.
-        if price_data.oracle_price:
-            oracle_price = Decimal(price_data.oracle_price)
-            logger.info(f"📈 Fetched oracle price for {asset}: ${oracle_price:.2f}")
-            return oracle_price
+        price_data = await client.get_asset_oracle_price(price_asset)
+        oracle_price = Decimal(price_data.oracle_price)
+        logger.info(f"📈 Fetched oracle price for {asset}: ${oracle_price:.2f}")
+        return oracle_price
     except (OSError, RuntimeError, ApiException) as e:
-        logger.warning(f"⚠️ Failed to fetch oracle price for {oracle_symbol}: {e}")
+        logger.warning(f"⚠️ Failed to fetch oracle price for {price_asset}: {e}")
 
     # Fall back to configured price if oracle is unavailable. ``is not None``
     # so a legitimate ``Decimal('0')`` sentinel (e.g. a free-transfer asset)

--- a/examples/rest_api/spot/spot_transfer.py
+++ b/examples/rest_api/spot/spot_transfer.py
@@ -58,15 +58,6 @@ ASSET_TO_SYMBOL = {
     "REYA": "REYARUSD",
 }
 
-# Mapping from asset to oracle symbol (perp symbol) for fetching oracle prices
-ASSET_TO_PRICE_ASSET = {
-    "ETH": "ETH",
-    "WETH": "ETH",
-    "BTC": "BTC",
-    "WBTC": "BTC",
-    "REYA": "REYA",
-}
-
 # Fallback prices for assets without a live oracle feed
 ASSET_FALLBACK_PRICES: dict[str, Decimal] = {
     "REYA": Decimal("0.10"),
@@ -74,6 +65,14 @@ ASSET_FALLBACK_PRICES: dict[str, Decimal] = {
 
 ORDER_SETTLEMENT_RETRIES = 3
 ORDER_SETTLEMENT_DELAY = 1.0
+
+
+def asset_oracle_asset(asset: str) -> str:
+    """Normalize wrapped spot aliases to the asset oracle feed name."""
+    normalized_asset = asset.upper()
+    if normalized_asset in {"WETH", "WBTC"}:
+        return normalized_asset[1:]
+    return normalized_asset
 
 
 async def get_account_balance(client: ReyaTradingClient, account_id: int, asset: str) -> Decimal:
@@ -101,11 +100,7 @@ async def get_oracle_price(client: ReyaTradingClient, asset: str) -> Decimal:
     Raises:
         SystemExit: If oracle price cannot be fetched
     """
-    price_asset = ASSET_TO_PRICE_ASSET.get(asset.upper())
-
-    if not price_asset:
-        logger.error(f"❌ No oracle asset mapping for {asset}. Supported: {list(ASSET_TO_PRICE_ASSET.keys())}")
-        sys.exit(1)
+    price_asset = asset_oracle_asset(asset)
 
     try:
         price_data = await client.get_asset_oracle_price(price_asset)

--- a/examples/websocket/perps/depth_market_maker.py
+++ b/examples/websocket/perps/depth_market_maker.py
@@ -13,6 +13,7 @@ shutdown. Adaptations vs the spot bot:
   rUSD; per-order required margin is approximated as ``price * qty /
   max_leverage``. Conservative on purpose — this is a depth source, not an
   alpha generator.
+- Price reference: ``/perpMarket/{symbol}/summary`` markPrice.
 - WS executions: ``ws.wallet.perp_executions(wallet)`` instead of
   ``spot_executions``.
 
@@ -51,8 +52,8 @@ from decimal import ROUND_DOWN, Decimal
 from dotenv import load_dotenv  # pip install python-dotenv
 
 from sdk.async_api.account_balance_update_payload import AccountBalanceUpdatePayload
+from sdk.async_api.market_summary_update_payload import MarketSummaryUpdatePayload
 from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
-from sdk.async_api.price_update_payload import PriceUpdatePayload
 from sdk.async_api.subscribed_message_payload import SubscribedMessagePayload
 from sdk.async_api.wallet_perp_execution_update_payload import WalletPerpExecutionUpdatePayload
 from sdk.open_api.exceptions import ApiException
@@ -75,10 +76,8 @@ logger = logging.getLogger("perp_market_maker_ws")
 
 # Market configuration (defaults, can be overridden via command line).
 # Defaults assume the standard devnet1 / cronos / mainnet ETH perp listing.
-# Default to the perp symbol as its own oracle reference. /v2/prices/{symbol}
-# returns `oraclePrice` for perp symbols on every env, whereas spot oracle
-# pairs (e.g. "ETHRUSD") are not registered on perp-only envs like devnet1.
-# Override with --oracle-symbol if you want to peg to a different reference.
+# Default to the perp symbol as its own mark-price reference.
+# Override with --oracle-symbol if you want to peg to a different perp summary.
 DEFAULT_SYMBOL = "ETHRUSDPERP"
 DEFAULT_ORACLE_SYMBOL = "ETHRUSDPERP"
 DEFAULT_MAX_SPREAD_PCT = Decimal("0.01")  # ±1% from reference price
@@ -320,7 +319,7 @@ def compute_available_margin(
 
 
 class WebSocketHandler:
-    """Subscribes to oracle price, wallet balances, order changes, perp executions."""
+    """Subscribes to mark price, wallet balances, order changes, perp executions."""
 
     def __init__(self, state: MarketMakerState):
         self.state = state
@@ -336,12 +335,12 @@ class WebSocketHandler:
             logger.error("No wallet address set in state")
             return
 
-        ws.prices.price(self.state.oracle_symbol).subscribe()
+        ws.market.summary(self.state.oracle_symbol).subscribe()
         ws.wallet.balances(wallet).subscribe()
         ws.wallet.order_changes(wallet).subscribe()
         ws.wallet.perp_executions(wallet).subscribe()
 
-        logger.info(f"   ✅ Subscribed to /v2/prices/{self.state.oracle_symbol}")
+        logger.info(f"   ✅ Subscribed to /v2/perpMarket/{self.state.oracle_symbol}/summary")
         logger.info(f"   ✅ Subscribed to /v2/wallet/{wallet}/accountBalances")
         logger.info(f"   ✅ Subscribed to /v2/wallet/{wallet}/openOrders")
         logger.info(f"   ✅ Subscribed to /v2/wallet/{wallet}/perpExecutions")
@@ -353,9 +352,9 @@ class WebSocketHandler:
             self._connected.set()
             return
 
-        if isinstance(message, PriceUpdatePayload):
-            if message.data and message.data.oracle_price:
-                price = Decimal(message.data.oracle_price)
+        if isinstance(message, MarketSummaryUpdatePayload):
+            if message.data and message.data.mark_price:
+                price = Decimal(message.data.mark_price)
                 if self.state.market_params:
                     price = round_to_tick(price, self.state.market_params.tick_size)
                 self.state.update_price(price)
@@ -437,10 +436,9 @@ async def fetch_initial_state(client: ReyaTradingClient, state: MarketMakerState
     if not market_params or not account_id:
         raise RuntimeError("Market params and account_id must be set before fetching initial state")
 
-    logger.info(f"   Fetching oracle price for {state.oracle_symbol}...")
-    price_info = await client.markets.get_price(state.oracle_symbol)
-    if price_info and price_info.oracle_price:
-        state.reference_price = round_to_tick(Decimal(price_info.oracle_price), market_params.tick_size)
+    logger.info(f"   Fetching mark price for {state.oracle_symbol}...")
+    mark_price = await client.get_market_mark_price(state.oracle_symbol)
+    state.reference_price = round_to_tick(Decimal(mark_price), market_params.tick_size)
 
     logger.info("   Fetching account balances...")
     balances = await client.get_account_balances()
@@ -836,7 +834,7 @@ async def main(symbol: str, oracle_symbol: str, max_spread_pct: Decimal) -> None
 
         min_price = state.reference_price * (1 - state.max_spread_pct)
         max_price = state.reference_price * (1 + state.max_spread_pct)
-        logger.info(f"   Reference Price: ${state.reference_price} (from {oracle_symbol} oracle)")
+        logger.info(f"   Reference Price: ${state.reference_price} (from {oracle_symbol} markPrice)")
         logger.info(f"   Price Range:     ${min_price:.2f} – ${max_price:.2f} (±{state.max_spread_pct * 100}%)")
         logger.info(f"   Tick Size:       {market_params.tick_size}")
         logger.info(f"   Min Order Qty:   {market_params.min_order_qty}")
@@ -930,7 +928,7 @@ def parse_args() -> argparse.Namespace:
         "--oracle-symbol",
         type=str,
         default=DEFAULT_ORACLE_SYMBOL,
-        help=f"Oracle reference symbol (default: {DEFAULT_ORACLE_SYMBOL})",
+        help=f"Perp summary reference symbol (default: {DEFAULT_ORACLE_SYMBOL})",
     )
     parser.add_argument(
         "--max-spread",

--- a/examples/websocket/perps/prices_monitoring.py
+++ b/examples/websocket/perps/prices_monitoring.py
@@ -2,8 +2,7 @@
 Prices Monitoring - Monitor asset oracle prices via WebSocket.
 
 This example connects to the Reya WebSocket API and subscribes to the canonical
-asset oracle price stream. The legacy /v2/prices channels remain available for
-existing consumers but are deprecated.
+asset oracle price stream.
 
 Requirements:
 - CHAIN_ID: The chain ID (1729 for mainnet, 89346162 for testnet)
@@ -25,8 +24,6 @@ from sdk.async_api.asset_oracle_prices_update_payload import AssetOraclePricesUp
 from sdk.async_api.error_message_payload import ErrorMessagePayload
 from sdk.async_api.ping_message_payload import PingMessagePayload
 from sdk.async_api.pong_message_payload import PongMessagePayload
-from sdk.async_api.price_update_payload import PriceUpdatePayload
-from sdk.async_api.prices_update_payload import PricesUpdatePayload
 from sdk.async_api.subscribed_message_payload import SubscribedMessagePayload
 from sdk.reya_websocket import ReyaSocket
 from sdk.reya_websocket.config import WebSocketConfig
@@ -37,19 +34,12 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 # Create a logger for this module
 logger = logging.getLogger("reya.prices_monitoring")
 
-# Legacy symbol to monitor if you opt into /v2/prices/{symbol}.
-LEGACY_SYMBOL = "ETHRUSDPERP"
-
 
 def on_open(ws):
     """Handle WebSocket connection open event."""
     logger.info("Connection established, subscribing to asset oracle prices")
 
     ws.prices.asset_oracle_prices.subscribe()
-
-    # Deprecated legacy channels:
-    # ws.prices.all_prices.subscribe()
-    # ws.prices.price(LEGACY_SYMBOL).subscribe()
 
 
 def handle_asset_oracle_prices_data(payload: AssetOraclePricesUpdatePayload) -> None:
@@ -68,36 +58,6 @@ def handle_asset_oracle_prices_data(payload: AssetOraclePricesUpdatePayload) -> 
         logger.info(f"    ... and {len(payload.data) - 5} more assets")
 
 
-def handle_all_prices_data(payload: PricesUpdatePayload) -> None:
-    """Handle deprecated /v2/prices channel data."""
-    logger.info("💰 Deprecated Legacy Prices Update:")
-    logger.info(f"  ├─ Timestamp: {payload.timestamp}")
-    logger.info(f"  ├─ Channel: {payload.channel}")
-    logger.info(f"  └─ Prices Count: {len(payload.data)}")
-
-    # Showcase individual price data structure
-    for i, price in enumerate(payload.data[:5]):  # Show first 5 prices
-        logger.info(f"    Price {i + 1}: {price.symbol}")
-        logger.info(f"      ├─ Oracle Price: {price.oracle_price or 'N/A'}")
-        logger.info(f"      ├─ Pool Price: {price.pool_price or 'N/A'}")
-        logger.info(f"      └─ Updated At: {price.updated_at}")
-
-    if len(payload.data) > 5:
-        logger.info(f"    ... and {len(payload.data) - 5} more prices")
-
-
-def handle_single_price_data(payload: PriceUpdatePayload) -> None:
-    """Handle deprecated /v2/prices/:symbol channel data."""
-    price = payload.data
-
-    logger.info(f"💵 Deprecated Legacy Price Update for {price.symbol}:")
-    logger.info(f"  ├─ Timestamp: {payload.timestamp}")
-    logger.info(f"  ├─ Channel: {payload.channel}")
-    logger.info(f"  ├─ Oracle Price: {price.oracle_price or 'N/A'}")
-    logger.info(f"  ├─ Pool Price: {price.pool_price or 'N/A'}")
-    logger.info(f"  └─ Updated At: {price.updated_at}")
-
-
 def on_message(ws, message):
     """Handle WebSocket messages - receives typed Pydantic models from SDK."""
     # Handle subscription confirmations
@@ -109,15 +69,6 @@ def on_message(ws, message):
 
     if isinstance(message, AssetOraclePricesUpdatePayload):
         handle_asset_oracle_prices_data(message)
-        return
-
-    # Handle deprecated legacy price data updates
-    if isinstance(message, PricesUpdatePayload):
-        handle_all_prices_data(message)
-        return
-
-    if isinstance(message, PriceUpdatePayload):
-        handle_single_price_data(message)
         return
 
     # Handle ping/pong

--- a/examples/websocket/spot/depth_market_maker.py
+++ b/examples/websocket/spot/depth_market_maker.py
@@ -354,11 +354,12 @@ class WebSocketHandler:
 
         # Handle market summary price updates
         if isinstance(message, SpotMarketSummaryUpdatePayload):
-            if message.data and message.data.oracle_price:
-                price = Decimal(message.data.oracle_price)
-                if self.state.market_params:
-                    price = round_to_tick(price, self.state.market_params.tick_size)
-                self.state.update_price(price)
+            if not message.data or message.data.oracle_price is None:
+                raise RuntimeError(f"Spot market summary for {self.state.oracle_symbol} missing oraclePrice")
+            price = Decimal(message.data.oracle_price)
+            if self.state.market_params:
+                price = round_to_tick(price, self.state.market_params.tick_size)
+            self.state.update_price(price)
             return
 
         # Handle balance updates
@@ -449,8 +450,9 @@ async def fetch_initial_state(
     # Fetch spot market reference price
     logger.info(f"   Fetching spot market summary for {state.oracle_symbol}...")
     summary = await client.markets.get_spot_market_summary(state.oracle_symbol)
-    if summary.oracle_price:
-        state.reference_price = round_to_tick(Decimal(summary.oracle_price), market_params.tick_size)
+    if summary.oracle_price is None:
+        raise RuntimeError(f"Spot market summary for {state.oracle_symbol} missing oraclePrice")
+    state.reference_price = round_to_tick(Decimal(summary.oracle_price), market_params.tick_size)
 
     # Fetch account balances
     logger.info("   Fetching account balances...")

--- a/examples/websocket/spot/depth_market_maker.py
+++ b/examples/websocket/spot/depth_market_maker.py
@@ -3,7 +3,7 @@
 Spot Market Maker (WebSocket Version) - Maintains realistic depth around current ETH price.
 
 This version uses WebSocket for real-time updates instead of REST polling:
-- Price updates via /v2/prices/{symbol}
+- Price updates via /v2/spotMarket/{symbol}/summary
 - Balance updates via /v2/wallet/{address}/accountBalances
 - Order changes via /v2/wallet/{address}/openOrders
 - Spot executions via /v2/wallet/{address}/spotExecutions
@@ -38,7 +38,7 @@ from dotenv import load_dotenv  # pip install python-dotenv
 
 from sdk.async_api.account_balance_update_payload import AccountBalanceUpdatePayload
 from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
-from sdk.async_api.price_update_payload import PriceUpdatePayload
+from sdk.async_api.spot_market_summary_update_payload import SpotMarketSummaryUpdatePayload
 from sdk.async_api.subscribed_message_payload import SubscribedMessagePayload
 from sdk.async_api.wallet_spot_execution_update_payload import WalletSpotExecutionUpdatePayload
 from sdk.open_api.exceptions import ApiException
@@ -329,15 +329,15 @@ class WebSocketHandler:
             logger.error("No wallet address set in state")
             return
 
-        # Subscribe to price updates for oracle symbol
-        ws.prices.price(self.state.oracle_symbol).subscribe()
+        # Subscribe to spot market summary updates for reference pricing.
+        ws.market.spot_summary(self.state.oracle_symbol).subscribe()
 
         # Subscribe to wallet channels
         ws.wallet.balances(wallet).subscribe()
         ws.wallet.order_changes(wallet).subscribe()
         ws.wallet.spot_executions(wallet).subscribe()
 
-        logger.info(f"   ✅ Subscribed to /v2/prices/{self.state.oracle_symbol}")
+        logger.info(f"   ✅ Subscribed to /v2/spotMarket/{self.state.oracle_symbol}/summary")
         logger.info(f"   ✅ Subscribed to /v2/wallet/{wallet}/accountBalances")
         logger.info(f"   ✅ Subscribed to /v2/wallet/{wallet}/openOrders")
         logger.info(f"   ✅ Subscribed to /v2/wallet/{wallet}/spotExecutions")
@@ -352,8 +352,8 @@ class WebSocketHandler:
             self._connected.set()
             return
 
-        # Handle price updates
-        if isinstance(message, PriceUpdatePayload):
+        # Handle market summary price updates
+        if isinstance(message, SpotMarketSummaryUpdatePayload):
             if message.data and message.data.oracle_price:
                 price = Decimal(message.data.oracle_price)
                 if self.state.market_params:
@@ -446,11 +446,11 @@ async def fetch_initial_state(
     if not market_params or not account_id:
         raise RuntimeError("Market params and account_id must be set before fetching initial state")
 
-    # Fetch oracle price
-    logger.info(f"   Fetching oracle price for {state.oracle_symbol}...")
-    price_info = await client.markets.get_price(state.oracle_symbol)
-    if price_info and price_info.oracle_price:
-        state.reference_price = round_to_tick(Decimal(price_info.oracle_price), market_params.tick_size)
+    # Fetch spot market reference price
+    logger.info(f"   Fetching spot market summary for {state.oracle_symbol}...")
+    summary = await client.markets.get_spot_market_summary(state.oracle_symbol)
+    if summary.oracle_price:
+        state.reference_price = round_to_tick(Decimal(summary.oracle_price), market_params.tick_size)
 
     # Fetch account balances
     logger.info("   Fetching account balances...")
@@ -940,7 +940,7 @@ async def main(symbol: str, oracle_symbol: str, max_spread_pct: Decimal):
         min_price = state.reference_price * (1 - state.max_spread_pct)
         max_price = state.reference_price * (1 + state.max_spread_pct)
 
-        logger.info(f"   Reference Price: ${state.reference_price} (from {oracle_symbol} oracle)")
+        logger.info(f"   Reference Price: ${state.reference_price} (from {oracle_symbol} summary)")
         logger.info(f"   Price Range:     ${min_price:.2f} - ${max_price:.2f} (±{state.max_spread_pct * 100}%)")
         logger.info(f"   Tick Size:       {market_params.tick_size}")
         logger.info(f"   Min Order Qty:   {market_params.min_order_qty}")

--- a/scripts/devnet_pr59_surface_smoke.py
+++ b/scripts/devnet_pr59_surface_smoke.py
@@ -23,7 +23,6 @@ import os
 import queue
 import sys
 import time
-import warnings
 from dataclasses import dataclass
 from enum import Enum
 
@@ -35,7 +34,8 @@ from sdk.async_api.error_message_payload import ErrorMessagePayload
 from sdk.async_api.market_summary_update_payload import MarketSummaryUpdatePayload
 from sdk.async_api.markets_summary_update_payload import MarketsSummaryUpdatePayload
 from sdk.async_api.ping_message_payload import PingMessagePayload
-from sdk.async_api.prices_update_payload import PricesUpdatePayload
+from sdk.async_api.spot_market_summary_update_payload import SpotMarketSummaryUpdatePayload
+from sdk.async_api.spot_markets_summary_update_payload import SpotMarketsSummaryUpdatePayload
 from sdk.async_api.subscribed_message_payload import SubscribedMessagePayload
 from sdk.open_api.api.market_data_api import MarketDataApi
 from sdk.open_api.api.reference_data_api import ReferenceDataApi
@@ -106,16 +106,16 @@ SMOKE_CHECKS: tuple[SmokeCheck, ...] = (
         reason="Preferred perp summary read WS channels replace the removed unprefixed summary aliases.",
     ),
     SmokeCheck(
-        id="rest.deprecatedPrices",
+        id="rest.spotMarketsSummary",
         kind=SmokeCheckKind.REST,
-        target="/v2/prices + /v2/prices/{symbol}",
-        reason="Legacy prices REST endpoints remain callable during deprecation and should emit SDK deprecation warnings.",
+        target="/v2/spotMarkets/summary + /v2/spotMarket/{symbol}/summary",
+        reason="Spot market summary REST paths replace spot consumers of the deprecated prices endpoint.",
     ),
     SmokeCheck(
-        id="ws.deprecatedPrices",
+        id="ws.spotMarketsSummary",
         kind=SmokeCheckKind.WEBSOCKET,
-        target="/v2/prices",
-        reason="Legacy prices read WS channel remains callable during deprecation while consumers migrate.",
+        target="/v2/spotMarkets/summary + /v2/spotMarket/{symbol}/summary",
+        reason="Spot market summary read WS channels replace spot consumers of the deprecated prices channel.",
     ),
 )
 
@@ -171,10 +171,23 @@ def _describe_perp_summaries(summaries: list[Any], symbol: str, max_age_ms: int)
     return f"{len(summaries)} perp summary row(s), including {symbol}"
 
 
+def _describe_spot_summaries(summaries: list[Any], symbol: str, max_age_ms: int) -> str:
+    _assert(bool(summaries), "spot markets summary response was empty")
+    symbols = {summary.symbol for summary in summaries}
+    _assert(symbol in symbols, f"{symbol} missing from spot markets summary")
+    for summary in summaries:
+        if summary.oracle_price is not None:
+            _assert_positive_decimal(summary.oracle_price, f"{summary.symbol}.oraclePrice")
+        _assert_recent_ms(summary.updated_at, f"{summary.symbol}.updatedAt", max_age_ms=max_age_ms)
+    return f"{len(summaries)} spot summary row(s), including {symbol}"
+
+
 def run_static_sdk_checks() -> CheckResult:
     _assert(hasattr(rest_open_api, "AssetOraclePrice"), "REST SDK must expose AssetOraclePrice")
     _assert(not hasattr(rest_open_api, "CollateralOraclePrice"), "REST SDK must not expose CollateralOraclePrice")
     _assert(hasattr(MarketDataApi, "get_asset_oracle_prices"), "REST SDK missing get_asset_oracle_prices")
+    _assert(hasattr(MarketDataApi, "get_spot_markets_summary"), "REST SDK missing get_spot_markets_summary")
+    _assert(hasattr(MarketDataApi, "get_spot_market_summary"), "REST SDK missing get_spot_market_summary")
     _assert(not hasattr(MarketDataApi, "get_collateral_oracle_prices"), "old collateral oracle method still present")
     _assert(not hasattr(MarketDataApi, "get_markets_summary"), "old /v2/markets/summary method still present")
     _assert(not hasattr(MarketDataApi, "get_market_summary"), "old /v2/market/{symbol}/summary method still present")
@@ -187,11 +200,20 @@ def run_static_sdk_checks() -> CheckResult:
         ReyaSocket.CHANNEL_PAYLOAD_MAP["/v2/assetOraclePrices"] is AssetOraclePricesUpdatePayload,
         "read WS asset oracle channel is not routed to AssetOraclePricesUpdatePayload",
     )
+    _assert(
+        ReyaSocket.CHANNEL_PAYLOAD_MAP["/v2/spotMarkets/summary"] is SpotMarketsSummaryUpdatePayload,
+        "read WS spot markets summary channel is not routed to SpotMarketsSummaryUpdatePayload",
+    )
+    _assert("/v2/prices" not in ReyaSocket.CHANNEL_PAYLOAD_MAP, "deprecated prices WS channel still routed")
+    _assert(
+        ReyaSocket()._get_payload_type("/v2/prices/ETHRUSDPERP") is None,  # pylint: disable=protected-access
+        "deprecated single-price WS channel still routed",
+    )
     _assert("/v2/markets/summary" not in ReyaSocket.CHANNEL_PAYLOAD_MAP, "old summary WS channel still routed")
-    return _ok("sdk.removedAmmSurfaces", "removed aliases absent; asset oracle SDK surface present")
+    return _ok("sdk.removedAmmSurfaces", "removed aliases absent; asset oracle and summary SDK surfaces present")
 
 
-async def run_rest_checks(client: ReyaTradingClient, max_age_ms: int) -> tuple[list[CheckResult], str]:
+async def run_rest_checks(client: ReyaTradingClient, max_age_ms: int) -> tuple[list[CheckResult], str, str]:
     perp_definitions = await client.reference.get_perp_market_definitions()
     spot_definitions = await client.reference.get_spot_market_definitions()
     _assert(bool(perp_definitions), "perp market definitions response was empty")
@@ -200,6 +222,7 @@ async def run_rest_checks(client: ReyaTradingClient, max_age_ms: int) -> tuple[l
     perp_symbol = (
         "ETHRUSDPERP" if any(m.symbol == "ETHRUSDPERP" for m in perp_definitions) else perp_definitions[0].symbol
     )
+    spot_symbol = "WETHRUSD" if any(m.symbol == "WETHRUSD" for m in spot_definitions) else spot_definitions[0].symbol
     results = [
         _ok(
             "rest.referenceDefinitions",
@@ -217,24 +240,17 @@ async def run_rest_checks(client: ReyaTradingClient, max_age_ms: int) -> tuple[l
         _assert_positive_decimal(summary.mark_price, f"{perp_symbol}.markPrice")
     results.append(_ok("rest.perpMarketsSummary", _describe_perp_summaries(summaries, perp_symbol, max_age_ms)))
 
-    with warnings.catch_warnings(record=True) as captured:
-        warnings.simplefilter("always", DeprecationWarning)
-        legacy_prices = await client.markets.get_prices()
-        legacy_price = await client.markets.get_price(perp_symbol)
-    _assert(bool(legacy_prices), "deprecated /prices response was empty")
-    _assert(legacy_price.symbol == perp_symbol, f"deprecated /prices/{{symbol}} returned {legacy_price.symbol}")
-    deprecation_messages = [str(warning.message) for warning in captured if warning.category is DeprecationWarning]
+    spot_summaries = await client.markets.get_spot_markets_summary()
+    spot_summary = await client.markets.get_spot_market_summary(spot_symbol)
     _assert(
-        any("/prices" in message for message in deprecation_messages), "missing SDK deprecation warning for /prices"
+        spot_summary.symbol == spot_symbol,
+        f"single spot summary returned {spot_summary.symbol}, expected {spot_symbol}",
     )
-    results.append(
-        _ok(
-            "rest.deprecatedPrices",
-            f"{len(legacy_prices)} legacy price row(s); {perp_symbol} single-price still callable with warning",
-        )
-    )
+    if spot_summary.oracle_price is not None:
+        _assert_positive_decimal(spot_summary.oracle_price, f"{spot_symbol}.oraclePrice")
+    results.append(_ok("rest.spotMarketsSummary", _describe_spot_summaries(spot_summaries, spot_symbol, max_age_ms)))
 
-    return results, perp_symbol
+    return results, perp_symbol, spot_symbol
 
 
 def _extract_contents_data(contents: dict[str, Any] | None) -> Any:
@@ -283,28 +299,45 @@ def _validate_ws_data(channel: str, data: Any, max_age_ms: int) -> str:
             _assert_positive_decimal(market_payload.data.mark_price, f"{market_payload.data.symbol}.markPrice")
         return f"{market_payload.data.symbol} summary parsed"
 
-    if channel == "/v2/prices":
+    if channel == "/v2/spotMarkets/summary":
         if isinstance(data, list) and data and isinstance(data[0], dict):
-            prices_payload = PricesUpdatePayload.model_validate(
+            spot_markets_payload = SpotMarketsSummaryUpdatePayload.model_validate(
                 {"type": "channel_data", "timestamp": time.time() * 1000, "channel": channel, "data": data}
             )
-        elif isinstance(data, PricesUpdatePayload):
-            prices_payload = data
+        elif isinstance(data, SpotMarketsSummaryUpdatePayload):
+            spot_markets_payload = data
         else:
-            raise AssertionError(f"unexpected legacy prices WS payload shape: {type(data).__name__}")
-        _assert(bool(prices_payload.data), "legacy prices WS data was empty")
-        return f"{len(prices_payload.data)} legacy price row(s)"
+            raise AssertionError(f"unexpected spot markets summary WS payload shape: {type(data).__name__}")
+        symbol = spot_markets_payload.data[0].symbol
+        return _describe_spot_summaries(spot_markets_payload.data, symbol, max_age_ms=max_age_ms)
+
+    if channel.startswith("/v2/spotMarket/") and channel.endswith("/summary"):
+        if isinstance(data, dict):
+            spot_market_payload = SpotMarketSummaryUpdatePayload.model_validate(
+                {"type": "channel_data", "timestamp": time.time() * 1000, "channel": channel, "data": data}
+            )
+        elif isinstance(data, SpotMarketSummaryUpdatePayload):
+            spot_market_payload = data
+        else:
+            raise AssertionError(f"unexpected spot market summary WS payload shape: {type(data).__name__}")
+        _assert(spot_market_payload.data.symbol in channel, f"{channel} returned {spot_market_payload.data.symbol}")
+        if spot_market_payload.data.oracle_price is not None:
+            _assert_positive_decimal(
+                spot_market_payload.data.oracle_price, f"{spot_market_payload.data.symbol}.oraclePrice"
+            )
+        return f"{spot_market_payload.data.symbol} spot summary parsed"
 
     raise AssertionError(f"no validator for channel {channel}")
 
 
-def run_websocket_checks(symbol: str, timeout_s: float, max_age_ms: int) -> list[CheckResult]:
+def run_websocket_checks(perp_symbol: str, spot_symbol: str, timeout_s: float, max_age_ms: int) -> list[CheckResult]:
     ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
     expected_channels = {
         "/v2/assetOraclePrices": "ws.assetOraclePrices",
         "/v2/perpMarkets/summary": "ws.perpMarketsSummary",
-        f"/v2/perpMarket/{symbol}/summary": "ws.perpMarketsSummary",
-        "/v2/prices": "ws.deprecatedPrices",
+        f"/v2/perpMarket/{perp_symbol}/summary": "ws.perpMarketsSummary",
+        "/v2/spotMarkets/summary": "ws.spotMarketsSummary",
+        f"/v2/spotMarket/{spot_symbol}/summary": "ws.spotMarketsSummary",
     }
     details_by_check: dict[str, list[str]] = {check_id: [] for check_id in expected_channels.values()}
     seen_channels: set[str] = set()
@@ -314,8 +347,9 @@ def run_websocket_checks(symbol: str, timeout_s: float, max_age_ms: int) -> list
     def on_open(ws: ReyaSocket) -> None:
         ws.prices.asset_oracle_prices.subscribe()
         ws.market.all_markets_summary.subscribe()
-        ws.market.summary(symbol).subscribe()
-        ws.prices.all_prices.subscribe()
+        ws.market.summary(perp_symbol).subscribe()
+        ws.market.all_spot_markets_summary.subscribe()
+        ws.market.spot_summary(spot_symbol).subscribe()
 
     def on_error(_ws: ReyaSocket, error: Exception) -> None:
         errors.put(str(error))
@@ -376,7 +410,7 @@ def run_websocket_checks(symbol: str, timeout_s: float, max_age_ms: int) -> list
     return [
         _ok("ws.assetOraclePrices", "; ".join(details_by_check["ws.assetOraclePrices"])),
         _ok("ws.perpMarketsSummary", "; ".join(details_by_check["ws.perpMarketsSummary"])),
-        _ok("ws.deprecatedPrices", "; ".join(details_by_check["ws.deprecatedPrices"])),
+        _ok("ws.spotMarketsSummary", "; ".join(details_by_check["ws.spotMarketsSummary"])),
     ]
 
 
@@ -384,9 +418,13 @@ async def run_smoke(timeout_s: float, max_age_ms: int) -> list[CheckResult]:
     load_dotenv()
     results = [run_static_sdk_checks()]
     async with ReyaTradingClient() as client:
-        rest_results, symbol = await run_rest_checks(client, max_age_ms=max_age_ms)
+        rest_results, perp_symbol, spot_symbol = await run_rest_checks(client, max_age_ms=max_age_ms)
         results.extend(rest_results)
-    results.extend(run_websocket_checks(symbol=symbol, timeout_s=timeout_s, max_age_ms=max_age_ms))
+    results.extend(
+        run_websocket_checks(
+            perp_symbol=perp_symbol, spot_symbol=spot_symbol, timeout_s=timeout_s, max_age_ms=max_age_ms
+        )
+    )
     return results
 
 

--- a/scripts/probe_perp_gate.py
+++ b/scripts/probe_perp_gate.py
@@ -29,15 +29,14 @@ async def main() -> None:
 
         for d in perp_defs:
             symbol = d.symbol
-            # Get oracle price; place far-below sell so it can't match.
+            # Get mark price; place far-above sell so it can't match.
             try:
-                price_resp = await client.markets.get_price(symbol)
-                oracle = float(price_resp.oracle_price)
+                mark_price = float(await client.get_market_mark_price(symbol))
             except ApiException as e:
-                print(f"  {symbol}: NO ORACLE PRICE ({e.body if hasattr(e, 'body') else e})")
+                print(f"  {symbol}: NO MARK PRICE ({e.body if hasattr(e, 'body') else e})")
                 continue
 
-            far_sell_px = str(round(oracle * 2.0, 2))
+            far_sell_px = str(round(mark_price * 2.0, 2))
             params = LimitOrderParameters(
                 symbol=symbol,
                 is_buy=False,

--- a/scripts/probe_perp_gate.py
+++ b/scripts/probe_perp_gate.py
@@ -32,8 +32,9 @@ async def main() -> None:
             # Get mark price; place far-above sell so it can't match.
             try:
                 mark_price = float(await client.get_market_mark_price(symbol))
-            except ApiException as e:
-                print(f"  {symbol}: NO MARK PRICE ({e.body if hasattr(e, 'body') else e})")
+            except (ApiException, RuntimeError) as e:
+                detail = e.body if isinstance(e, ApiException) and hasattr(e, "body") else e
+                print(f"  {symbol}: NO MARK PRICE ({detail})")
                 continue
 
             far_sell_px = str(round(mark_price * 2.0, 2))

--- a/sdk/reya_rest_api/client.py
+++ b/sdk/reya_rest_api/client.py
@@ -22,6 +22,7 @@ from sdk.open_api.api_client import ApiClient
 from sdk.open_api.configuration import Configuration
 from sdk.open_api.models.account import Account
 from sdk.open_api.models.account_balance import AccountBalance
+from sdk.open_api.models.asset_oracle_price import AssetOraclePrice
 from sdk.open_api.models.cancel_all_after_request import CancelAllAfterRequest
 from sdk.open_api.models.cancel_all_after_response import CancelAllAfterResponse
 from sdk.open_api.models.cancel_order_request import CancelOrderRequest
@@ -249,6 +250,31 @@ class ReyaTradingClient:
         or one with delegated trading permission.
         """
         return self._config.owner_wallet_address
+
+    async def get_asset_oracle_price(self, asset: str) -> AssetOraclePrice:
+        """Fetch a single asset Stork oracle price from /assetOraclePrices."""
+        target = asset.upper()
+        prices = await self.markets.get_asset_oracle_prices()
+        for price in prices:
+            if price.asset.upper() == target:
+                return price
+
+        available_assets = ", ".join(sorted(price.asset for price in prices))
+        raise RuntimeError(f"Asset oracle price not found for {asset}. Available assets: {available_assets}")
+
+    async def get_market_mark_price(self, symbol: str) -> str:
+        """Fetch a perp market's mark price from /perpMarket/{symbol}/summary."""
+        summary = await self.markets.get_perp_market_summary(symbol)
+        if summary.mark_price is None:
+            raise RuntimeError(f"Market summary for {symbol} did not include markPrice")
+        return summary.mark_price
+
+    async def get_market_mid_price(self, symbol: str) -> str:
+        """Fetch a perp market's throttled mid price from /perpMarket/{symbol}/summary."""
+        summary = await self.markets.get_perp_market_summary(symbol)
+        if summary.throttled_mid_price is None:
+            raise RuntimeError(f"Market summary for {symbol} did not include throttledMidPrice")
+        return summary.throttled_mid_price
 
     def build_create_limit_order_payload(self, params: LimitOrderParameters) -> tuple[dict, int]:
         """Build the camelCase wire payload for a createOrder LIMIT request and

--- a/sdk/reya_websocket/resources/market.py
+++ b/sdk/reya_websocket/resources/market.py
@@ -20,6 +20,8 @@ class MarketResource:
         self.socket = socket
         self._all_markets_summary = AllMarketsSummaryResource(socket)
         self._market_summary = MarketSummaryResource(socket)
+        self._all_spot_markets_summary = AllSpotMarketsSummaryResource(socket)
+        self._spot_market_summary = SpotMarketSummaryResource(socket)
         self._market_perp_executions = MarketPerpExecutionsResource(socket)
         self._market_spot_executions = MarketSpotExecutionsResource(socket)
         self._market_execution_busts = MarketExecutionBustsResource(socket)
@@ -30,16 +32,32 @@ class MarketResource:
         """Access the all markets summary resource."""
         return self._all_markets_summary
 
+    @property
+    def all_spot_markets_summary(self) -> "AllSpotMarketsSummaryResource":
+        """Access the all spot markets summary resource."""
+        return self._all_spot_markets_summary
+
     def summary(self, symbol: str) -> "MarketSummarySubscription":
         """Get market summary for a specific symbol.
 
         Args:
-            symbol: The trading symbol (e.g., "BTCRUSDPERP", "ETHRUSD").
+            symbol: The perp trading symbol (e.g., "BTCRUSDPERP").
 
         Returns:
             A subscription object for the specified market summary.
         """
         return self._market_summary.for_symbol(symbol)
+
+    def spot_summary(self, symbol: str) -> "SpotMarketSummarySubscription":
+        """Get spot market summary for a specific symbol.
+
+        Args:
+            symbol: The spot trading symbol (e.g., "WETHRUSD").
+
+        Returns:
+            A subscription object for the specified spot market summary.
+        """
+        return self._spot_market_summary.for_symbol(symbol)
 
     def perp_executions(self, symbol: str) -> "MarketPerpExecutionsSubscription":
         """Get perpetual executions for a specific symbol.
@@ -120,7 +138,7 @@ class AllMarketsSummaryResource(SubscribableResource):
 
 
 class MarketSummaryResource(SubscribableParameterizedResource):
-    """Resource for accessing market summary data."""
+    """Resource for accessing perp market summary data."""
 
     def __init__(self, socket: "ReyaSocket"):
         """Initialize the market summary resource.
@@ -140,6 +158,59 @@ class MarketSummaryResource(SubscribableParameterizedResource):
             A subscription object for the specified market summary.
         """
         return MarketSummarySubscription(self.socket, symbol)
+
+
+class AllSpotMarketsSummaryResource(SubscribableResource):
+    """Resource for accessing all spot markets summary data."""
+
+    def __init__(self, socket: "ReyaSocket"):
+        """Initialize the all spot markets summary resource.
+
+        Args:
+            socket: The WebSocket connection to use for this resource.
+        """
+        super().__init__(socket)
+        self.path = "/v2/spotMarkets/summary"
+
+    def subscribe(self, batched: bool = False, **kwargs) -> None:
+        """Subscribe to all spot markets summary data.
+
+        Args:
+            batched: Whether to receive updates in batches.
+            **kwargs: Additional keyword arguments (unused).
+        """
+        self.socket.send_subscribe(channel=self.path, batched=batched)
+
+    def unsubscribe(self, **kwargs) -> None:
+        """Unsubscribe from all spot markets summary data.
+
+        Args:
+            **kwargs: Additional keyword arguments (unused).
+        """
+        self.socket.send_unsubscribe(channel=self.path)
+
+
+class SpotMarketSummaryResource(SubscribableParameterizedResource):
+    """Resource for accessing spot market summary data."""
+
+    def __init__(self, socket: "ReyaSocket"):
+        """Initialize the spot market summary resource.
+
+        Args:
+            socket: The WebSocket connection to use for this resource.
+        """
+        super().__init__(socket, "/v2/spotMarket/{symbol}/summary")
+
+    def for_symbol(self, symbol: str) -> "SpotMarketSummarySubscription":
+        """Create a subscription for a specific spot market's summary.
+
+        Args:
+            symbol: The spot trading symbol (e.g., "WETHRUSD").
+
+        Returns:
+            A subscription object for the specified spot market summary.
+        """
+        return SpotMarketSummarySubscription(self.socket, symbol)
 
 
 class MarketPerpExecutionsResource(SubscribableParameterizedResource):
@@ -166,14 +237,14 @@ class MarketPerpExecutionsResource(SubscribableParameterizedResource):
 
 
 class MarketSummarySubscription:
-    """Manages a subscription to market summary for a specific symbol."""
+    """Manages a subscription to perp market summary for a specific symbol."""
 
     def __init__(self, socket: "ReyaSocket", symbol: str):
         """Initialize a market summary subscription.
 
         Args:
             socket: The WebSocket connection to use for this subscription.
-            symbol: The trading symbol (e.g., "BTCRUSDPERP", "ETHRUSD").
+            symbol: The perp trading symbol (e.g., "BTCRUSDPERP").
         """
         self.socket = socket
         self.symbol = symbol
@@ -189,6 +260,33 @@ class MarketSummarySubscription:
 
     def unsubscribe(self) -> None:
         """Unsubscribe from market summary."""
+        self.socket.send_unsubscribe(channel=self.path)
+
+
+class SpotMarketSummarySubscription:
+    """Manages a subscription to spot market summary for a specific symbol."""
+
+    def __init__(self, socket: "ReyaSocket", symbol: str):
+        """Initialize a spot market summary subscription.
+
+        Args:
+            socket: The WebSocket connection to use for this subscription.
+            symbol: The spot trading symbol (e.g., "WETHRUSD").
+        """
+        self.socket = socket
+        self.symbol = symbol
+        self.path = f"/v2/spotMarket/{symbol}/summary"
+
+    def subscribe(self, batched: bool = False) -> None:
+        """Subscribe to spot market summary.
+
+        Args:
+            batched: Whether to receive updates in batches.
+        """
+        self.socket.send_subscribe(channel=self.path, batched=batched)
+
+    def unsubscribe(self) -> None:
+        """Unsubscribe from spot market summary."""
         self.socket.send_unsubscribe(channel=self.path)
 
 

--- a/sdk/reya_websocket/resources/market.py
+++ b/sdk/reya_websocket/resources/market.py
@@ -1,6 +1,6 @@
 """Market-related WebSocket resources for v2 API."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from sdk.reya_websocket.resources.common import SubscribableParameterizedResource, SubscribableResource
 
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 class MarketResource:
     """Container for all market-related WebSocket resources for v2 API."""
 
-    def __init__(self, socket: "ReyaSocket"):
+    def __init__(self, socket: "ReyaSocket") -> None:
         """Initialize the market resource container.
 
         Args:
@@ -110,7 +110,7 @@ class MarketResource:
 class AllMarketsSummaryResource(SubscribableResource):
     """Resource for accessing all markets summary data."""
 
-    def __init__(self, socket: "ReyaSocket"):
+    def __init__(self, socket: "ReyaSocket") -> None:
         """Initialize the all markets summary resource.
 
         Args:
@@ -119,7 +119,7 @@ class AllMarketsSummaryResource(SubscribableResource):
         super().__init__(socket)
         self.path = "/v2/perpMarkets/summary"
 
-    def subscribe(self, batched: bool = False, **kwargs) -> None:
+    def subscribe(self, batched: bool = False, **kwargs: Any) -> None:
         """Subscribe to all markets summary data.
 
         Args:
@@ -128,7 +128,7 @@ class AllMarketsSummaryResource(SubscribableResource):
         """
         self.socket.send_subscribe(channel=self.path, batched=batched)
 
-    def unsubscribe(self, **kwargs) -> None:
+    def unsubscribe(self, **kwargs: Any) -> None:
         """Unsubscribe from all markets summary data.
 
         Args:
@@ -140,7 +140,7 @@ class AllMarketsSummaryResource(SubscribableResource):
 class MarketSummaryResource(SubscribableParameterizedResource):
     """Resource for accessing perp market summary data."""
 
-    def __init__(self, socket: "ReyaSocket"):
+    def __init__(self, socket: "ReyaSocket") -> None:
         """Initialize the market summary resource.
 
         Args:
@@ -163,7 +163,7 @@ class MarketSummaryResource(SubscribableParameterizedResource):
 class AllSpotMarketsSummaryResource(SubscribableResource):
     """Resource for accessing all spot markets summary data."""
 
-    def __init__(self, socket: "ReyaSocket"):
+    def __init__(self, socket: "ReyaSocket") -> None:
         """Initialize the all spot markets summary resource.
 
         Args:
@@ -172,7 +172,7 @@ class AllSpotMarketsSummaryResource(SubscribableResource):
         super().__init__(socket)
         self.path = "/v2/spotMarkets/summary"
 
-    def subscribe(self, batched: bool = False, **kwargs) -> None:
+    def subscribe(self, batched: bool = False, **kwargs: Any) -> None:
         """Subscribe to all spot markets summary data.
 
         Args:
@@ -181,7 +181,7 @@ class AllSpotMarketsSummaryResource(SubscribableResource):
         """
         self.socket.send_subscribe(channel=self.path, batched=batched)
 
-    def unsubscribe(self, **kwargs) -> None:
+    def unsubscribe(self, **kwargs: Any) -> None:
         """Unsubscribe from all spot markets summary data.
 
         Args:
@@ -193,7 +193,7 @@ class AllSpotMarketsSummaryResource(SubscribableResource):
 class SpotMarketSummaryResource(SubscribableParameterizedResource):
     """Resource for accessing spot market summary data."""
 
-    def __init__(self, socket: "ReyaSocket"):
+    def __init__(self, socket: "ReyaSocket") -> None:
         """Initialize the spot market summary resource.
 
         Args:
@@ -239,7 +239,7 @@ class MarketPerpExecutionsResource(SubscribableParameterizedResource):
 class MarketSummarySubscription:
     """Manages a subscription to perp market summary for a specific symbol."""
 
-    def __init__(self, socket: "ReyaSocket", symbol: str):
+    def __init__(self, socket: "ReyaSocket", symbol: str) -> None:
         """Initialize a market summary subscription.
 
         Args:
@@ -266,7 +266,7 @@ class MarketSummarySubscription:
 class SpotMarketSummarySubscription:
     """Manages a subscription to spot market summary for a specific symbol."""
 
-    def __init__(self, socket: "ReyaSocket", symbol: str):
+    def __init__(self, socket: "ReyaSocket", symbol: str) -> None:
         """Initialize a spot market summary subscription.
 
         Args:

--- a/sdk/reya_websocket/resources/market.py
+++ b/sdk/reya_websocket/resources/market.py
@@ -1,6 +1,6 @@
 """Market-related WebSocket resources for v2 API."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from sdk.reya_websocket.resources.common import SubscribableParameterizedResource, SubscribableResource
 
@@ -107,20 +107,21 @@ class MarketResource:
         return self._market_depth.for_symbol(symbol)
 
 
-class AllMarketsSummaryResource(SubscribableResource):
-    """Resource for accessing all markets summary data."""
+class _AllMarketSummaryResource(SubscribableResource):
+    """Shared implementation for all-market summary subscriptions."""
 
-    def __init__(self, socket: "ReyaSocket") -> None:
-        """Initialize the all markets summary resource.
+    def __init__(self, socket: "ReyaSocket", path: str) -> None:
+        """Initialize the all-market summary resource.
 
         Args:
             socket: The WebSocket connection to use for this resource.
+            path: The channel path to subscribe to.
         """
         super().__init__(socket)
-        self.path = "/v2/perpMarkets/summary"
+        self.path = path
 
     def subscribe(self, batched: bool = False, **kwargs: Any) -> None:
-        """Subscribe to all markets summary data.
+        """Subscribe to all-market summary data.
 
         Args:
             batched: Whether to receive updates in batches.
@@ -129,7 +130,7 @@ class AllMarketsSummaryResource(SubscribableResource):
         self.socket.send_subscribe(channel=self.path, batched=batched)
 
     def unsubscribe(self, **kwargs: Any) -> None:
-        """Unsubscribe from all markets summary data.
+        """Unsubscribe from all-market summary data.
 
         Args:
             **kwargs: Additional keyword arguments (unused).
@@ -137,7 +138,104 @@ class AllMarketsSummaryResource(SubscribableResource):
         self.socket.send_unsubscribe(channel=self.path)
 
 
-class MarketSummaryResource(SubscribableParameterizedResource):
+class _MarketSummarySubscriptionBase:
+    """Shared implementation for a symbol-specific market summary subscription."""
+
+    def __init__(self, socket: "ReyaSocket", symbol: str, path_template: str) -> None:
+        """Initialize a market summary subscription.
+
+        Args:
+            socket: The WebSocket connection to use for this subscription.
+            symbol: The trading symbol.
+            path_template: The channel path template for this market type.
+        """
+        self.socket = socket
+        self.symbol = symbol
+        self.path = path_template.format(symbol=symbol)
+
+    def subscribe(self, batched: bool = False) -> None:
+        """Subscribe to market summary.
+
+        Args:
+            batched: Whether to receive updates in batches.
+        """
+        self.socket.send_subscribe(channel=self.path, batched=batched)
+
+    def unsubscribe(self) -> None:
+        """Unsubscribe from market summary."""
+        self.socket.send_unsubscribe(channel=self.path)
+
+
+class MarketSummarySubscription(_MarketSummarySubscriptionBase):
+    """Manages a subscription to perp market summary for a specific symbol."""
+
+    def __init__(self, socket: "ReyaSocket", symbol: str) -> None:
+        """Initialize a market summary subscription.
+
+        Args:
+            socket: The WebSocket connection to use for this subscription.
+            symbol: The perp trading symbol (e.g., "BTCRUSDPERP").
+        """
+        super().__init__(socket, symbol, "/v2/perpMarket/{symbol}/summary")
+
+
+class SpotMarketSummarySubscription(_MarketSummarySubscriptionBase):
+    """Manages a subscription to spot market summary for a specific symbol."""
+
+    def __init__(self, socket: "ReyaSocket", symbol: str) -> None:
+        """Initialize a spot market summary subscription.
+
+        Args:
+            socket: The WebSocket connection to use for this subscription.
+            symbol: The spot trading symbol (e.g., "WETHRUSD").
+        """
+        super().__init__(socket, symbol, "/v2/spotMarket/{symbol}/summary")
+
+
+class _MarketSummaryResourceBase(SubscribableParameterizedResource):
+    """Shared implementation for symbol-specific market summary resources."""
+
+    def __init__(
+        self,
+        socket: "ReyaSocket",
+        path_template: str,
+        subscription_factory: Callable[..., _MarketSummarySubscriptionBase],
+    ) -> None:
+        """Initialize the market summary resource.
+
+        Args:
+            socket: The WebSocket connection to use for this resource.
+            path_template: A template string for the channel path.
+            subscription_factory: Constructor for a symbol-specific subscription.
+        """
+        super().__init__(socket, path_template)
+        self._subscription_factory = subscription_factory
+
+    def for_symbol(self, symbol: str) -> _MarketSummarySubscriptionBase:
+        """Create a subscription for a specific market's summary.
+
+        Args:
+            symbol: The trading symbol.
+
+        Returns:
+            A subscription object for the specified market summary.
+        """
+        return self._subscription_factory(self.socket, symbol)
+
+
+class AllMarketsSummaryResource(_AllMarketSummaryResource):
+    """Resource for accessing all markets summary data."""
+
+    def __init__(self, socket: "ReyaSocket") -> None:
+        """Initialize the all markets summary resource.
+
+        Args:
+            socket: The WebSocket connection to use for this resource.
+        """
+        super().__init__(socket, "/v2/perpMarkets/summary")
+
+
+class MarketSummaryResource(_MarketSummaryResourceBase):
     """Resource for accessing perp market summary data."""
 
     def __init__(self, socket: "ReyaSocket") -> None:
@@ -146,7 +244,7 @@ class MarketSummaryResource(SubscribableParameterizedResource):
         Args:
             socket: The WebSocket connection to use for this resource.
         """
-        super().__init__(socket, "/v2/perpMarket/{symbol}/summary")
+        super().__init__(socket, "/v2/perpMarket/{symbol}/summary", MarketSummarySubscription)
 
     def for_symbol(self, symbol: str) -> "MarketSummarySubscription":
         """Create a subscription for a specific market's summary.
@@ -157,10 +255,10 @@ class MarketSummaryResource(SubscribableParameterizedResource):
         Returns:
             A subscription object for the specified market summary.
         """
-        return MarketSummarySubscription(self.socket, symbol)
+        return cast("MarketSummarySubscription", super().for_symbol(symbol))
 
 
-class AllSpotMarketsSummaryResource(SubscribableResource):
+class AllSpotMarketsSummaryResource(_AllMarketSummaryResource):
     """Resource for accessing all spot markets summary data."""
 
     def __init__(self, socket: "ReyaSocket") -> None:
@@ -169,28 +267,10 @@ class AllSpotMarketsSummaryResource(SubscribableResource):
         Args:
             socket: The WebSocket connection to use for this resource.
         """
-        super().__init__(socket)
-        self.path = "/v2/spotMarkets/summary"
-
-    def subscribe(self, batched: bool = False, **kwargs: Any) -> None:
-        """Subscribe to all spot markets summary data.
-
-        Args:
-            batched: Whether to receive updates in batches.
-            **kwargs: Additional keyword arguments (unused).
-        """
-        self.socket.send_subscribe(channel=self.path, batched=batched)
-
-    def unsubscribe(self, **kwargs: Any) -> None:
-        """Unsubscribe from all spot markets summary data.
-
-        Args:
-            **kwargs: Additional keyword arguments (unused).
-        """
-        self.socket.send_unsubscribe(channel=self.path)
+        super().__init__(socket, "/v2/spotMarkets/summary")
 
 
-class SpotMarketSummaryResource(SubscribableParameterizedResource):
+class SpotMarketSummaryResource(_MarketSummaryResourceBase):
     """Resource for accessing spot market summary data."""
 
     def __init__(self, socket: "ReyaSocket") -> None:
@@ -199,7 +279,7 @@ class SpotMarketSummaryResource(SubscribableParameterizedResource):
         Args:
             socket: The WebSocket connection to use for this resource.
         """
-        super().__init__(socket, "/v2/spotMarket/{symbol}/summary")
+        super().__init__(socket, "/v2/spotMarket/{symbol}/summary", SpotMarketSummarySubscription)
 
     def for_symbol(self, symbol: str) -> "SpotMarketSummarySubscription":
         """Create a subscription for a specific spot market's summary.
@@ -210,7 +290,7 @@ class SpotMarketSummaryResource(SubscribableParameterizedResource):
         Returns:
             A subscription object for the specified spot market summary.
         """
-        return SpotMarketSummarySubscription(self.socket, symbol)
+        return cast("SpotMarketSummarySubscription", super().for_symbol(symbol))
 
 
 class MarketPerpExecutionsResource(SubscribableParameterizedResource):
@@ -234,60 +314,6 @@ class MarketPerpExecutionsResource(SubscribableParameterizedResource):
             A subscription object for the specified market perpetual executions.
         """
         return MarketPerpExecutionsSubscription(self.socket, symbol)
-
-
-class MarketSummarySubscription:
-    """Manages a subscription to perp market summary for a specific symbol."""
-
-    def __init__(self, socket: "ReyaSocket", symbol: str) -> None:
-        """Initialize a market summary subscription.
-
-        Args:
-            socket: The WebSocket connection to use for this subscription.
-            symbol: The perp trading symbol (e.g., "BTCRUSDPERP").
-        """
-        self.socket = socket
-        self.symbol = symbol
-        self.path = f"/v2/perpMarket/{symbol}/summary"
-
-    def subscribe(self, batched: bool = False) -> None:
-        """Subscribe to market summary.
-
-        Args:
-            batched: Whether to receive updates in batches.
-        """
-        self.socket.send_subscribe(channel=self.path, batched=batched)
-
-    def unsubscribe(self) -> None:
-        """Unsubscribe from market summary."""
-        self.socket.send_unsubscribe(channel=self.path)
-
-
-class SpotMarketSummarySubscription:
-    """Manages a subscription to spot market summary for a specific symbol."""
-
-    def __init__(self, socket: "ReyaSocket", symbol: str) -> None:
-        """Initialize a spot market summary subscription.
-
-        Args:
-            socket: The WebSocket connection to use for this subscription.
-            symbol: The spot trading symbol (e.g., "WETHRUSD").
-        """
-        self.socket = socket
-        self.symbol = symbol
-        self.path = f"/v2/spotMarket/{symbol}/summary"
-
-    def subscribe(self, batched: bool = False) -> None:
-        """Subscribe to spot market summary.
-
-        Args:
-            batched: Whether to receive updates in batches.
-        """
-        self.socket.send_subscribe(channel=self.path, batched=batched)
-
-    def unsubscribe(self) -> None:
-        """Unsubscribe from spot market summary."""
-        self.socket.send_unsubscribe(channel=self.path)
 
 
 class MarketPerpExecutionsSubscription:

--- a/sdk/reya_websocket/resources/prices.py
+++ b/sdk/reya_websocket/resources/prices.py
@@ -2,7 +2,7 @@
 
 from typing import TYPE_CHECKING
 
-from sdk.reya_websocket.resources.common import SubscribableParameterizedResource, SubscribableResource
+from sdk.reya_websocket.resources.common import SubscribableResource
 
 if TYPE_CHECKING:
     from sdk.reya_websocket.socket import ReyaSocket
@@ -18,60 +18,12 @@ class PricesResource:
             socket: The WebSocket connection to use for this resource.
         """
         self.socket = socket
-        self._all_prices = AllPricesResource(socket)
         self._asset_oracle_prices = AssetOraclePricesResource(socket)
-        self._price = PriceResource(socket)
-
-    @property
-    def all_prices(self) -> "AllPricesResource":
-        """Access the all prices resource."""
-        return self._all_prices
 
     @property
     def asset_oracle_prices(self) -> "AssetOraclePricesResource":
         """Access asset oracle prices."""
         return self._asset_oracle_prices
-
-    def price(self, symbol: str) -> "PriceSubscription":
-        """Get price data for a specific symbol.
-
-        Args:
-            symbol: The trading symbol (e.g., "BTCRUSDPERP", "ETHRUSD").
-
-        Returns:
-            A subscription object for the specified symbol's price data.
-        """
-        return self._price.for_symbol(symbol)
-
-
-class AllPricesResource(SubscribableResource):
-    """Resource for accessing all prices data."""
-
-    def __init__(self, socket: "ReyaSocket"):
-        """Initialize the all prices resource.
-
-        Args:
-            socket: The WebSocket connection to use for this resource.
-        """
-        super().__init__(socket)
-        self.path = "/v2/prices"
-
-    def subscribe(self, batched: bool = False, **kwargs) -> None:
-        """Subscribe to all prices data.
-
-        Args:
-            batched: Whether to receive updates in batches.
-            **kwargs: Additional keyword arguments (unused).
-        """
-        self.socket.send_subscribe(channel=self.path, batched=batched)
-
-    def unsubscribe(self, **kwargs) -> None:
-        """Unsubscribe from all prices data.
-
-        Args:
-            **kwargs: Additional keyword arguments (unused).
-        """
-        self.socket.send_unsubscribe(channel=self.path)
 
 
 class AssetOraclePricesResource(SubscribableResource):
@@ -101,54 +53,4 @@ class AssetOraclePricesResource(SubscribableResource):
         Args:
             **kwargs: Additional keyword arguments (unused).
         """
-        self.socket.send_unsubscribe(channel=self.path)
-
-
-class PriceResource(SubscribableParameterizedResource):
-    """Resource for accessing price data for specific symbols."""
-
-    def __init__(self, socket: "ReyaSocket"):
-        """Initialize the price resource.
-
-        Args:
-            socket: The WebSocket connection to use for this resource.
-        """
-        super().__init__(socket, "/v2/prices/{symbol}")
-
-    def for_symbol(self, symbol: str) -> "PriceSubscription":
-        """Create a subscription for a specific symbol's price data.
-
-        Args:
-            symbol: The trading symbol (e.g., "BTCRUSDPERP", "ETHRUSD").
-
-        Returns:
-            A subscription object for the specified symbol's price data.
-        """
-        return PriceSubscription(self.socket, symbol)
-
-
-class PriceSubscription:
-    """Manages a subscription to price data for a specific symbol."""
-
-    def __init__(self, socket: "ReyaSocket", symbol: str):
-        """Initialize a price subscription.
-
-        Args:
-            socket: The WebSocket connection to use for this subscription.
-            symbol: The trading symbol (e.g., "BTCRUSDPERP", "ETHRUSD").
-        """
-        self.socket = socket
-        self.symbol = symbol
-        self.path = f"/v2/prices/{symbol}"
-
-    def subscribe(self, batched: bool = False) -> None:
-        """Subscribe to price data.
-
-        Args:
-            batched: Whether to receive updates in batches.
-        """
-        self.socket.send_subscribe(channel=self.path, batched=batched)
-
-    def unsubscribe(self) -> None:
-        """Unsubscribe from price data."""
         self.socket.send_unsubscribe(channel=self.path)

--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -30,8 +30,6 @@ from sdk.async_api.order_changes_subscribed_payload import OrderChangesSubscribe
 from sdk.async_api.ping_message_payload import PingMessagePayload
 from sdk.async_api.pong_message_payload import PongMessagePayload
 from sdk.async_api.position_update_payload import PositionUpdatePayload
-from sdk.async_api.price_update_payload import PriceUpdatePayload
-from sdk.async_api.prices_update_payload import PricesUpdatePayload
 from sdk.async_api.spot_market_summary_update_payload import SpotMarketSummaryUpdatePayload
 from sdk.async_api.spot_markets_summary_update_payload import SpotMarketsSummaryUpdatePayload
 from sdk.async_api.subscribed_message_payload import SubscribedMessagePayload
@@ -76,8 +74,6 @@ WebSocketMessage = Union[
     AccountBalanceUpdatePayload,  # /v2/wallet/{address}/accountBalances
     # Price channels
     AssetOraclePricesUpdatePayload,  # /v2/assetOraclePrices
-    PricesUpdatePayload,  # /v2/prices
-    PriceUpdatePayload,  # /v2/prices/{symbol}
 ]
 
 
@@ -98,9 +94,8 @@ class ReyaSocket(WebSocketApp):
         # All markets summary (exact match)
         "/v2/perpMarkets/summary": MarketsSummaryUpdatePayload,
         "/v2/spotMarkets/summary": SpotMarketsSummaryUpdatePayload,
-        # All prices (exact match)
+        # Asset oracle prices (exact match)
         "/v2/assetOraclePrices": AssetOraclePricesUpdatePayload,
-        "/v2/prices": PricesUpdatePayload,
     }
 
     def __init__(
@@ -224,8 +219,6 @@ class ReyaSocket(WebSocketApp):
                 return WalletExecutionBustUpdatePayload
             elif channel.endswith("/accountBalances"):
                 return AccountBalanceUpdatePayload
-        elif "/v2/prices/" in channel and channel != "/v2/prices":
-            return PriceUpdatePayload
 
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1244,7 +1244,7 @@ async def spot_config(maker_tester_session, spot_market_configs, spot_asset):  #
         price_str = await maker_tester_session.data.asset_oracle_price(oracle_asset)
         oracle_price = float(price_str)
         logger.info(f"📊 Fetched {spot_asset} oracle price: ${oracle_price:.2f}")
-    except (OSError, RuntimeError, ValueError) as e:
+    except (ApiException, OSError, RuntimeError, ValueError) as e:
         logger.warning(f"Failed to fetch oracle price for {oracle_asset}: {e}")
         # Fallback prices per asset
         fallback_prices = {"ETH": 3000.0, "BTC": 80000.0}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1236,15 +1236,16 @@ async def spot_config(maker_tester_session, spot_market_configs, spot_asset):  #
     logger.info(f"   Min Balance: {selected_market.min_balance}")
     logger.info("=" * 60)
 
-    # Fetch oracle price using PERP symbol (e.g., ETHRUSDPERP, BTCRUSDPERP)
-    oracle_symbol = selected_market.oracle_symbol
+    # Fetch asset oracle price without going through the deprecated /prices endpoint
+    # or a perp mark-price substitute.
+    oracle_asset = {"WETH": "ETH", "WBTC": "BTC"}.get(selected_market.base_asset, selected_market.base_asset)
 
     try:
-        price_str = await maker_tester_session.data.current_price(oracle_symbol)
+        price_str = await maker_tester_session.data.asset_oracle_price(oracle_asset)
         oracle_price = float(price_str)
         logger.info(f"📊 Fetched {spot_asset} oracle price: ${oracle_price:.2f}")
     except (OSError, RuntimeError, ValueError) as e:
-        logger.warning(f"Failed to fetch oracle price for {oracle_symbol}: {e}")
+        logger.warning(f"Failed to fetch oracle price for {oracle_asset}: {e}")
         # Fallback prices per asset
         fallback_prices = {"ETH": 3000.0, "BTC": 80000.0}
         oracle_price = fallback_prices.get(spot_asset, 1000.0)

--- a/tests/engine/test_post_only_ws_exec.py
+++ b/tests/engine/test_post_only_ws_exec.py
@@ -106,20 +106,19 @@ async def _open_order_ids(rest: ReyaTradingClient) -> set[str]:
     return {str(order.order_id) for order in await rest.get_open_orders()}
 
 
-async def _oracle_price(rest: ReyaTradingClient, symbol: str, max_attempts: int = 5) -> float:
-    """Oracle price for the liquidity gate, retrying through the transient
+async def _mark_price(rest: ReyaTradingClient, symbol: str, max_attempts: int = 5) -> float:
+    """Mark price for the liquidity gate, retrying through the transient
     NO_PRICES_FOUND_FOR_SYMBOL_ERROR feed gap (mirrors DataOperations.current_price)."""
     last_exc: Exception | None = None
     for _ in range(max_attempts):
         try:
-            price = await rest.markets.get_price(symbol)
-            return float(price.oracle_price)
+            return float(await rest.get_market_mark_price(symbol))
         except ApiException as exc:
             if "NO_PRICES_FOUND_FOR_SYMBOL_ERROR" not in str(exc) and "Price not found" not in str(exc):
                 raise
             last_exc = exc
         await asyncio.sleep(0.3)
-    raise RuntimeError(f"Oracle price for {symbol} unavailable after {max_attempts} attempts") from last_exc
+    raise RuntimeError(f"Mark price for {symbol} unavailable after {max_attempts} attempts") from last_exc
 
 
 class _RestDepthOps:
@@ -212,11 +211,11 @@ async def test_ws_exec_post_only_would_cross_error_envelope(  # pylint: disable=
         ws = ReyaWsExecClient(rest_client=rest, ws_url=os.environ["REYA_WS_EXEC_URL"])
         await ws.connect()
 
-        oracle = await _oracle_price(rest, oracle_symbol)
+        mark_price = await _mark_price(rest, oracle_symbol)
         await skip_if_external_liquidity(
             cast(DataOperations, _RestDepthOps(rest)),
             SPOT_SYMBOL,
-            oracle,
+            mark_price,
             reason_prefix="post-only would-cross (ws-exec)",
         )
 

--- a/tests/engine/test_post_only_ws_exec.py
+++ b/tests/engine/test_post_only_ws_exec.py
@@ -113,8 +113,13 @@ async def _mark_price(rest: ReyaTradingClient, symbol: str, max_attempts: int = 
     for _ in range(max_attempts):
         try:
             return float(await rest.get_market_mark_price(symbol))
-        except ApiException as exc:
-            if "NO_PRICES_FOUND_FOR_SYMBOL_ERROR" not in str(exc) and "Price not found" not in str(exc):
+        except (ApiException, RuntimeError) as exc:
+            error_text = str(exc)
+            if (
+                "NO_PRICES_FOUND_FOR_SYMBOL_ERROR" not in error_text
+                and "Price not found" not in error_text
+                and "did not include markPrice" not in error_text
+            ):
                 raise
             last_exc = exc
         await asyncio.sleep(0.3)

--- a/tests/helpers/market_trackers.py
+++ b/tests/helpers/market_trackers.py
@@ -9,8 +9,6 @@ fields (logPriceMultiplier, priceSpread, depthFactor) that are critical
 for execution price calculations.
 """
 
-from typing import Optional
-
 import logging
 from dataclasses import dataclass
 from decimal import Decimal
@@ -22,10 +20,10 @@ logger = logging.getLogger("reya.integration_tests")
 
 @dataclass
 class PriceData:
-    """Parsed price data from the v2 prices endpoint."""
+    """Parsed mark/mid price data from the v2 market summary endpoint."""
 
-    oracle_price: float
-    pool_price: Optional[float]
+    mark_price: float
+    mid_price: float | None
 
 
 @dataclass
@@ -116,7 +114,7 @@ async def fetch_price(
     symbol: str,
     timeout: float = 10.0,
 ) -> PriceData:
-    """Fetch price data via raw HTTP from the v2 prices endpoint.
+    """Fetch mark/mid price data via raw HTTP from the v2 market summary endpoint.
 
     This avoids needing a full SDK client / reya_tester session.
 
@@ -126,27 +124,29 @@ async def fetch_price(
         timeout: Request timeout in seconds.
 
     Returns:
-        PriceData with oracle_price and pool_price.
+        PriceData with mark_price and mid_price.
     """
     # Ensure base URL ends without trailing slash
     base = v2_api_url.rstrip("/")
-    url = f"{base}/prices/{symbol}"
+    url = f"{base}/perpMarket/{symbol}/summary"
 
-    logger.info(f"Fetching price: {url}")
+    logger.info(f"Fetching market summary: {url}")
 
     async with aiohttp.ClientSession() as session:
         async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout)) as response:
             if response.status != 200:
                 text = await response.text()
-                raise RuntimeError(f"Price request failed ({response.status}): {text}")
+                raise RuntimeError(f"Market summary request failed ({response.status}): {text}")
 
             data = await response.json()
 
-    # API returns camelCase keys
-    oracle_price = float(data.get("oraclePrice") or data.get("oracle_price"))
-    raw_pool = data.get("poolPrice") or data.get("pool_price")
-    pool_price = float(raw_pool) if raw_pool is not None else None
+    raw_mark = data.get("markPrice") or data.get("mark_price")
+    if raw_mark is None:
+        raise RuntimeError(f"Market summary response missing markPrice for {symbol}")
+    mark_price = float(raw_mark)
+    raw_mid = data.get("throttledMidPrice") or data.get("throttled_mid_price")
+    mid_price = float(raw_mid) if raw_mid is not None else None
 
-    logger.info(f"Price for {symbol}: oracle={oracle_price}, pool={pool_price}")
+    logger.info(f"Market summary for {symbol}: mark={mark_price}, mid={mid_price}")
 
-    return PriceData(oracle_price=oracle_price, pool_price=pool_price)
+    return PriceData(mark_price=mark_price, mid_price=mid_price)

--- a/tests/helpers/reya_tester/data.py
+++ b/tests/helpers/reya_tester/data.py
@@ -15,7 +15,6 @@ from sdk.open_api.models.order import Order
 from sdk.open_api.models.perp_execution import PerpExecution
 from sdk.open_api.models.perp_execution_list import PerpExecutionList
 from sdk.open_api.models.position import Position
-from sdk.open_api.models.price import Price
 from sdk.open_api.models.spot_execution import SpotExecution
 from sdk.open_api.models.spot_execution_list import SpotExecutionList
 
@@ -32,37 +31,29 @@ class DataOperations:
         self._t = tester
 
     async def current_price(self, symbol: str = "ETHRUSDPERP", max_attempts: int = 5) -> str:
-        """Fetch current market price for a symbol, retrying through transient price-feed gaps.
-
-        Devnet's price endpoint (`GET /prices/{symbol}`) occasionally returns a
-        momentary `400 NO_PRICES_FOUND_FOR_SYMBOL_ERROR` ("Price not found") during an
-        oracle-push / cache-refresh race. This is a precondition read for many
-        tests, so a transient blip here would otherwise fail unrelated tests.
-        Retry a few times with a short backoff; a sustained outage still raises.
-        """
+        """Fetch current perp mark price for a symbol, retrying through transient market-data gaps."""
         last_exc: Optional[Exception] = None
         for attempt in range(max_attempts):
             try:
-                price_info: Price = await self._t.client.markets.get_price(symbol)
-                logger.info(f"Price info: {price_info}")
-                current_price = price_info.oracle_price
-                if current_price:
-                    logger.info(f"💰 Current market price for {symbol}: ${float(current_price):.2f}")
-                    return current_price
-                logger.info(f"❌ Current market price for {symbol} missing oracle_price")
+                current_price = await self._t.client.get_market_mark_price(symbol)
+                logger.info(f"💰 Current mark price for {symbol}: ${float(current_price):.2f}")
+                return current_price
             except ApiException as e:
-                # Only the transient price-feed gap is retryable; anything else is a real error.
+                # Only transient market-data gaps are retryable; anything else is a real error.
                 error_text = str(e)
-                if "NO_PRICES_FOUND_FOR_SYMBOL_ERROR" not in error_text and "Price not found" not in error_text:
+                if (
+                    "NO_PRICES_FOUND_FOR_SYMBOL_ERROR" not in error_text
+                    and "Price not found" not in error_text
+                    and "market data not found" not in error_text
+                ):
                     raise
                 last_exc = e
                 logger.warning(
-                    f"⚠️ price feed gap for {symbol} (attempt {attempt + 1}/{max_attempts}): "
-                    "NO_PRICES_FOUND_FOR_SYMBOL_ERROR; retrying in 0.3s"
+                    f"⚠️ market summary gap for {symbol} (attempt {attempt + 1}/{max_attempts}); " "retrying in 0.3s"
                 )
             await asyncio.sleep(0.3)
 
-        raise RuntimeError(f"Current market price for {symbol} unavailable after {max_attempts} attempts") from last_exc
+        raise RuntimeError(f"Current mark price for {symbol} unavailable after {max_attempts} attempts") from last_exc
 
     async def positions(self) -> dict[str, Position]:
         """Get all current positions."""

--- a/tests/helpers/reya_tester/data.py
+++ b/tests/helpers/reya_tester/data.py
@@ -64,9 +64,13 @@ class DataOperations:
                 current_price = (await self._t.client.get_asset_oracle_price(asset)).oracle_price
                 logger.info(f"💰 Current asset oracle price for {asset}: ${float(current_price):.2f}")
                 return current_price
-            except ApiException as e:
+            except (ApiException, RuntimeError) as e:
                 error_text = str(e)
-                if "Price not found" not in error_text and "market data not found" not in error_text:
+                if (
+                    "Price not found" not in error_text
+                    and "market data not found" not in error_text
+                    and "Asset oracle price not found" not in error_text
+                ):
                     raise
                 last_exc = e
                 logger.warning(

--- a/tests/helpers/reya_tester/data.py
+++ b/tests/helpers/reya_tester/data.py
@@ -38,13 +38,14 @@ class DataOperations:
                 current_price = await self._t.client.get_market_mark_price(symbol)
                 logger.info(f"💰 Current mark price for {symbol}: ${float(current_price):.2f}")
                 return current_price
-            except ApiException as e:
+            except (ApiException, RuntimeError) as e:
                 # Only transient market-data gaps are retryable; anything else is a real error.
                 error_text = str(e)
                 if (
                     "NO_PRICES_FOUND_FOR_SYMBOL_ERROR" not in error_text
                     and "Price not found" not in error_text
                     and "market data not found" not in error_text
+                    and "did not include markPrice" not in error_text
                 ):
                     raise
                 last_exc = e

--- a/tests/helpers/reya_tester/data.py
+++ b/tests/helpers/reya_tester/data.py
@@ -55,6 +55,28 @@ class DataOperations:
 
         raise RuntimeError(f"Current mark price for {symbol} unavailable after {max_attempts} attempts") from last_exc
 
+    async def asset_oracle_price(self, asset: str, max_attempts: int = 5) -> str:
+        """Fetch current asset oracle price, retrying through transient market-data gaps."""
+        last_exc: Optional[Exception] = None
+        for attempt in range(max_attempts):
+            try:
+                current_price = (await self._t.client.get_asset_oracle_price(asset)).oracle_price
+                logger.info(f"💰 Current asset oracle price for {asset}: ${float(current_price):.2f}")
+                return current_price
+            except ApiException as e:
+                error_text = str(e)
+                if "Price not found" not in error_text and "market data not found" not in error_text:
+                    raise
+                last_exc = e
+                logger.warning(
+                    f"⚠️ asset oracle price gap for {asset} (attempt {attempt + 1}/{max_attempts}); " "retrying in 0.3s"
+                )
+            await asyncio.sleep(0.3)
+
+        raise RuntimeError(
+            f"Current asset oracle price for {asset} unavailable after {max_attempts} attempts"
+        ) from last_exc
+
     async def positions(self) -> dict[str, Position]:
         """Get all current positions."""
         positions_list: list[Position] = await self._t.client.get_positions()

--- a/tests/perp/test_market_data.py
+++ b/tests/perp/test_market_data.py
@@ -5,8 +5,6 @@ Field changes vs the AMM era:
 - ``MarketSummary``: ``longOiQty`` / ``shortOiQty`` collapsed to a single ``oiQty``;
   ``fundingRateVelocity`` removed; ``throttledOraclePrice`` → ``markPrice``;
   ``throttledPoolPrice`` → ``throttledMidPrice``.
-- ``Price.poolPrice`` is now optional — present only while the AMM-era pool-price
-  publisher is still running on a market; absent on perpOB-only markets.
 """
 
 import re
@@ -52,41 +50,38 @@ async def test_market_definitions(reya_tester: ReyaTester):
 
 
 @pytest.mark.asyncio
-async def test_market_price(reya_tester: ReyaTester):
+async def test_market_mark_and_mid_price(reya_tester: ReyaTester):
     symbol = "ETHRUSDPERP"
-    price = await reya_tester.client.markets.get_price(symbol)
-    assert price is not None
-    assert price.symbol == symbol
-    assert 0 < float(price.oracle_price) < 10**18
+    mark_price = await reya_tester.client.get_market_mark_price(symbol)
+    assert 0 < float(mark_price) < 10**18
 
-    # ``pool_price`` is optional under v2.3.0 — only set while the AMM
-    # pool-price publisher still ticks. Validate when present.
-    if price.pool_price is not None:
-        assert 0 < float(price.pool_price) < 10**18
+    mid_price = await reya_tester.client.get_market_mid_price(symbol)
+    assert 0 < float(mid_price) < 10**18
 
-    current_time = int(time.time())
-    assert price.updated_at / 1000 > current_time - 60
+    market_summary = await reya_tester.client.markets.get_perp_market_summary(symbol)
+    current_time = int(time.time() * 1000)
+    assert market_summary.prices_updated_at is not None
+    assert market_summary.prices_updated_at > current_time - 60_000
 
 
 @pytest.mark.asyncio
-async def test_all_prices(reya_tester: ReyaTester):
-    prices = await reya_tester.client.markets.get_prices()
-    assert prices is not None
-    assert len(prices) > 0, "Should have at least one price"
+async def test_all_market_summaries(reya_tester: ReyaTester):
+    summaries = await reya_tester.client.markets.get_perp_markets_summary()
+    assert summaries is not None
+    assert len(summaries) > 0, "Should have at least one market summary"
 
-    for sample_price in prices:
-        assert sample_price.symbol is not None and len(sample_price.symbol) > 0, "Symbol should not be empty"
-        assert 0 <= float(sample_price.oracle_price) < 10**18, "Oracle price should be a valid positive number"
-        if sample_price.pool_price is not None:
-            assert (
-                0 <= float(sample_price.pool_price) < 10**18
-            ), "Pool price should be a valid positive number when present"
+    for summary in summaries:
+        assert summary.symbol is not None and len(summary.symbol) > 0, "Symbol should not be empty"
+        if summary.mark_price is not None:
+            assert 0 <= float(summary.mark_price) < 10**18, "Mark price should be a valid positive number"
+        if summary.throttled_mid_price is not None:
+            assert 0 <= float(summary.throttled_mid_price) < 10**18, "Mid price should be a valid positive number"
         current_time = int(time.time() * 1000)
-        assert sample_price.updated_at > current_time - (60 * 60 * 1000), "Updated timestamp should be within last hour"
-        assert sample_price.updated_at <= current_time + (60 * 1000), "Updated timestamp should not be in future"
+        assert summary.updated_at > current_time - (60 * 60 * 1000), "Updated timestamp should be within last hour"
+        assert summary.updated_at <= current_time + (60 * 1000), "Updated timestamp should not be in future"
 
-    symbols = {price.symbol for price in prices}
-    assert "ETHRUSDPERP" in symbols, "Should include ETHRUSDPERP in all prices"
+    symbols = {summary.symbol for summary in summaries}
+    assert "ETHRUSDPERP" in symbols, "Should include ETHRUSDPERP in all market summaries"
 
 
 @pytest.mark.asyncio

--- a/tests/validation/test_generated_models.py
+++ b/tests/validation/test_generated_models.py
@@ -11,7 +11,6 @@ import sdk.open_api as rest_open_api
 from sdk.async_api.asset_oracle_prices_channel import AssetOraclePricesChannel
 from sdk.async_api.asset_oracle_prices_update_payload import AssetOraclePricesUpdatePayload
 from sdk.async_api.cancel_reason import CancelReason as WsInfoCancelReason
-from sdk.async_api.deprecated_prices_channel import DeprecatedPricesChannel
 from sdk.async_api.execution_bust import ExecutionBust as WsInfoExecutionBust
 from sdk.async_api.market_summary_update_payload import MarketSummaryUpdatePayload
 from sdk.async_api.markets_summary_channel import MarketsSummaryChannel
@@ -20,7 +19,6 @@ from sdk.async_api.order import Order as WsInfoOrder
 from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
 from sdk.async_api.order_changes_subscribed_payload import OrderChangesSubscribedPayload
 from sdk.async_api.order_status import OrderStatus as WsInfoOrderStatus
-from sdk.async_api.prices_update_payload import PricesUpdatePayload
 from sdk.async_api.spot_execution import SpotExecution as WsInfoSpotExecution
 from sdk.async_exec_api.cancel_reason import CancelReason as WsExecCancelReason
 from sdk.async_exec_api.create_order_request import CreateOrderRequest as WsExecCreateOrderRequest
@@ -494,19 +492,6 @@ def test_ws_info_asset_oracle_prices_payload_parses_without_pool_price() -> None
         "updatedAt": 1747927089946,
     }
     assert "poolPrice" not in serialized["data"][0]
-
-
-def test_ws_info_deprecated_prices_channel_is_explicitly_named() -> None:
-    payload = PricesUpdatePayload.model_validate(
-        {
-            "type": "channel_data",
-            "timestamp": 1747927089946,
-            "channel": "/v2/prices",
-            "data": [{"symbol": "ETHRUSDPERP", "oraclePrice": "2500", "updatedAt": 1747927089946}],
-        }
-    )
-
-    assert payload.channel is DeprecatedPricesChannel.SLASH_V2_SLASH_PRICES
 
 
 class _RecordingSocket:

--- a/tests/validation/test_pr59_devnet_smoke_plan.py
+++ b/tests/validation/test_pr59_devnet_smoke_plan.py
@@ -25,7 +25,8 @@ def test_smoke_plan_tracks_pr59_manual_gap_surfaces() -> None:
         "ws.assetOraclePrices",
         "rest.perpMarketsSummary",
         "ws.perpMarketsSummary",
-        "rest.deprecatedPrices",
+        "rest.spotMarketsSummary",
+        "ws.spotMarketsSummary",
         "sdk.removedAmmSurfaces",
     } <= checks_by_id.keys()
 
@@ -33,6 +34,11 @@ def test_smoke_plan_tracks_pr59_manual_gap_surfaces() -> None:
     assert asset_ws.kind is smoke_check_kind.WEBSOCKET
     assert asset_ws.target == "/v2/assetOraclePrices"
     assert "asset oracle" in asset_ws.reason.lower()
+
+    spot_ws = checks_by_id["ws.spotMarketsSummary"]
+    assert spot_ws.kind is smoke_check_kind.WEBSOCKET
+    assert spot_ws.target == "/v2/spotMarkets/summary + /v2/spotMarket/{symbol}/summary"
+    assert "spot market summary" in spot_ws.reason.lower()
 
     removed_surfaces = checks_by_id["sdk.removedAmmSurfaces"]
     assert removed_surfaces.kind is smoke_check_kind.SDK_STATIC

--- a/tests/validation/test_price_endpoint_migration.py
+++ b/tests/validation/test_price_endpoint_migration.py
@@ -1,0 +1,123 @@
+"""Offline guards for the /v2/prices deprecation migration."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from sdk.open_api.models.asset_oracle_price import AssetOraclePrice
+from sdk.open_api.models.market_summary import MarketSummary
+from sdk.reya_rest_api import ReyaTradingClient
+from sdk.reya_rest_api.config import TradingConfig
+from sdk.reya_websocket.resources.market import MarketResource
+from sdk.reya_websocket.resources.prices import PricesResource
+from sdk.reya_websocket.socket import ReyaSocket
+
+pytestmark = pytest.mark.offline
+
+PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+OWNER_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+
+
+class _RecordingSocket:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str, dict[str, Any]]] = []
+
+    def send_subscribe(self, channel: str, **kwargs: Any) -> None:
+        self.messages.append(("subscribe", channel, kwargs))
+
+    def send_unsubscribe(self, channel: str, **kwargs: Any) -> None:
+        self.messages.append(("unsubscribe", channel, kwargs))
+
+
+class _FakeMarkets:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    async def get_asset_oracle_prices(self) -> list[AssetOraclePrice]:
+        self.calls.append(("get_asset_oracle_prices", None))
+        return [
+            AssetOraclePrice(asset="BTC", oraclePrice="100000", updatedAt=1747927089946),
+            AssetOraclePrice(asset="ETH", oraclePrice="2500", updatedAt=1747927089946),
+        ]
+
+    async def get_perp_market_summary(self, symbol: str) -> MarketSummary:
+        self.calls.append(("get_perp_market_summary", symbol))
+        return MarketSummary(
+            symbol=symbol,
+            updatedAt=1747927089946,
+            oiQty="1",
+            fundingRate="0",
+            longFundingValue="0",
+            shortFundingValue="0",
+            volume24h="10",
+            markPrice="2500",
+            throttledMidPrice="2501",
+            pricesUpdatedAt=1747927089946,
+        )
+
+
+@pytest.fixture
+def client() -> ReyaTradingClient:
+    config = TradingConfig(
+        api_url="https://invalid.example/v2",
+        chain_id=89346162,
+        owner_wallet_address=OWNER_ADDRESS,
+        private_key=PRIVATE_KEY,
+        account_id=12345,
+        dex_id_override=2,
+    )
+    c = ReyaTradingClient(config)
+    c._resources.markets = cast(Any, _FakeMarkets())  # pylint: disable=protected-access
+    return c
+
+
+@pytest.mark.asyncio
+async def test_asset_oracle_price_helper_uses_asset_oracle_prices_endpoint(client: ReyaTradingClient) -> None:
+    price = await client.get_asset_oracle_price("eth")
+
+    assert price.asset == "ETH"
+    assert price.oracle_price == "2500"
+    assert client.markets.calls == [("get_asset_oracle_prices", None)]  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_market_price_helpers_use_market_summary_endpoint(client: ReyaTradingClient) -> None:
+    mark_price = await client.get_market_mark_price("ETHRUSDPERP")
+    mid_price = await client.get_market_mid_price("ETHRUSDPERP")
+
+    assert mark_price == "2500"
+    assert mid_price == "2501"
+    assert client.markets.calls == [  # type: ignore[attr-defined]
+        ("get_perp_market_summary", "ETHRUSDPERP"),
+        ("get_perp_market_summary", "ETHRUSDPERP"),
+    ]
+
+
+def test_websocket_resource_no_longer_exposes_deprecated_prices_channels() -> None:
+    assert "/v2/prices" not in ReyaSocket.CHANNEL_PAYLOAD_MAP
+
+    socket = ReyaSocket()
+    assert socket._get_payload_type("/v2/prices/ETHRUSDPERP") is None  # pylint: disable=protected-access
+
+    prices = PricesResource(_RecordingSocket())  # type: ignore[arg-type]
+    assert not hasattr(prices, "all_prices")
+    assert not hasattr(prices, "price")
+
+
+def test_websocket_market_resources_expose_summary_channels() -> None:
+    socket = _RecordingSocket()
+    market = MarketResource(socket)  # type: ignore[arg-type]
+
+    market.all_markets_summary.subscribe(batched=True)
+    market.summary("ETHRUSDPERP").subscribe()
+    market.all_spot_markets_summary.subscribe()
+    market.spot_summary("WETHRUSD").subscribe()
+
+    assert socket.messages == [
+        ("subscribe", "/v2/perpMarkets/summary", {"batched": True}),
+        ("subscribe", "/v2/perpMarket/ETHRUSDPERP/summary", {"batched": False}),
+        ("subscribe", "/v2/spotMarkets/summary", {"batched": False}),
+        ("subscribe", "/v2/spotMarket/WETHRUSD/summary", {"batched": False}),
+    ]

--- a/tests/validation/test_price_endpoint_migration.py
+++ b/tests/validation/test_price_endpoint_migration.py
@@ -1,5 +1,7 @@
 """Offline guards for the /v2/prices deprecation migration."""
 
+# pylint: disable=redefined-outer-name
+
 from __future__ import annotations
 
 from typing import Any, cast
@@ -59,7 +61,7 @@ class _FakeMarkets:
 
 
 @pytest.fixture
-def client() -> ReyaTradingClient:
+def trading_client() -> ReyaTradingClient:
     config = TradingConfig(
         api_url="https://invalid.example/v2",
         chain_id=89346162,
@@ -74,22 +76,24 @@ def client() -> ReyaTradingClient:
 
 
 @pytest.mark.asyncio
-async def test_asset_oracle_price_helper_uses_asset_oracle_prices_endpoint(client: ReyaTradingClient) -> None:
-    price = await client.get_asset_oracle_price("eth")
+async def test_asset_oracle_price_helper_uses_asset_oracle_prices_endpoint(
+    trading_client: ReyaTradingClient,
+) -> None:
+    price = await trading_client.get_asset_oracle_price("eth")
 
     assert price.asset == "ETH"
     assert price.oracle_price == "2500"
-    assert client.markets.calls == [("get_asset_oracle_prices", None)]  # type: ignore[attr-defined]
+    assert trading_client.markets.calls == [("get_asset_oracle_prices", None)]  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio
-async def test_market_price_helpers_use_market_summary_endpoint(client: ReyaTradingClient) -> None:
-    mark_price = await client.get_market_mark_price("ETHRUSDPERP")
-    mid_price = await client.get_market_mid_price("ETHRUSDPERP")
+async def test_market_price_helpers_use_market_summary_endpoint(trading_client: ReyaTradingClient) -> None:
+    mark_price = await trading_client.get_market_mark_price("ETHRUSDPERP")
+    mid_price = await trading_client.get_market_mid_price("ETHRUSDPERP")
 
     assert mark_price == "2500"
     assert mid_price == "2501"
-    assert client.markets.calls == [  # type: ignore[attr-defined]
+    assert trading_client.markets.calls == [  # type: ignore[attr-defined]
         ("get_perp_market_summary", "ETHRUSDPERP"),
         ("get_perp_market_summary", "ETHRUSDPERP"),
     ]


### PR DESCRIPTION
## Summary
- add REST helpers for asset oracle prices and perp market mark/mid prices backed by /assetOraclePrices and /perpMarket/{symbol}/summary
- remove SDK websocket resource/routing for deprecated /v2/prices channels and add spot market summary resources
- migrate examples, smoke scripts, and tests from legacy price endpoints/channels to asset oracle and market summary surfaces

## Verification
- poetry run pytest -m offline
- SKIP=pyupgrade poetry run pre-commit run --all-files --verbose --show-diff-on-failure --color never
- /tmp/reya-python-sdk-pyupgrade-313/bin/pyupgrade --py39-plus \

Note: local full pre-commit without SKIP hits a pyupgrade hook crash under system Python 3.14.5 (TypeError in pyupgrade token handling). The pinned pyupgrade hook version made no changes when run under Python 3.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spot market summary support with REST and WebSocket access, plus new market-data helpers for asset oracle price, perp mark price, and perp mid price.
* **Bug Fixes**
  * Removed legacy `/v2/prices` websocket handling and updated examples to use summary-based pricing (mark/mid/oracle summary) instead of deprecated price feeds.
  * Updated market-making and monitoring examples to reference the correct summary fields.
* **Documentation**
  * Updated README to document spot market summary endpoints and remove deprecated legacy price endpoint references.
* **Tests**
  * Expanded validation, smoke checks, and added migration tests covering deprecated channel removal and new summary flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->