### PR TITLE
Add shared test price helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ from tests.helpers.market_config import (  # noqa: E402
     SpotTestConfig,
     fetch_spot_market_configs,
 )
+from tests.helpers.price_helpers import limit_price, quantize_price  # noqa: E402
 from tests.helpers.reya_tester import logger  # noqa: E402
 from tests.helpers.settlement import make_settlement_probe  # noqa: E402
 from tests.helpers.spot_prerequisites import (  # noqa: E402
@@ -1450,7 +1451,7 @@ async def spot_balance_guard(
     logger.info(f"📈 Maker changes: {base_asset} {maker_asset_change:+}, RUSD {maker_rusd_change:+}")
     logger.info(f"📈 Taker changes: {base_asset} {taker_asset_change:+}, RUSD {taker_rusd_change:+}")
 
-    oracle_price = Decimal(str(spot_config.oracle_price))
+    oracle_price = limit_price(spot_config.oracle_price, spot_config.tick_size)
     min_price = oracle_price * Decimal("0.95")
     max_price = oracle_price * Decimal("1.05")
 
@@ -1497,7 +1498,7 @@ async def spot_balance_guard(
             effective_price = oracle_price
 
         restoration_price = max(min_price, min(max_price, effective_price))
-        restoration_price = restoration_price.quantize(Decimal("0.01"))
+        restoration_price = quantize_price(restoration_price, spot_config.tick_size)
         logger.info(f"💱 Restoration price: ${restoration_price}")
 
         if abs(maker_asset_needed) >= min_qty:

--- a/tests/engine/test_modify_ws_exec.py
+++ b/tests/engine/test_modify_ws_exec.py
@@ -32,6 +32,7 @@ from sdk.reya_rest_api import ReyaTradingClient
 from sdk.reya_rest_api.models.orders import LimitOrderParameters, ModifyOrderParameters
 from sdk.reya_ws_exec import WsExecOperationError
 from tests.helpers.builders.order_builder import full_state_modify_params
+from tests.helpers.price_helpers import self_match_resting_prices
 from tests.helpers.ws_exec_market import WsExecMarket
 
 pytestmark = [pytest.mark.e2e, pytest.mark.modify]
@@ -331,11 +332,9 @@ async def test_ws_exec_self_match_modify_cancelled(ws_exec_market: WsExecMarket)
     yields CANCELLED) and no settlement occurs, so the shared account balances
     are untouched. The resting ask survives.
 
-    Spot-pinned: the cross is engineered with both legs far BELOW an ETH-priced
-    spot book (ask "2" above bid "1") so the bid->ask cross only ever reaches the
-    account's OWN ask; on perp that same construction (a sell far below mark)
-    would execute against the real book instead of resting. The engine self-match
-    semantics are proven [spot, perp] via REST in
+    Spot-pinned: choose same-account bid/ask prices from the live spread so the
+    resting ask does not fill externally, then modify the bid into that ask. The
+    engine self-match semantics are proven [spot, perp] via REST in
     test_modify_execution.py::test_crossing_modify_self_match_cancelled."""
     m = ws_exec_market
     if m.market_type != "spot":
@@ -344,11 +343,19 @@ async def test_ws_exec_self_match_modify_cancelled(ws_exec_market: WsExecMarket)
             "single far-from-touch rest price); engine SMP proven [spot, perp] via REST "
             "(test_modify_execution.py::test_crossing_modify_self_match_cancelled)"
         )
-    ask_px = "2"
-    bid_px = "1"
 
-    # Resting ask ABOVE the bid (both far below the ETH-priced book's market, so
-    # the bid->ask cross only ever reaches the account's OWN ask, never external).
+    depth = await m.rest.markets.get_market_depth(symbol=m.symbol)
+    best_bid = depth.bids[0].px if depth.bids else None
+    best_ask = depth.asks[0].px if depth.asks else None
+    prices = self_match_resting_prices(best_bid=best_bid, best_ask=best_ask, tick_size=m.tick_size)
+    if prices is None:
+        pytest.skip("external spot spread has no tick room for a controlled ws-exec self-match")
+
+    ask_px = prices.ask_px
+    bid_px = prices.bid_px
+
+    # Resting ask ABOVE the bid and inside the external spread, so the bid->ask
+    # cross only ever reaches the account's OWN ask, never external liquidity.
     ask = await m.ws.create_limit_order(
         LimitOrderParameters(
             symbol=m.symbol, is_buy=False, limit_px=ask_px, qty=m.min_qty, time_in_force=TimeInForce.GTC

--- a/tests/engine/test_post_only_resting.py
+++ b/tests/engine/test_post_only_resting.py
@@ -13,8 +13,6 @@ maker→taker every run), so the module wires the per-market settlement cleanup
 (spot balance guard / perp baseline restore) via the autouse fixture.
 """
 
-from decimal import Decimal
-
 import pytest
 
 from sdk.open_api.models.order_status import OrderStatus
@@ -72,10 +70,8 @@ async def test_post_only_one_tick_from_touch_rests(
     is per-market reference data, so this is pinned on both books."""
     await skip_if_external_config_liquidity(market_config, maker, RESTING_REASON)
 
-    # Snap the ask to the tick grid so probe = ask - tick is also grid-valid.
-    tick = Decimal(market_config.tick_size)
-    oracle = Decimal(str(market_config.oracle_price))
-    ask = (oracle * Decimal("1.01")) // tick * tick
+    tick = market_config.price_tick
+    ask = market_config.floor_price("1.01")
     ask_px = str(ask)
     probe_px = str(ask - tick)
 

--- a/tests/helpers/market_config.py
+++ b/tests/helpers/market_config.py
@@ -44,6 +44,14 @@ from tests.helpers.liquidity_detector import (
     OrderBookState,
     log_order_book_state,
 )
+from tests.helpers.price_helpers import (
+    floor_price,
+    format_price,
+    limit_price,
+    one_tick_below,
+    one_tick_inside_spread,
+    price_tick,
+)
 
 if TYPE_CHECKING:
     from sdk.reya_rest_api.client import ReyaTradingClient
@@ -174,6 +182,19 @@ class MarketTestConfig:
         """
         return round(self.oracle_price * multiplier, 2)
 
+    @property
+    def price_tick(self) -> Decimal:
+        return price_tick(self.tick_size)
+
+    def limit_price(self, multiplier: Decimal | float | str = 1) -> Decimal:
+        return limit_price(self.oracle_price, self.tick_size, multiplier)
+
+    def limit_price_str(self, multiplier: Decimal | float | str = 1) -> str:
+        return format_price(self.limit_price(multiplier))
+
+    def floor_price(self, multiplier: Decimal | float | str = 1) -> Decimal:
+        return floor_price(self.oracle_price, self.tick_size, multiplier)
+
     def buy_price(self, multiplier: float = 0.99) -> float:
         """Get a buy price (default 99% of oracle - within deviation limit)."""
         return self.price(multiplier)
@@ -239,6 +260,24 @@ class MarketTestConfig:
         if self._order_book is None or not self._order_book.asks.has_liquidity:
             return None
         return self._order_book.asks.best_price
+
+    def maker_bid_above_external_bid(self) -> Decimal | None:
+        return one_tick_inside_spread(
+            best_bid=self.best_bid_price,
+            best_ask=self.best_ask_price,
+            tick_size=self.tick_size,
+        )
+
+    def maker_ask_below_external_ask(self) -> Decimal | None:
+        if self.best_ask_price is None:
+            return None
+
+        candidate = one_tick_below(self.best_ask_price, self.tick_size)
+        if candidate is None:
+            return None
+        if self.best_bid_price is not None and candidate <= self.best_bid_price:
+            return None
+        return candidate
 
     @property
     def circuit_breaker_floor(self) -> Decimal:

--- a/tests/helpers/price_helpers.py
+++ b/tests/helpers/price_helpers.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+
+PriceInput = Decimal | int | float | str
+
+
+@dataclass(frozen=True)
+class SelfMatchPrices:
+    """Resting prices for a same-account bid that can modify up into its ask."""
+
+    bid_px: str
+    ask_px: str
+
+
+def _decimal(value: PriceInput) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+def price_tick(tick_size: PriceInput) -> Decimal:
+    tick = _decimal(tick_size)
+    if tick <= 0:
+        raise ValueError(f"tick_size must be positive, got {tick_size!r}")
+    return tick
+
+
+def format_price(price: Decimal) -> str:
+    return format(price, "f")
+
+
+def quantize_price(value: PriceInput, tick_size: PriceInput) -> Decimal:
+    tick = price_tick(tick_size)
+    units = (_decimal(value) / tick).to_integral_value(rounding=ROUND_HALF_UP)
+    return (units * tick).quantize(tick)
+
+
+def limit_price(oracle_price: PriceInput, tick_size: PriceInput, multiplier: PriceInput = 1) -> Decimal:
+    return quantize_price(_decimal(oracle_price) * _decimal(multiplier), tick_size)
+
+
+def floor_price(oracle_price: PriceInput, tick_size: PriceInput, multiplier: PriceInput = 1) -> Decimal:
+    tick = price_tick(tick_size)
+    raw_price = _decimal(oracle_price) * _decimal(multiplier)
+    return ((raw_price // tick) * tick).quantize(tick)
+
+
+def one_tick_above(price: PriceInput, tick_size: PriceInput) -> Decimal:
+    tick = price_tick(tick_size)
+    return quantize_price(_decimal(price) + tick, tick)
+
+
+def one_tick_below(price: PriceInput, tick_size: PriceInput) -> Decimal | None:
+    tick = price_tick(tick_size)
+    candidate = quantize_price(_decimal(price) - tick, tick)
+    if candidate <= 0:
+        return None
+    return candidate
+
+
+def one_tick_inside_spread(
+    *,
+    best_bid: PriceInput | None,
+    best_ask: PriceInput | None,
+    tick_size: PriceInput,
+) -> Decimal | None:
+    if best_bid is not None:
+        candidate = one_tick_above(best_bid, tick_size)
+        if best_ask is not None and candidate >= _decimal(best_ask):
+            return None
+        return candidate
+
+    if best_ask is None:
+        return None
+
+    return one_tick_below(best_ask, tick_size)
+
+
+def self_match_resting_prices(
+    *,
+    best_bid: PriceInput | None,
+    best_ask: PriceInput | None,
+    tick_size: PriceInput,
+    fallback_bid: PriceInput = "1",
+    fallback_ask: PriceInput = "2",
+) -> SelfMatchPrices | None:
+    if best_bid is None and best_ask is None:
+        fallback_bid_price = quantize_price(fallback_bid, tick_size)
+        fallback_ask_price = quantize_price(fallback_ask, tick_size)
+        if fallback_bid_price <= 0 or fallback_bid_price >= fallback_ask_price:
+            return None
+        return SelfMatchPrices(
+            bid_px=format_price(fallback_bid_price),
+            ask_px=format_price(fallback_ask_price),
+        )
+
+    resting_ask = one_tick_inside_spread(best_bid=best_bid, best_ask=best_ask, tick_size=tick_size)
+    if resting_ask is None:
+        return None
+
+    resting_bid = one_tick_below(resting_ask, tick_size)
+    if resting_bid is None:
+        return None
+
+    return SelfMatchPrices(bid_px=format_price(resting_bid), ask_px=format_price(resting_ask))

--- a/tests/helpers/ws_exec_market.py
+++ b/tests/helpers/ws_exec_market.py
@@ -53,6 +53,7 @@ class WsExecMarket:
     ws: ReyaWsExecClient
     symbol: str
     min_qty: str
+    tick_size: str
     rest_buy_px: str  # a passive, far-from-touch buy price that rests (never crosses)
 
 
@@ -90,11 +91,13 @@ async def build_ws_exec_market(market_type: str) -> AsyncIterator[WsExecMarket]:
             if symbol not in spot_defs:
                 ws_exec_prerequisite_missing(f"{symbol} not found in /v2/spotMarketDefinitions")
             min_qty = str(spot_defs[symbol].min_order_qty)
+            tick_size = str(spot_defs[symbol].tick_size)
         else:
             perp_defs = {d.symbol: d for d in await rest.reference.get_perp_market_definitions()}
             if symbol not in perp_defs:
                 ws_exec_prerequisite_missing(f"{symbol} not found in /v2/perpMarketDefinitions")
             min_qty = str(perp_defs[symbol].min_order_qty)
+            tick_size = str(perp_defs[symbol].tick_size)
         ws = ReyaWsExecClient(rest_client=rest, ws_url=os.environ["REYA_WS_EXEC_URL"])
         await ws.connect()
         yield WsExecMarket(
@@ -103,6 +106,7 @@ async def build_ws_exec_market(market_type: str) -> AsyncIterator[WsExecMarket]:
             ws=ws,
             symbol=symbol,
             min_qty=min_qty,
+            tick_size=tick_size,
             rest_buy_px=rest_buy_px,
         )
     finally:

--- a/tests/spot/test_pretrade_checks.py
+++ b/tests/spot/test_pretrade_checks.py
@@ -51,8 +51,8 @@ async def test_spot_ioc_insufficient_balance_buy(spot_config: SpotTestConfig, sp
     logger.info(f"Current RUSD balance: {rusd_balance}")
 
     # Calculate qty that would require slightly more RUSD than available
-    # At spot_config.oracle_price, we need (rusd_balance / price) + small_extra ETH
-    order_price = Decimal(str(spot_config.price(1.0)))
+    # At the current tick-valid market price, request slightly more than the account can afford.
+    order_price = spot_config.limit_price(1.0)
     max_qty_at_price = rusd_balance / order_price
     # Request 10% more than we can afford
     exceeding_qty = str((max_qty_at_price * Decimal("1.1")).quantize(Decimal("0.01")))
@@ -113,8 +113,7 @@ async def test_spot_ioc_insufficient_balance_sell(spot_config: SpotTestConfig, s
     # Request 10% more than we have, quantized to qty_step_size
     qty_step = Decimal(spot_config.qty_step_size) if hasattr(spot_config, "qty_step_size") else Decimal("0.01")
     exceeding_qty = str((asset_balance * Decimal("1.1")).quantize(qty_step))
-    # Round price to tick size
-    order_price = str(spot_config.price(1.0))
+    order_price = spot_config.limit_price_str(1.0)
 
     order_params = OrderBuilder().symbol(spot_config.symbol).sell().price(order_price).qty(exceeding_qty).ioc().build()
 

--- a/tests/spot/test_response_validation.py
+++ b/tests/spot/test_response_validation.py
@@ -371,8 +371,10 @@ async def test_spot_execution_maker_vs_taker_fields(
     # Case 4: Both exist - maker buys at better price than external bids
     if best_external_ask is not None and best_external_bid is None:
         # Only external asks exist - maker places SELL, taker BUYS
-        # Place our ask BELOW the best external ask so we get matched first
-        maker_price = round(float(best_external_ask) * 0.999, 2)
+        # Place our ask one tick BELOW the best external ask so we get matched first.
+        maker_price = spot_config.maker_ask_below_external_ask()
+        if maker_price is None:
+            pytest.skip("External ask is too close to the tick floor to place a better maker ask")
         logger.info(f"Only external asks exist - placing maker SELL at ${maker_price} (below ${best_external_ask})")
 
         maker_params = OrderBuilder.from_config(spot_config).sell().price(str(maker_price)).gtc().build()
@@ -380,11 +382,13 @@ async def test_spot_execution_maker_vs_taker_fields(
     else:
         # No external liquidity, only bids, or both - maker places BUY, taker SELLS
         if best_external_bid is not None:
-            # Place our bid ABOVE the best external bid so we get matched first
-            maker_price = round(float(best_external_bid) * 1.001, 2)
+            # Place our bid one tick ABOVE the best external bid without crossing the ask.
+            maker_price = spot_config.maker_bid_above_external_bid()
+            if maker_price is None:
+                pytest.skip("External spread has no tick room for a better maker bid")
             logger.info(f"External bids exist - placing maker BUY at ${maker_price} (above ${best_external_bid})")
         else:
-            maker_price = spot_config.price(0.99)
+            maker_price = spot_config.limit_price("0.99")
             logger.info(f"No external liquidity - placing maker BUY at ${maker_price}")
 
         maker_params = OrderBuilder.from_config(spot_config).buy().price(str(maker_price)).gtc().build()

--- a/tests/validation/test_price_helpers.py
+++ b/tests/validation/test_price_helpers.py
@@ -1,0 +1,64 @@
+from decimal import Decimal
+
+import pytest
+
+from tests.helpers.price_helpers import (
+    floor_price,
+    format_price,
+    limit_price,
+    one_tick_inside_spread,
+    self_match_resting_prices,
+)
+
+pytestmark = pytest.mark.offline
+
+
+def test_limit_price_quantizes_oracle_price_to_market_tick():
+    price = limit_price(oracle_price="1738.2773364199493", tick_size="0.01")
+
+    assert price == Decimal("1738.28")
+    assert format_price(price) == "1738.28"
+
+
+def test_limit_price_snaps_to_non_power_of_ten_tick_multiple():
+    price = limit_price(oracle_price="100.03", tick_size="0.05")
+
+    assert price == Decimal("100.05")
+
+
+def test_floor_price_snaps_down_to_tick_grid():
+    price = floor_price(oracle_price="100.019", tick_size="0.01")
+
+    assert price == Decimal("100.01")
+
+
+def test_one_tick_inside_spread_improves_bid_without_crossing_ask():
+    price = one_tick_inside_spread(best_bid="100", best_ask="100.02", tick_size="0.01")
+
+    assert price == Decimal("100.01")
+
+
+def test_one_tick_inside_spread_returns_none_when_no_tick_room():
+    price = one_tick_inside_spread(best_bid="100", best_ask="100.01", tick_size="0.01")
+
+    assert price is None
+
+
+def test_one_tick_inside_spread_improves_ask_when_only_asks_exist():
+    price = one_tick_inside_spread(best_bid=None, best_ask="100", tick_size="0.01")
+
+    assert price == Decimal("99.99")
+
+
+def test_self_match_resting_prices_stay_inside_external_spread():
+    prices = self_match_resting_prices(best_bid="100", best_ask="100.03", tick_size="0.01")
+
+    assert prices is not None
+    assert prices.bid_px == "100.00"
+    assert prices.ask_px == "100.01"
+
+
+def test_self_match_resting_prices_return_none_when_spread_has_no_tick_room():
+    prices = self_match_resting_prices(best_bid="100", best_ask="100.01", tick_size="0.01")
+
+    assert prices is None

--- a/tests/validation/test_price_math_guardrails.py
+++ b/tests/validation/test_price_math_guardrails.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.offline
+
+TESTS_ROOT = Path(__file__).parents[1]
+EXCLUDED_RELATIVE_PATHS = {
+    Path("validation/test_price_math_guardrails.py"),
+    Path("helpers/price_helpers.py"),
+}
+
+FORBIDDEN_PATTERNS = {
+    "raw oracle Decimal for order prices": re.compile(r"Decimal\(\s*str\(\s*[^)\n]*\.oracle_price\s*\)\s*\)"),
+    "percentage-improved live best bid": re.compile(r"best_external_bid[^\n]*\*\s*1\.001"),
+    "percentage-improved live best ask": re.compile(r"best_external_ask[^\n]*\*\s*0\.999"),
+    "hard-coded ws-exec spot self-match prices": re.compile(
+        r"ask_px\s*=\s*[\"']2[\"']\s*\n\s*bid_px\s*=\s*[\"']1[\"']"
+    ),
+}
+
+
+def test_live_tests_do_not_reintroduce_known_unsafe_price_math():
+    violations: list[str] = []
+
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        rel_path = path.relative_to(TESTS_ROOT)
+        if rel_path in EXCLUDED_RELATIVE_PATHS or rel_path.parts[0] in {"helpers", "validation"}:
+            continue
+
+        source = path.read_text()
+        for name, pattern in FORBIDDEN_PATTERNS.items():
+            if pattern.search(source):
+                violations.append(f"{rel_path}: {name}")
+
+    assert not violations, "Use tests.helpers.price_helpers instead:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary
- Add `tests.helpers.price_helpers` for tick-valid price construction, one-tick inside-spread prices, and ws-exec self-match price selection.
- Route the fragile spot pretrade, spot maker/taker field, ws-exec self-match, post-only one-tick, and spot balance-restoration price math through shared helpers.
- Add offline guardrails that fail if the known unsafe raw oracle, live-book percentage improvement, or hard-coded ws-exec self-match price patterns are reintroduced.

## Notes
- Base is now `feat/perpOB` after #66 merged.

## Validation
- `poetry run pytest -q tests/validation/test_price_helpers.py tests/validation/test_price_math_guardrails.py` -> `9 passed in 0.04s`
- `poetry run mypy --config-file pyproject.toml ./ --exclude "sdk/async_api|sdk/async_exec_api"` -> `Success: no issues found in 269 source files`
- Focused live devnet run for the changed behavior -> `5 passed, 1 skipped in 68.90s`; the skip was the controlled-book post-only one-tick case because devnet had external liquidity.
- `poetry run black --check ...` on touched files
- `poetry run isort --check-only ...` on touched files
- `poetry run flake8 --ignore=E501,E203,W503 ...` on touched files
- `git diff --check`

Local note: `make pre-commit` passed all hooks after pyupgrade, but local pyupgrade itself crashes under the machine's Python 3.14 pre-commit env. The earlier GitHub Python 3.10 run showed pyupgrade passing; the force-push should trigger a fresh CI run.
