### PR TITLE
fix: round spot pretrade buy price

### DIFF
--- a/tests/spot/test_pretrade_checks.py
+++ b/tests/spot/test_pretrade_checks.py
@@ -52,7 +52,7 @@ async def test_spot_ioc_insufficient_balance_buy(spot_config: SpotTestConfig, sp
 
     # Calculate qty that would require slightly more RUSD than available
     # At spot_config.oracle_price, we need (rusd_balance / price) + small_extra ETH
-    order_price = Decimal(str(spot_config.oracle_price))
+    order_price = Decimal(str(spot_config.price(1.0)))
     max_qty_at_price = rusd_balance / order_price
     # Request 10% more than we can afford
     exceeding_qty = str((max_qty_at_price * Decimal("1.1")).quantize(Decimal("0.01")))


### PR DESCRIPTION
## Summary
- Use the existing tick-rounded spot price helper in the IOC insufficient-balance buy test
- Avoid sending raw asset oracle prices with excessive decimal precision before the test reaches the intended insufficient-balance assertion

## Verification
- Loaded the devnet1-perp-bust env with explicit devnet read/ws-exec URLs
- `poetry run pytest -q -rxXs --tb=short tests/spot/test_pretrade_checks.py::test_spot_ioc_insufficient_balance_buy` -> `1 passed in 21.59s`
- `poetry run black tests/spot/test_pretrade_checks.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an insufficient-balance test to use the configured spot price when validating immediate-or-cancel buy orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->