### PR TITLE
test(e2e): market-data localnet suite — batching, depth continuity, feed-resync recovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ markers = [
     "post_only: Post-only (maker-only) order tests",
     "gtt: Good-Till-Time (auto-expiring resting order) tests",
     "offline: No-network tests (parity golden vectors + client guards) — safe without devnet/.env",
+    "localnet: Market-data pipeline tests that need the local k3d stack (batching, depth continuity, 1012/1013 resync/backpressure). Some require LOCALNET_KUBECONFIG to restart the ME.",
     "strict_spot_prerequisites: Internal marker for tests that must fail on missing spot prerequisites",
     "strict_ws_exec_prerequisites: Internal marker for tests that must fail on missing ws-exec prerequisites",
 ]

--- a/tests/market_data/__init__.py
+++ b/tests/market_data/__init__.py
@@ -1,0 +1,14 @@
+"""Market-data pipeline e2e tests (localnet).
+
+Covers behaviours introduced by the market-data producer/consumer work that the
+rest of the suite does not exercise:
+
+- T1 ``test_order_changes_batching`` — batched orderChanges frames (one WS frame
+  may carry multiple order events), losslessness and per-/cross-frame ordering.
+- T2 ``test_depth_continuity`` — snapshot + absolute per-level diffs (qty "0"
+  removes a level), local-book convergence to REST depth, and ``?limit=N``.
+- T3 ``test_resync_close`` — matching-engine reseed resync signal (1012 close
+  and/or inline FEED_RESET), reconnect+resubscribe, fresh-snapshot consistency.
+- T4 ``test_slow_consumer_close`` — 1013 slow-consumer/backpressure close
+  (opt-in stress; see the module docstring for why it is skip-by-default).
+"""

--- a/tests/market_data/local_book.py
+++ b/tests/market_data/local_book.py
@@ -1,0 +1,75 @@
+"""Client-side L2 book maintained from a snapshot + absolute per-level diffs.
+
+Depth continuity contract: subscribing yields a full snapshot, then every
+update is an *absolute* per-level statement — a level's ``qty`` replaces the
+prior value, and ``qty == "0"`` removes the level. Rebuilding the book this way
+and comparing it to ``GET /v2/market/{symbol}/depth`` (no param = full book) is
+the convergence check T2/T3 rely on.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sdk.async_api.depth import Depth as AsyncDepth
+from sdk.open_api.models.depth import Depth as RestDepth
+
+# A price/qty level normalised to Decimals for exact set comparison.
+Levels = dict[Decimal, Decimal]
+
+
+class LocalBook:
+    """Bids/asks maintained by applying absolute per-level depth diffs."""
+
+    def __init__(self) -> None:
+        self.bids: Levels = {}
+        self.asks: Levels = {}
+
+    @classmethod
+    def from_snapshot(cls, depth: AsyncDepth) -> "LocalBook":
+        book = cls()
+        book._replace_side(book.bids, depth.bids)
+        book._replace_side(book.asks, depth.asks)
+        return book
+
+    def apply(self, depth: AsyncDepth) -> None:
+        """Apply one depth update frame with absolute per-level semantics."""
+        self._merge_side(self.bids, depth.bids)
+        self._merge_side(self.asks, depth.asks)
+
+    @staticmethod
+    def _replace_side(side: Levels, levels) -> None:
+        side.clear()
+        for level in levels:
+            qty = Decimal(level.qty)
+            if qty > 0:
+                side[Decimal(level.px)] = qty
+
+    @staticmethod
+    def _merge_side(side: Levels, levels) -> None:
+        for level in levels:
+            px = Decimal(level.px)
+            qty = Decimal(level.qty)
+            if qty > 0:
+                side[px] = qty
+            else:
+                side.pop(px, None)
+
+    def bids_sorted(self) -> list[tuple[Decimal, Decimal]]:
+        return sorted(self.bids.items(), key=lambda kv: kv[0], reverse=True)
+
+    def asks_sorted(self) -> list[tuple[Decimal, Decimal]]:
+        return sorted(self.asks.items(), key=lambda kv: kv[0])
+
+
+def rest_levels(levels) -> list[tuple[Decimal, Decimal]]:
+    """Normalise a REST/async Depth side to sorted (px, qty) Decimals, dropping zeros."""
+    out = [(Decimal(level.px), Decimal(level.qty)) for level in levels if Decimal(level.qty) > 0]
+    return out
+
+
+def depth_sides(depth: RestDepth | AsyncDepth) -> tuple[list, list]:
+    """Return (bids, asks) as sorted Decimal tuples: bids descending, asks ascending."""
+    bids = sorted(rest_levels(depth.bids), key=lambda kv: kv[0], reverse=True)
+    asks = sorted(rest_levels(depth.asks), key=lambda kv: kv[0])
+    return bids, asks

--- a/tests/market_data/local_book.py
+++ b/tests/market_data/local_book.py
@@ -26,7 +26,7 @@ class LocalBook:
         self.asks: Levels = {}
 
     @classmethod
-    def from_snapshot(cls, depth: AsyncDepth) -> "LocalBook":
+    def from_snapshot(cls, depth: AsyncDepth) -> LocalBook:
         book = cls()
         book._replace_side(book.bids, depth.bids)
         book._replace_side(book.asks, depth.asks)

--- a/tests/market_data/md_ws_recorder.py
+++ b/tests/market_data/md_ws_recorder.py
@@ -1,0 +1,157 @@
+"""Frame-level WebSocket recorder for market-data pipeline tests.
+
+The shared ``ReyaTester`` WebSocket state (``tests/helpers/reya_tester/websocket.py``)
+collapses every incoming frame into ``EventStore``s, which is perfect for
+"does the final state contain X" assertions but discards two things these
+tests need to observe directly:
+
+1. **Frame boundaries** — batching means one ``channel_data`` frame may carry
+   several entries in ``data[]``. To assert "all events arrived, batching
+   tolerated, order preserved within and across frames" we must keep each frame
+   as a distinct list, in arrival order.
+2. **Close codes** — the 1012 (feed resync) / 1013 (slow consumer) contract is a
+   WebSocket *close frame*; ``ReyaTester`` uses the SDK default ``on_close`` which
+   only logs. We record ``(code, reason)`` so a test can assert on them.
+
+This is test-only infrastructure built on the public ``ReyaSocket`` — no SDK
+library change. Callbacks fire on the ``websocket-client`` reader thread, so all
+recorded state is guarded by a lock and copied out for the asyncio test thread.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import logging
+import threading
+
+from sdk.async_api.depth import Depth
+from sdk.async_api.error_message_payload import ErrorMessagePayload
+from sdk.async_api.market_depth_update_payload import MarketDepthUpdatePayload
+from sdk.async_api.order import Order as AsyncOrder
+from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
+from sdk.async_api.order_changes_snapshot import OrderChangesSnapshot
+from sdk.async_api.order_changes_subscribed_payload import OrderChangesSubscribedPayload
+from sdk.async_api.subscribed_message_payload import SubscribedMessagePayload
+from sdk.reya_websocket import ReyaSocket, WebSocketMessage
+
+logger = logging.getLogger("reya.integration_tests")
+
+
+class MarketDataRecorder:
+    """Records depth / orderChanges frames and close events from one connection.
+
+    Pass an ``address`` to subscribe to that wallet's ``orderChanges`` and/or a
+    ``symbol`` to subscribe to that market's ``depth``. ``connect()`` opens the
+    socket in a background thread; ``close()`` tears it down.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        address: Optional[str] = None,
+        symbol: Optional[str] = None,
+        subscribe_order_changes: bool = False,
+        subscribe_depth: bool = False,
+    ) -> None:
+        self._url = url
+        self._address = address
+        self._symbol = symbol
+        self._sub_order_changes = subscribe_order_changes
+        self._sub_depth = subscribe_depth
+
+        self._lock = threading.Lock()
+
+        # orderChanges: the subscribe snapshot, then each live update frame's data[].
+        self.order_changes_snapshot: Optional[OrderChangesSnapshot] = None
+        self.order_change_frames: list[list[AsyncOrder]] = []
+
+        # depth: the subscribe snapshot, then each live update frame (a Depth diff).
+        self.depth_snapshot: Optional[Depth] = None
+        self.depth_frames: list[Depth] = []
+
+        # Control-plane observations.
+        self.closes: list[tuple[Optional[int], Optional[str]]] = []
+        self.errors: list[str] = []
+        self.open_count = 0
+
+        self._socket = ReyaSocket(
+            url=url,
+            on_open=self._on_open,
+            on_message=self._on_message,
+            on_close=self._on_close,
+        )
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def connect(self) -> None:
+        self._socket.connect()
+
+    def close(self) -> None:
+        try:
+            self._socket.close()
+        except (OSError, RuntimeError) as exc:  # pragma: no cover - teardown best effort
+            logger.debug("recorder close ignored: %s", exc)
+
+    # -- callbacks (run on the websocket reader thread) --------------------
+
+    def _on_open(self, ws) -> None:
+        with self._lock:
+            self.open_count += 1
+        if self._sub_order_changes and self._address:
+            ws.wallet.order_changes(self._address).subscribe()
+        if self._sub_depth and self._symbol:
+            ws.market.depth(self._symbol).subscribe()
+
+    def _on_message(self, _ws, message: WebSocketMessage) -> None:
+        with self._lock:
+            if isinstance(message, OrderChangesSubscribedPayload):
+                self.order_changes_snapshot = message.contents
+            elif isinstance(message, SubscribedMessagePayload):
+                if "depth" in message.channel and message.contents:
+                    self.depth_snapshot = Depth.model_validate(message.contents)
+            elif isinstance(message, OrderChangeUpdatePayload):
+                self.order_change_frames.append(list(message.data))
+            elif isinstance(message, MarketDepthUpdatePayload):
+                self.depth_frames.append(message.data)
+            elif isinstance(message, ErrorMessagePayload):
+                self.errors.append(str(message.message))
+
+    def _on_close(self, _ws, code: Optional[int], reason: Optional[str]) -> None:
+        with self._lock:
+            self.closes.append((code, reason))
+        logger.info("recorder observed close: code=%s reason=%r", code, reason)
+
+    # -- snapshots for the test thread -------------------------------------
+
+    def order_change_events(self) -> list[AsyncOrder]:
+        """All live orderChanges events flattened in arrival order (across frames)."""
+        with self._lock:
+            return [order for frame in self.order_change_frames for order in frame]
+
+    def order_change_frame_sizes(self) -> list[int]:
+        with self._lock:
+            return [len(frame) for frame in self.order_change_frames]
+
+    def depth_updates(self) -> list[Depth]:
+        with self._lock:
+            return list(self.depth_frames)
+
+    def close_events(self) -> list[tuple[Optional[int], Optional[str]]]:
+        with self._lock:
+            return list(self.closes)
+
+    def has_close_code(self, code: int) -> bool:
+        with self._lock:
+            return any(c == code for c, _ in self.closes)
+
+    def order_changes_snapshot_orders(self) -> list[AsyncOrder]:
+        with self._lock:
+            if self.order_changes_snapshot is None:
+                return []
+            return list(self.order_changes_snapshot.data)
+
+    def depth_snapshot_copy(self) -> Optional[Depth]:
+        with self._lock:
+            return self.depth_snapshot

--- a/tests/market_data/md_ws_recorder.py
+++ b/tests/market_data/md_ws_recorder.py
@@ -20,8 +20,9 @@ recorded state is guarded by a lock and copied out for the asyncio test thread.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
+import json
 import logging
 import threading
 
@@ -71,6 +72,14 @@ class MarketDataRecorder:
         self.depth_snapshot: Optional[Depth] = None
         self.depth_frames: list[Depth] = []
 
+        # Raw wire frames (pre-Pydantic) captured off the same reader thread via the
+        # websocket-client ``on_data`` hook, which fires with the decoded text of every
+        # TEXT frame immediately before ``on_message`` parses it. Kept as the exact
+        # decoded JSON dicts so a test can assert on the literal wire strings (e.g. a
+        # decimal ``"0.617"`` never silently reformatted to ``"0.6170"`` or a float),
+        # independently of the typed Pydantic view.
+        self.raw_frames: list[dict[str, Any]] = []
+
         # Control-plane observations.
         self.closes: list[tuple[Optional[int], Optional[str]]] = []
         self.errors: list[str] = []
@@ -81,6 +90,7 @@ class MarketDataRecorder:
             on_open=self._on_open,
             on_message=self._on_message,
             on_close=self._on_close,
+            on_data=self._on_data,
         )
 
     # -- lifecycle ---------------------------------------------------------
@@ -117,6 +127,24 @@ class MarketDataRecorder:
                 self.depth_frames.append(message.data)
             elif isinstance(message, ErrorMessagePayload):
                 self.errors.append(str(message.message))
+
+    def _on_data(self, _ws, data: Any, _data_type: Any = None, _cont: Any = None) -> None:
+        # ``on_data`` sees TEXT and BINARY frames; only TEXT carries our JSON. Decode
+        # bytes defensively and skip anything that is not a JSON object.
+        if isinstance(data, (bytes, bytearray)):
+            try:
+                data = data.decode("utf-8")
+            except UnicodeDecodeError:
+                return
+        if not isinstance(data, str):
+            return
+        try:
+            frame = json.loads(data)
+        except (ValueError, TypeError):
+            return
+        if isinstance(frame, dict):
+            with self._lock:
+                self.raw_frames.append(frame)
 
     def _on_close(self, _ws, code: Optional[int], reason: Optional[str]) -> None:
         with self._lock:
@@ -155,3 +183,34 @@ class MarketDataRecorder:
     def depth_snapshot_copy(self) -> Optional[Depth]:
         with self._lock:
             return self.depth_snapshot
+
+    # -- raw wire accessors (pre-Pydantic) ---------------------------------
+
+    def raw_order_entries(self) -> list[dict[str, Any]]:
+        """Every raw order dict delivered on ``orderChanges`` channel_data frames,
+        flattened in arrival order (the literal wire objects, not Pydantic models)."""
+        with self._lock:
+            frames = list(self.raw_frames)
+        entries: list[dict[str, Any]] = []
+        for frame in frames:
+            if frame.get("type") == "channel_data" and str(frame.get("channel", "")).endswith("/orderChanges"):
+                data = frame.get("data")
+                if isinstance(data, list):
+                    entries.extend(item for item in data if isinstance(item, dict))
+        return entries
+
+    def raw_depth_update_levels(self, side: str) -> list[tuple[dict[str, Any], int]]:
+        """Raw ``{px, qty}`` level dicts for ``side`` ("bids"/"asks") across every
+        ``depth`` channel_data frame, each paired with its frame index so a test can
+        pick the latest wire statement for a price."""
+        with self._lock:
+            frames = list(enumerate(self.raw_frames))
+        levels: list[tuple[dict[str, Any], int]] = []
+        for index, frame in frames:
+            if frame.get("type") == "channel_data" and str(frame.get("channel", "")).endswith("/depth"):
+                data = frame.get("data")
+                if isinstance(data, dict):
+                    for level in data.get(side, []) or []:
+                        if isinstance(level, dict):
+                            levels.append((level, index))
+        return levels

--- a/tests/market_data/md_ws_recorder.py
+++ b/tests/market_data/md_ws_recorder.py
@@ -20,7 +20,7 @@ recorded state is guarded by a lock and copied out for the asyncio test thread.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import json
 import logging
@@ -51,8 +51,8 @@ class MarketDataRecorder:
         self,
         url: str,
         *,
-        address: Optional[str] = None,
-        symbol: Optional[str] = None,
+        address: str | None = None,
+        symbol: str | None = None,
         subscribe_order_changes: bool = False,
         subscribe_depth: bool = False,
     ) -> None:
@@ -65,11 +65,11 @@ class MarketDataRecorder:
         self._lock = threading.Lock()
 
         # orderChanges: the subscribe snapshot, then each live update frame's data[].
-        self.order_changes_snapshot: Optional[OrderChangesSnapshot] = None
+        self.order_changes_snapshot: OrderChangesSnapshot | None = None
         self.order_change_frames: list[list[AsyncOrder]] = []
 
         # depth: the subscribe snapshot, then each live update frame (a Depth diff).
-        self.depth_snapshot: Optional[Depth] = None
+        self.depth_snapshot: Depth | None = None
         self.depth_frames: list[Depth] = []
 
         # Raw wire frames (pre-Pydantic) captured off the same reader thread via the
@@ -81,7 +81,7 @@ class MarketDataRecorder:
         self.raw_frames: list[dict[str, Any]] = []
 
         # Control-plane observations.
-        self.closes: list[tuple[Optional[int], Optional[str]]] = []
+        self.closes: list[tuple[int | None, str | None]] = []
         self.errors: list[str] = []
         self.open_count = 0
 
@@ -146,7 +146,7 @@ class MarketDataRecorder:
             with self._lock:
                 self.raw_frames.append(frame)
 
-    def _on_close(self, _ws, code: Optional[int], reason: Optional[str]) -> None:
+    def _on_close(self, _ws, code: int | None, reason: str | None) -> None:
         with self._lock:
             self.closes.append((code, reason))
         logger.info("recorder observed close: code=%s reason=%r", code, reason)
@@ -166,7 +166,7 @@ class MarketDataRecorder:
         with self._lock:
             return list(self.depth_frames)
 
-    def close_events(self) -> list[tuple[Optional[int], Optional[str]]]:
+    def close_events(self) -> list[tuple[int | None, str | None]]:
         with self._lock:
             return list(self.closes)
 
@@ -180,7 +180,7 @@ class MarketDataRecorder:
                 return []
             return list(self.order_changes_snapshot.data)
 
-    def depth_snapshot_copy(self) -> Optional[Depth]:
+    def depth_snapshot_copy(self) -> Depth | None:
         with self._lock:
             return self.depth_snapshot
 

--- a/tests/market_data/poll.py
+++ b/tests/market_data/poll.py
@@ -1,0 +1,36 @@
+"""Async polling helper for the market-data tests.
+
+Market-data surfaces (WS frames, REST projections) settle asynchronously behind
+the ingest drain, so tests poll for a condition within a generous window rather
+than asserting on a fixed sleep (which flakes under full-suite load).
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable, Union
+
+import asyncio
+import inspect
+import time
+
+
+async def wait_until(
+    predicate: Callable[[], Union[bool, Awaitable[bool]]],
+    *,
+    timeout: float = 10.0,
+    interval: float = 0.1,
+) -> bool:
+    """Poll ``predicate`` until it is truthy or ``timeout`` elapses.
+
+    ``predicate`` may be sync or async. Returns whether it became true.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        result = predicate()
+        if inspect.isawaitable(result):
+            result = await result
+        if result:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(interval)

--- a/tests/market_data/poll.py
+++ b/tests/market_data/poll.py
@@ -7,15 +7,16 @@ than asserting on a fixed sleep (which flakes under full-suite load).
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable, Union
+from typing import Callable
 
 import asyncio
 import inspect
 import time
+from collections.abc import Awaitable
 
 
 async def wait_until(
-    predicate: Callable[[], Union[bool, Awaitable[bool]]],
+    predicate: Callable[[], bool | Awaitable[bool]],
     *,
     timeout: float = 10.0,
     interval: float = 0.1,

--- a/tests/market_data/test_cross_wallet_isolation.py
+++ b/tests/market_data/test_cross_wallet_isolation.py
@@ -1,0 +1,106 @@
+"""S3 — orderChanges is wallet-scoped: A's feed never carries B's orders.
+
+Subscribes to wallet A's ``walletOrderChanges`` and then acts on wallet B. A's
+feed must never surface B's order ids or B's account id — the channel is keyed by
+address and one wallet's activity must not leak into another's stream. The test is
+non-trivial in both directions: A also places its own order, so the feed is proven
+live (it delivers A's event) while B's concurrent activity stays absent throughout
+a bounded observation window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+import pytest
+
+from tests.helpers import ReyaTester
+from tests.helpers.builders import OrderBuilder
+from tests.helpers.market_config import SpotTestConfig
+from tests.market_data.md_ws_recorder import MarketDataRecorder
+from tests.market_data.poll import wait_until
+
+logger = logging.getLogger("reya.integration_tests")
+
+# Bounded window (seconds) to let any erroneously-leaked cross-wallet event land
+# after A's own event confirms the feed is live.
+_OBSERVE_SECONDS = 6.0
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_cross_wallet_isolation(spot_config: SpotTestConfig, maker_tester: ReyaTester, taker_tester: ReyaTester):
+    logger.info("=" * 80)
+    logger.info("S3 CROSS-WALLET ISOLATION (A subscribes, B acts): %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    wallet_a = maker_tester  # subscriber
+    wallet_b = taker_tester  # actor
+    address_a = wallet_a.owner_wallet_address
+    assert address_a is not None
+    assert wallet_a.account_id != wallet_b.account_id, "A and B must be distinct accounts"
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+
+    await wallet_a.orders.close_all(fail_if_none=False)
+    await wallet_b.orders.close_all(fail_if_none=False)
+
+    recorder = MarketDataRecorder(ws_url, address=address_a, subscribe_order_changes=True)
+    recorder.connect()
+    try:
+        assert await wait_until(
+            lambda: recorder.order_changes_snapshot is not None, timeout=15.0
+        ), "did not receive A's orderChanges snapshot"
+
+        # B rests orders at safe-no-match prices (same side as any A order, so they
+        # never cross — pure resting activity on B's own book).
+        b_created: set[str] = set()
+        for px in ["12.31", "12.43", "12.57"]:
+            params = OrderBuilder.from_config(spot_config).buy().price(px).gtc().build()
+            oid = await wallet_b.orders.create_limit(params)
+            assert oid, f"B create_limit returned no id for {px}"
+            b_created.add(oid)
+
+        # A places its own order — the feed must deliver THIS (proving it is live).
+        a_params = OrderBuilder.from_config(spot_config).buy().price("10.19").gtc().build()
+        a_id = await wallet_a.orders.create_limit(a_params)
+        assert a_id, "A create_limit returned no id"
+
+        assert await wait_until(
+            lambda: any(o.order_id == a_id for o in recorder.order_change_events()), timeout=15.0
+        ), "A's feed never delivered A's own order — subscription not live, isolation check would be vacuous"
+
+        # Cancel B's orders too (more B activity to potentially leak).
+        for oid in b_created:
+            await wallet_b.client.cancel_order(order_id=oid, symbol=symbol, account_id=wallet_b.account_id)
+
+        # Bounded observation: give any leaked B event time to arrive.
+        await asyncio.sleep(_OBSERVE_SECONDS)
+
+        events = recorder.order_change_events()
+        snapshot_ids = {o.order_id for o in recorder.order_changes_snapshot_orders()}
+        leaked_by_id = [o.order_id for o in events if o.order_id in b_created] + [
+            oid for oid in snapshot_ids if oid in b_created
+        ]
+        leaked_by_account = [o.order_id for o in events if o.account_id == wallet_b.account_id]
+        assert not leaked_by_id, f"A's feed leaked B's order ids: {leaked_by_id}"
+        assert not leaked_by_account, f"A's feed carried B's account_id {wallet_b.account_id}: {leaked_by_account}"
+
+        # Every event A did see belongs to A.
+        foreign_accounts = {o.account_id for o in events if o.account_id != wallet_a.account_id}
+        assert not foreign_accounts, f"A's feed carried foreign account ids: {foreign_accounts}"
+        logger.info(
+            "S3 PASS: A saw its own order and %d total events, none from B (account %s) over %.0fs",
+            len(events),
+            wallet_b.account_id,
+            _OBSERVE_SECONDS,
+        )
+    finally:
+        recorder.close()
+        await wallet_a.orders.close_all(fail_if_none=False)
+        await wallet_b.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_depth_continuity.py
+++ b/tests/market_data/test_depth_continuity.py
@@ -1,0 +1,140 @@
+"""T2 — depth continuity + ``?limit``.
+
+Subscribes to depth, captures the snapshot, then maintains a local book by
+applying absolute per-level diffs (``qty == "0"`` removes a level) as orders are
+placed and cancelled. Asserts:
+
+* the locally-maintained book converges to REST ``/depth`` (no param = full book),
+  proving snapshot + diffs are self-consistent and lossless, and
+* ``/depth?limit=1`` returns exactly the top level per side of that same book.
+
+The generated ``MarketDataApi.get_market_depth`` does not expose the ``limit``
+query param yet, so the top-N slice is exercised with a direct HTTP GET against
+the SDK's configured base URL (reported as an SDK regen gap, not worked around
+in library code).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from tests.helpers import ReyaTester
+from tests.helpers.builders import OrderBuilder
+from tests.helpers.market_config import SpotTestConfig
+from tests.market_data.local_book import LocalBook, depth_sides
+from tests.market_data.md_ws_recorder import MarketDataRecorder
+from tests.market_data.poll import wait_until
+
+logger = logging.getLogger("reya.integration_tests")
+
+
+def _build_local_book(recorder: MarketDataRecorder) -> LocalBook | None:
+    snapshot = recorder.depth_snapshot_copy()
+    if snapshot is None:
+        return None
+    book = LocalBook.from_snapshot(snapshot)
+    for frame in recorder.depth_updates():
+        book.apply(frame)
+    return book
+
+
+async def _fetch_depth_raw(base_url: str, symbol: str, limit: int | None = None) -> dict:
+    url = f"{base_url.rstrip('/')}/market/{symbol}/depth"
+    params = {"limit": str(limit)} if limit is not None else None
+    async with httpx.AsyncClient(timeout=10.0, verify=False) as client:
+        response = await client.get(url, params=params)
+        response.raise_for_status()
+        payload: dict = response.json()
+        return payload
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_depth_continuity(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    logger.info("=" * 80)
+    logger.info("T2 DEPTH CONTINUITY + LIMIT: %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+    recorder = MarketDataRecorder(ws_url, symbol=symbol, subscribe_depth=True)
+    recorder.connect()
+    try:
+        assert await wait_until(
+            lambda: recorder.depth_snapshot_copy() is not None, timeout=10.0
+        ), "did not receive depth subscribe snapshot"
+        snap = recorder.depth_snapshot_copy()
+        assert snap is not None
+        logger.info("Depth snapshot: %d bids, %d asks", len(snap.bids), len(snap.asks))
+
+        # Place two resting bids at distinct safe no-match prices, then remove one.
+        base = int(spot_config.get_safe_no_match_buy_price())
+        low_px, high_px = base, base + 2
+        low_params = OrderBuilder.from_config(spot_config).buy().price(str(low_px)).gtc().build()
+        high_params = OrderBuilder.from_config(spot_config).buy().price(str(high_px)).gtc().build()
+
+        low_id = await spot_tester.orders.create_limit(low_params)
+        high_id = await spot_tester.orders.create_limit(high_params)
+        assert low_id and high_id, "both bid creates must return order ids"
+        logger.info("Placed bids at %s and %s", low_px, high_px)
+
+        # Local book (snapshot + diffs) should reflect both new levels.
+        async def _both_bids_present() -> bool:
+            book = _build_local_book(recorder)
+            return book is not None and Decimal(low_px) in book.bids and Decimal(high_px) in book.bids
+
+        assert await wait_until(_both_bids_present, timeout=15.0), "depth diffs did not add both bid levels"
+
+        # Cancel the low bid -> expect an absolute qty-0 removal diff for that level.
+        await spot_tester.client.cancel_order(order_id=low_id, symbol=symbol, account_id=spot_tester.account_id)
+
+        async def _low_bid_removed() -> bool:
+            book = _build_local_book(recorder)
+            return book is not None and Decimal(low_px) not in book.bids and Decimal(high_px) in book.bids
+
+        assert await wait_until(_low_bid_removed, timeout=15.0), "qty-0 diff did not remove the cancelled bid level"
+        logger.info("qty-0 removal applied: low bid gone, high bid retained")
+
+        # Convergence: local book (snapshot + absolute diffs) == REST full book.
+        async def _converged() -> bool:
+            book = _build_local_book(recorder)
+            if book is None:
+                return False
+            rest = await spot_tester.data.market_depth(symbol)
+            rest_bids, rest_asks = depth_sides(rest)
+            return book.bids_sorted() == rest_bids and book.asks_sorted() == rest_asks
+
+        assert await wait_until(_converged, timeout=20.0), "locally-maintained book did not converge to REST /depth"
+        logger.info("Local book converged to REST full depth: OK")
+
+        # ?limit=1 == top level per side of the same (full) book.
+        base_url = spot_tester.client.config.api_url
+        full = await spot_tester.data.market_depth(symbol)
+        full_bids, full_asks = depth_sides(full)
+        limited = await _fetch_depth_raw(base_url, symbol, limit=1)
+        lim_bids = [(Decimal(b["px"]), Decimal(b["qty"])) for b in limited.get("bids", [])]
+        lim_asks = [(Decimal(a["px"]), Decimal(a["qty"])) for a in limited.get("asks", [])]
+
+        assert len(lim_bids) == min(1, len(full_bids)), f"limit=1 returned {len(lim_bids)} bids"
+        assert len(lim_asks) == min(1, len(full_asks)), f"limit=1 returned {len(lim_asks)} asks"
+        if full_bids:
+            assert lim_bids[0] == full_bids[0], f"limit=1 bid {lim_bids[0]} != top bid {full_bids[0]}"
+        if full_asks:
+            assert lim_asks[0] == full_asks[0], f"limit=1 ask {lim_asks[0]} != top ask {full_asks[0]}"
+
+        # No-param full book must be a superset of the top-1 slice.
+        assert len(full_bids) >= len(lim_bids) and len(full_asks) >= len(lim_asks)
+        logger.info("T2 PASS: convergence holds; limit=1 -> %d bid / %d ask top level(s)", len(lim_bids), len(lim_asks))
+    finally:
+        recorder.close()
+        await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_depth_continuity.py
+++ b/tests/market_data/test_depth_continuity.py
@@ -46,7 +46,7 @@ def _build_local_book(recorder: MarketDataRecorder) -> LocalBook | None:
 async def _fetch_depth_raw(base_url: str, symbol: str, limit: int | None = None) -> dict:
     url = f"{base_url.rstrip('/')}/market/{symbol}/depth"
     params = {"limit": str(limit)} if limit is not None else None
-    async with httpx.AsyncClient(timeout=10.0, verify=False) as client:
+    async with httpx.AsyncClient(timeout=10.0, verify=False) as client:  # nosec B501 — localnet self-signed TLS
         response = await client.get(url, params=params)
         response.raise_for_status()
         payload: dict = response.json()

--- a/tests/market_data/test_depth_continuity.py
+++ b/tests/market_data/test_depth_continuity.py
@@ -138,3 +138,143 @@ async def test_depth_continuity(spot_config: SpotTestConfig, spot_tester: ReyaTe
     finally:
         recorder.close()
         await spot_tester.orders.close_all(fail_if_none=False)
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_depth_residual_qty_on_partial_cancel(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    """S2a — cancelling ONE of two orders at the same price is an absolute qty
+    REDUCTION, not a qty-0 removal: the price level survives with the remaining
+    order's quantity, and the diff that changes it carries the reduced (positive)
+    qty. This is the residual-qty aggregation contract T2's single-order removal
+    can't exercise."""
+    logger.info("=" * 80)
+    logger.info("S2a DEPTH RESIDUAL-QTY (partial cancel keeps level): %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+    recorder = MarketDataRecorder(ws_url, symbol=symbol, subscribe_depth=True)
+    recorder.connect()
+    try:
+        assert await wait_until(
+            lambda: recorder.depth_snapshot_copy() is not None, timeout=10.0
+        ), "did not receive depth subscribe snapshot"
+
+        px = "10.13"
+        cancel_qty, keep_qty = "0.002", "0.003"
+        aggregate = Decimal(cancel_qty) + Decimal(keep_qty)  # 0.005
+        px_d = Decimal(px)
+
+        cancel_params = OrderBuilder.from_config(spot_config).buy().price(px).qty(cancel_qty).gtc().build()
+        keep_params = OrderBuilder.from_config(spot_config).buy().price(px).qty(keep_qty).gtc().build()
+        cancel_id = await spot_tester.orders.create_limit(cancel_params)
+        keep_id = await spot_tester.orders.create_limit(keep_params)
+        assert cancel_id and keep_id, "both same-price bids must be created"
+
+        # Level aggregates to cancel_qty + keep_qty.
+        async def _aggregated() -> bool:
+            book = _build_local_book(recorder)
+            return book is not None and book.bids.get(px_d) == aggregate
+
+        assert await wait_until(_aggregated, timeout=15.0), f"level {px} did not aggregate to {aggregate}"
+
+        frames_before_cancel = len(recorder.depth_updates())
+        await spot_tester.client.cancel_order(order_id=cancel_id, symbol=symbol, account_id=spot_tester.account_id)
+
+        # After the cancel the level must survive at exactly keep_qty (a reduction).
+        async def _reduced_not_removed() -> bool:
+            book = _build_local_book(recorder)
+            return book is not None and book.bids.get(px_d) == Decimal(keep_qty)
+
+        if not await wait_until(_reduced_not_removed, timeout=15.0):
+            settled_book = _build_local_book(recorder)
+            current_qty = settled_book.bids.get(px_d) if settled_book else None
+            raise AssertionError(f"level {px} did not settle to the residual {keep_qty}; current={current_qty}")
+
+        # The post-cancel diffs for this level are an absolute reduction to keep_qty,
+        # and NONE of them removed it (qty "0"): the level was reduced, never deleted.
+        post_cancel = recorder.depth_updates()[frames_before_cancel:]
+        seen_qtys = [lvl.qty for frame in post_cancel for lvl in frame.bids if Decimal(lvl.px) == px_d]
+        assert seen_qtys, f"no post-cancel depth diff mentioned level {px}"
+        assert keep_qty in seen_qtys, f"post-cancel diffs never stated the residual {keep_qty}: {seen_qtys}"
+        assert "0" not in seen_qtys and Decimal("0") not in [
+            Decimal(q) for q in seen_qtys
+        ], f"a post-cancel diff removed level {px} (qty 0) instead of reducing it: {seen_qtys}"
+
+        # REST agrees: the level is present with the residual qty.
+        rest = await spot_tester.data.market_depth(symbol)
+        rest_bids, _ = depth_sides(rest)
+        rest_level = next((qty for lvl_px, qty in rest_bids if lvl_px == px_d), None)
+        assert rest_level == Decimal(keep_qty), f"REST depth level {px} qty {rest_level} != residual {keep_qty}"
+        logger.info("S2a PASS: partial cancel reduced level %s to %s (survived, not qty-0)", px, keep_qty)
+    finally:
+        recorder.close()
+        await spot_tester.orders.close_all(fail_if_none=False)
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_depth_limit_truncation_both_sides(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    """S2b — ``?limit=1`` really truncates: with two bid levels and one ask level
+    resting, the top-1 slice returns exactly the best bid (EXCLUDING the second)
+    and the single ask, while the no-param book carries all of them."""
+    logger.info("=" * 80)
+    logger.info("S2b DEPTH ?limit=1 TRUNCATION (both sides): %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    # Two bid levels (best = higher px) + one ask level (safe-no-match high sell).
+    second_bid_px, best_bid_px = Decimal("10.13"), Decimal("11.17")
+    ask_px = Decimal("399999.87")  # below SAFE_NO_MATCH_SELL_PRICE (400000), never crosses
+    qty = "0.003"
+    for px, side_is_buy in [(second_bid_px, True), (best_bid_px, True), (ask_px, False)]:
+        params = OrderBuilder.from_config(spot_config).side(side_is_buy).price(str(px)).qty(qty).gtc().build()
+        oid = await spot_tester.orders.create_limit(params)
+        assert oid, f"create_limit returned no id for {'BUY' if side_is_buy else 'SELL'} {px}"
+
+    async def _book_ready() -> bool:
+        rest = await spot_tester.data.market_depth(symbol)
+        rest_bids, rest_asks = depth_sides(rest)
+        bid_pxs = {p for p, _ in rest_bids}
+        ask_pxs = {p for p, _ in rest_asks}
+        return {second_bid_px, best_bid_px}.issubset(bid_pxs) and ask_px in ask_pxs
+
+    assert await wait_until(_book_ready, timeout=20.0), "resting book did not reach 2 bids + 1 ask"
+
+    base_url = spot_tester.client.config.api_url
+    full = await spot_tester.data.market_depth(symbol)
+    full_bids, full_asks = depth_sides(full)
+
+    limited = await _fetch_depth_raw(base_url, symbol, limit=1)
+    lim_bids = [(Decimal(b["px"]), Decimal(b["qty"])) for b in limited.get("bids", [])]
+    lim_asks = [(Decimal(a["px"]), Decimal(a["qty"])) for a in limited.get("asks", [])]
+
+    # Exactly the best bid; the second-best is excluded.
+    assert len(lim_bids) == 1, f"limit=1 returned {len(lim_bids)} bids: {lim_bids}"
+    assert lim_bids[0][0] == best_bid_px, f"limit=1 top bid {lim_bids[0][0]} != best {best_bid_px}"
+    assert all(px != second_bid_px for px, _ in lim_bids), "limit=1 leaked the second-best bid level"
+    # The ask side is exercised too: exactly the single ask.
+    assert len(lim_asks) == 1, f"limit=1 returned {len(lim_asks)} asks: {lim_asks}"
+    assert lim_asks[0][0] == ask_px, f"limit=1 top ask {lim_asks[0][0]} != {ask_px}"
+
+    # The no-param full book is a superset: it retains the excluded second bid.
+    assert second_bid_px in {px for px, _ in full_bids}, "full book lost the second bid level"
+    assert best_bid_px in {px for px, _ in full_bids} and ask_px in {px for px, _ in full_asks}
+    logger.info(
+        "S2b PASS: limit=1 -> best bid %s (excluded %s), ask %s; full book kept all",
+        best_bid_px,
+        second_bid_px,
+        ask_px,
+    )
+    await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_order_changes_batching.py
+++ b/tests/market_data/test_order_changes_batching.py
@@ -17,6 +17,8 @@ import os
 
 import pytest
 
+from sdk.open_api.exceptions import ApiException
+from sdk.reya_rest_api.models import LimitOrderParameters
 from tests.helpers import ReyaTester
 from tests.helpers.builders import OrderBuilder
 from tests.helpers.market_config import SpotTestConfig
@@ -26,6 +28,30 @@ from tests.market_data.poll import wait_until
 logger = logging.getLogger("reya.integration_tests")
 
 BURST_N = 5
+FORCED_BURST_N = 10
+
+
+async def _nonce_safe_create(tester: ReyaTester, params: LimitOrderParameters, attempts: int = 12) -> str | None:
+    """Create a limit order, retrying ONLY the ME's per-wallet nonce-ordering
+    rejection.
+
+    Firing creates truly concurrently (``asyncio.gather``) is the point of S4, but
+    the matching engine requires each wallet's order nonces to ARRIVE strictly
+    increasing; racing HTTP sends therefore make some land out of order and bounce
+    with ``INVALID_NONCE_ERROR``. Each retry re-signs with a fresh (higher) nonce,
+    so the burst stays concurrent yet every order eventually lands. A little jitter
+    desynchronises retriers so the round converges.
+    """
+    for attempt in range(attempts):
+        try:
+            response = await tester.client.create_limit_order(params)
+            return response.order_id
+        except ApiException as exc:
+            if "INVALID_NONCE" in str(exc) and attempt < attempts - 1:
+                await asyncio.sleep(0.02 * (attempt + 1))
+                continue
+            raise
+    return None
 
 
 def _status(order) -> str:
@@ -142,6 +168,134 @@ async def test_order_changes_batching(spot_config: SpotTestConfig, spot_tester: 
         ), f"WS open set {ws_still_open} disagrees with REST {rest_final & created}"
         assert not (rest_final & created), f"REST still shows our orders open: {rest_final & created}"
         logger.info("T1 PASS: 2N=%d events delivered, ordered, REST/WS agree", 2 * BURST_N)
+    finally:
+        recorder.close()
+        await spot_tester.orders.close_all(fail_if_none=False)
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_order_changes_forced_batching(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    """S4 — forced batching: fire N creates CONCURRENTLY (no await between
+    submissions) to make the ingest drain group several order events into one
+    ``channel_data`` frame. Regardless of how the server batches, the stream stays
+    lossless and ordered: every OPEN arrives and ``sequenceNumber`` is strictly
+    increasing across the flattened arrival order. Multi-entry frames are LIKELY
+    but not guaranteed (batching is server-timing), so their occurrence is LOGGED,
+    not required. A same-wallet sequence-contiguity sub-assertion is attempted on
+    the quiet burst window and documented-and-skipped if background traffic (global
+    sequencing / other same-wallet activity) leaves gaps."""
+    logger.info("=" * 80)
+    logger.info("S4 FORCED BATCHING (concurrent burst of %d): %s", FORCED_BURST_N, spot_config.symbol)
+    logger.info("=" * 80)
+
+    address = spot_tester.owner_wallet_address
+    assert address is not None
+
+    await spot_tester.orders.close_all(fail_if_none=False)
+    await asyncio.sleep(0.3)
+
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+    recorder = MarketDataRecorder(ws_url, address=address, subscribe_order_changes=True)
+    recorder.connect()
+    try:
+        assert await wait_until(
+            lambda: recorder.order_changes_snapshot is not None, timeout=10.0
+        ), "did not receive orderChanges subscribe snapshot"
+
+        base = int(spot_config.get_safe_no_match_buy_price())
+        prices = [base + i for i in range(FORCED_BURST_N)]
+
+        # Fire ALL creates concurrently — no await between submissions. The ME's
+        # per-wallet nonce-arrival guard bounces racers with INVALID_NONCE, which
+        # _nonce_safe_create re-signs and re-fires; the burst stays concurrent and
+        # every order lands.
+        async def _create(price: int) -> str | None:
+            params = OrderBuilder.from_config(spot_config).buy().price(str(price)).gtc().build()
+            return await _nonce_safe_create(spot_tester, params)
+
+        results = await asyncio.gather(*(_create(p) for p in prices))
+        created = {oid for oid in results if oid}
+        assert len(created) == FORCED_BURST_N, f"expected {FORCED_BURST_N} distinct ids, got {sorted(created)}"
+        logger.info("Fired %d concurrent creates: %s", FORCED_BURST_N, sorted(created))
+
+        def _saw_open_for_all() -> bool:
+            seen = {o.order_id for o in recorder.order_change_events() if _status(o) == "OPEN"}
+            return created.issubset(seen)
+
+        assert await wait_until(_saw_open_for_all, timeout=20.0), (
+            "orderChanges did not deliver an OPEN for every concurrently-created order; "
+            f"missing {created - {o.order_id for o in recorder.order_change_events() if _status(o) == 'OPEN'}}"
+        )
+
+        # --- atomic mass_cancel: one call cancels all N, producing a burst of N
+        # CANCELLED events the outbound drain is very likely to group into a
+        # multi-entry frame. Snapshot the frame boundary first so we can scope the
+        # contiguity check to just this atomic burst.
+        frames_before_cancel = len(recorder.order_change_frame_sizes())
+        await spot_tester.client.mass_cancel(symbol=spot_config.symbol, account_id=spot_tester.account_id)
+
+        def _saw_cancel_for_all() -> bool:
+            seen = {o.order_id for o in recorder.order_change_events() if _status(o) == "CANCELLED"}
+            return created.issubset(seen)
+
+        assert await wait_until(_saw_cancel_for_all, timeout=20.0), "mass_cancel did not deliver every CANCELLED"
+
+        # Ordering: sequenceNumber strictly increasing + unique across flattened arrival.
+        events = recorder.order_change_events()
+        seqs = [o.sequence_number for o in events if o.sequence_number is not None]
+        assert seqs == sorted(seqs), f"sequenceNumber not monotonic across frames: {seqs}"
+        assert len(set(seqs)) == len(seqs), f"duplicate sequenceNumbers across frames: {seqs}"
+
+        # Losslessness: every one of the 2N lifecycle events for our orders is present.
+        our_events = [o for o in events if o.order_id in created]
+        opened = {o.order_id for o in our_events if _status(o) == "OPEN"}
+        cancelled = {o.order_id for o in our_events if _status(o) == "CANCELLED"}
+        assert opened == created, f"missing OPEN for {created - opened}"
+        assert cancelled == created, f"missing CANCELLED for {created - cancelled}"
+
+        # Batching is LIKELY (report, don't require) — expected on the mass_cancel burst.
+        frame_sizes = recorder.order_change_frame_sizes()
+        cancel_burst_sizes = frame_sizes[frames_before_cancel:]
+        multi_entry = [n for n in frame_sizes if n > 1]
+        logger.info(
+            "S4 frames=%d sizes=%s; cancel-burst frame sizes=%s; %d multi-entry frame(s) (max %d/frame) — batching %s",
+            len(frame_sizes),
+            frame_sizes,
+            cancel_burst_sizes,
+            len(multi_entry),
+            max(frame_sizes) if frame_sizes else 0,
+            "OBSERVED" if multi_entry else "not observed this run (tolerated)",
+        )
+
+        # Same-wallet contiguity on the ATOMIC mass_cancel burst: the ME assigns the
+        # N cancels consecutive sequence numbers, so on a quiet wallet window they are
+        # contiguous. Asserted when contiguous; documented-and-skipped if background /
+        # global sequencing left gaps (per S4 tolerance).
+        cancel_seqs = sorted(
+            o.sequence_number for o in our_events if _status(o) == "CANCELLED" and o.sequence_number is not None
+        )
+        assert len(cancel_seqs) == FORCED_BURST_N, f"expected {FORCED_BURST_N} CANCELLED seqs, got {cancel_seqs}"
+        if cancel_seqs[-1] - cancel_seqs[0] == FORCED_BURST_N - 1:
+            assert cancel_seqs == list(range(cancel_seqs[0], cancel_seqs[0] + FORCED_BURST_N)), cancel_seqs
+            logger.info("S4 contiguity: mass_cancel seqs %s are contiguous (quiet window) — asserted", cancel_seqs)
+        else:
+            logger.warning(
+                "S4 contiguity SKIPPED (documented): mass_cancel seqs %s span %d for %d events — background "
+                "same-wallet/global sequencing left gaps; contiguity not asserted to avoid flakiness",
+                cancel_seqs,
+                cancel_seqs[-1] - cancel_seqs[0] + 1,
+                FORCED_BURST_N,
+            )
+
+        rest_final = {o.order_id for o in await spot_tester.client.get_open_orders() if o.symbol == spot_config.symbol}
+        assert not (rest_final & created), f"REST still shows our orders open: {rest_final & created}"
+        logger.info(
+            "S4 PASS: %d concurrent creates + atomic mass_cancel lossless + ordered; batching reported", FORCED_BURST_N
+        )
     finally:
         recorder.close()
         await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_order_changes_batching.py
+++ b/tests/market_data/test_order_changes_batching.py
@@ -183,11 +183,13 @@ async def test_order_changes_forced_batching(spot_config: SpotTestConfig, spot_t
     submissions) to make the ingest drain group several order events into one
     ``channel_data`` frame. Regardless of how the server batches, the stream stays
     lossless and ordered: every OPEN arrives and ``sequenceNumber`` is strictly
-    increasing across the flattened arrival order. Multi-entry frames are LIKELY
-    but not guaranteed (batching is server-timing), so their occurrence is LOGGED,
-    not required. A same-wallet sequence-contiguity sub-assertion is attempted on
-    the quiet burst window and documented-and-skipped if background traffic (global
-    sequencing / other same-wallet activity) leaves gaps."""
+    increasing across the flattened arrival order. Because this variant *engineers*
+    the batching conditions (10 concurrent creates + an atomic mass_cancel that
+    emits N CANCELLED events in one drain), at least one multi-entry frame is
+    REQUIRED here — a regression that silently disabled batching (one event per
+    frame) must fail this test. A same-wallet sequence-contiguity sub-assertion is
+    attempted on the quiet burst window and documented-and-skipped if background
+    traffic (global sequencing / other same-wallet activity) leaves gaps."""
     logger.info("=" * 80)
     logger.info("S4 FORCED BATCHING (concurrent burst of %d): %s", FORCED_BURST_N, spot_config.symbol)
     logger.info("=" * 80)
@@ -257,7 +259,11 @@ async def test_order_changes_forced_batching(spot_config: SpotTestConfig, spot_t
         assert opened == created, f"missing OPEN for {created - opened}"
         assert cancelled == created, f"missing CANCELLED for {created - cancelled}"
 
-        # Batching is LIKELY (report, don't require) — expected on the mass_cancel burst.
+        # Batching is REQUIRED here: this variant engineers the conditions (10
+        # concurrent creates + an atomic mass_cancel emitting N CANCELLED in one
+        # drain), so at least one channel_data frame MUST carry >1 entry. Report
+        # the observed shape, then assert it — a silent regression to one event
+        # per frame (batching disabled) has to fail this test.
         frame_sizes = recorder.order_change_frame_sizes()
         cancel_burst_sizes = frame_sizes[frames_before_cancel:]
         multi_entry = [n for n in frame_sizes if n > 1]
@@ -268,7 +274,14 @@ async def test_order_changes_forced_batching(spot_config: SpotTestConfig, spot_t
             cancel_burst_sizes,
             len(multi_entry),
             max(frame_sizes) if frame_sizes else 0,
-            "OBSERVED" if multi_entry else "not observed this run (tolerated)",
+            "OBSERVED" if multi_entry else "NOT observed",
+        )
+        assert frame_sizes, "no orderChanges frames recorded, cannot assert batching"
+        assert max(frame_sizes) > 1, (
+            f"forced batching produced no multi-event frame (max entries/frame={max(frame_sizes)}): "
+            f"{FORCED_BURST_N} concurrent creates + an atomic mass_cancel should coalesce into at least "
+            f"one channel_data frame carrying >1 entry, but every frame held exactly one event "
+            f"(sizes={frame_sizes}) — batching may have silently regressed to one event per frame"
         )
 
         # Same-wallet contiguity on the ATOMIC mass_cancel burst: the ME assigns the

--- a/tests/market_data/test_order_changes_batching.py
+++ b/tests/market_data/test_order_changes_batching.py
@@ -1,0 +1,147 @@
+"""T1 — orderChanges batch shape.
+
+Bursts N rapid create+cancel pairs on one wallet and asserts the orderChanges
+WS stream is lossless and correctly ordered *regardless of frame batching*:
+one ``channel_data`` frame may carry several entries in ``data[]`` (grouped per
+ingest drain), so the test tolerates any frame size but requires that
+
+* every one of the 2N lifecycle events (N opens, N cancels) is delivered,
+* ``sequenceNumber`` is strictly increasing across the flattened arrival order
+  (ordering preserved *within and across* frames), and
+* the final WS-derived open set equals REST ``openOrders``.
+"""
+
+import asyncio
+import logging
+import os
+
+import pytest
+
+from tests.helpers import ReyaTester
+from tests.helpers.builders import OrderBuilder
+from tests.helpers.market_config import SpotTestConfig
+from tests.market_data.md_ws_recorder import MarketDataRecorder
+from tests.market_data.poll import wait_until
+
+logger = logging.getLogger("reya.integration_tests")
+
+BURST_N = 5
+
+
+def _status(order) -> str:
+    status = order.status
+    return status.value if hasattr(status, "value") else str(status)
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_order_changes_batching(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    logger.info("=" * 80)
+    logger.info("T1 ORDER CHANGES BATCHING: %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    address = spot_tester.owner_wallet_address
+    assert address is not None, "spot tester must have an owner wallet address"
+
+    # Start from a clean book so the pre-burst snapshot is unambiguous.
+    await spot_tester.orders.close_all(fail_if_none=False)
+    await asyncio.sleep(0.3)
+
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+    recorder = MarketDataRecorder(ws_url, address=address, subscribe_order_changes=True)
+    recorder.connect()
+    try:
+        got_snapshot = await wait_until(lambda: recorder.order_changes_snapshot is not None, timeout=10.0)
+        assert got_snapshot, "did not receive orderChanges subscribe snapshot"
+        logger.info(
+            "Subscribed; snapshot has %d resting order(s)",
+            len(recorder.order_changes_snapshot_orders()),
+        )
+
+        # --- burst N creates (distinct safe no-match bid prices, all rest) ---
+        base = int(spot_config.get_safe_no_match_buy_price())
+        prices = [base + i for i in range(BURST_N)]
+        created_ids: list[str] = []
+        for price in prices:
+            params = OrderBuilder.from_config(spot_config).buy().price(str(price)).gtc().build()
+            order_id = await spot_tester.orders.create_limit(params)
+            assert order_id is not None, "create_limit returned no order_id"
+            created_ids.append(order_id)
+        created = set(created_ids)
+        logger.info("Created %d orders: %s", len(created_ids), created_ids)
+
+        def _saw_open_for_all() -> bool:
+            seen = {o.order_id for o in recorder.order_change_events() if _status(o) == "OPEN"}
+            return created.issubset(seen)
+
+        assert await wait_until(_saw_open_for_all, timeout=15.0), (
+            "orderChanges did not deliver an OPEN for every created order; "
+            f"saw {sorted({o.order_id for o in recorder.order_change_events()})}"
+        )
+
+        # WS-derived open set == REST openOrders at the peak.
+        rest_open = {o.order_id for o in await spot_tester.client.get_open_orders() if o.symbol == spot_config.symbol}
+        assert created.issubset(rest_open), f"REST openOrders missing some created: {created - rest_open}"
+
+        # --- burst N cancels ---
+        for order_id in created_ids:
+            await spot_tester.client.cancel_order(
+                order_id=order_id, symbol=spot_config.symbol, account_id=spot_tester.account_id
+            )
+
+        def _saw_cancel_for_all() -> bool:
+            seen = {o.order_id for o in recorder.order_change_events() if _status(o) == "CANCELLED"}
+            return created.issubset(seen)
+
+        assert await wait_until(
+            _saw_cancel_for_all, timeout=15.0
+        ), "orderChanges did not deliver a CANCELLED for every cancelled order"
+
+        # ---- assertions on the recorded stream ----
+        events = recorder.order_change_events()
+        our_events = [o for o in events if o.order_id in created]
+        opened = {o.order_id for o in our_events if _status(o) == "OPEN"}
+        cancelled = {o.order_id for o in our_events if _status(o) == "CANCELLED"}
+
+        assert opened == created, f"missing OPEN events for {created - opened}"
+        assert cancelled == created, f"missing CANCELLED events for {created - cancelled}"
+        assert (
+            len(our_events) >= 2 * BURST_N
+        ), f"expected >= {2 * BURST_N} lifecycle events for our orders, got {len(our_events)}"
+
+        # Batching is tolerated, not required: report the observed frame shape.
+        frame_sizes = recorder.order_change_frame_sizes()
+        batched_frames = [n for n in frame_sizes if n > 1]
+        logger.info(
+            "orderChanges frames=%d sizes=%s; %d frame(s) carried >1 event (batching %s)",
+            len(frame_sizes),
+            frame_sizes,
+            len(batched_frames),
+            "observed" if batched_frames else "not observed this run",
+        )
+
+        # Ordering preserved within and across frames: sequenceNumber strictly
+        # increases along the flattened arrival order.
+        seqs = [o.sequence_number for o in events if o.sequence_number is not None]
+        assert seqs == sorted(seqs), f"sequenceNumber not monotonic across frames: {seqs}"
+        assert len(set(seqs)) == len(seqs), f"duplicate sequenceNumbers across frames: {seqs}"
+        logger.info("sequenceNumbers strictly increasing across %d frames: OK", len(frame_sizes))
+
+        # Final WS-derived open set == REST openOrders (both empty after cancels).
+        latest_status: dict[str, str] = {}
+        for o in events:
+            if o.order_id in created:
+                latest_status[o.order_id] = _status(o)
+        ws_still_open = {oid for oid, st in latest_status.items() if st == "OPEN"}
+        rest_final = {o.order_id for o in await spot_tester.client.get_open_orders() if o.symbol == spot_config.symbol}
+        assert ws_still_open == (
+            rest_final & created
+        ), f"WS open set {ws_still_open} disagrees with REST {rest_final & created}"
+        assert not (rest_final & created), f"REST still shows our orders open: {rest_final & created}"
+        logger.info("T1 PASS: 2N=%d events delivered, ordered, REST/WS agree", 2 * BURST_N)
+    finally:
+        recorder.close()
+        await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_precision_roundtrip.py
+++ b/tests/market_data/test_precision_roundtrip.py
@@ -30,7 +30,7 @@ tick/step constraint.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import logging
 import os
@@ -60,23 +60,23 @@ AGG_QTY_SUM = "0.3"  # NOT "0.30000000000000004": aggregation must be exact.
 
 
 async def _fetch_json(url: str) -> Any:
-    async with httpx.AsyncClient(timeout=10.0, verify=False) as client:
+    async with httpx.AsyncClient(timeout=10.0, verify=False) as client:  # nosec B501 — localnet self-signed TLS
         response = await client.get(url)
         response.raise_for_status()
         return response.json()
 
 
-def _raw_order_entry(recorder: MarketDataRecorder, order_id: str) -> Optional[dict[str, Any]]:
+def _raw_order_entry(recorder: MarketDataRecorder, order_id: str) -> dict[str, Any] | None:
     for entry in recorder.raw_order_entries():
         if entry.get("orderId") == order_id:
             return entry
     return None
 
 
-def _latest_raw_bid_level(recorder: MarketDataRecorder, px: str) -> Optional[dict[str, Any]]:
+def _latest_raw_bid_level(recorder: MarketDataRecorder, px: str) -> dict[str, Any] | None:
     """Latest raw wire bid-level dict for ``px`` (highest frame index wins, since
     depth updates are absolute per-level statements)."""
-    best: Optional[dict[str, Any]] = None
+    best: dict[str, Any] | None = None
     best_index = -1
     for level, index in recorder.raw_depth_update_levels("bids"):
         if level.get("px") == px and index > best_index:
@@ -84,7 +84,7 @@ def _latest_raw_bid_level(recorder: MarketDataRecorder, px: str) -> Optional[dic
     return best
 
 
-def _typed_order_event(recorder: MarketDataRecorder, order_id: str) -> Optional[AsyncOrder]:
+def _typed_order_event(recorder: MarketDataRecorder, order_id: str) -> AsyncOrder | None:
     matches = [o for o in recorder.order_change_events() if o.order_id == order_id]
     return matches[-1] if matches else None
 

--- a/tests/market_data/test_precision_roundtrip.py
+++ b/tests/market_data/test_precision_roundtrip.py
@@ -1,0 +1,206 @@
+"""M1 — decimal-string precision round-trip (no float coercion in the model path).
+
+A price/quantity is an exact decimal all the way through the stack: the wire
+carries a decimal *string* and the SDK Pydantic models keep it a ``str``. This
+test proves the SDK never round-trips a px/qty through a binary float (which
+would turn ``"0.617"`` into ``"0.6170000000000001"`` or ``"0.617"`` via a
+non-shortest formatter, and would make ``0.1 + 0.2`` aggregate to
+``"0.30000000000000004"``).
+
+It asserts on TWO independent views of the same value:
+
+* the **raw wire string** the recorder captured off the socket (pre-Pydantic,
+  via the ``on_data`` hook), and
+* the **parsed model** attribute (``Order.limit_px`` / ``Order.qty`` /
+  ``Level.px`` / ``Level.qty``),
+
+for BOTH the ``depth`` level and the ``orderChanges`` order, plus the REST
+``openOrders`` / ``depth`` projections.
+
+Precision note (softened vs. the audit's literal ``2500.123456789`` example):
+the localnet spot market ``WETHRUSD`` enforces ``tickSize=0.01`` /
+``qtyStepSize=0.001`` — the matching engine rejects any sub-tick / sub-step
+value with HTTP 400, so a 9-decimal order is not placeable. The test therefore
+uses the finest fractional px/qty the market admits (2 px decimals, 3 qty
+decimals) at deliberately non-round values, and additionally exercises the
+float-hostile **aggregation** path (``0.1 + 0.2`` must aggregate to exactly
+``"0.3"``), which is the sharpest float-coercion probe available under the
+tick/step constraint.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import logging
+import os
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from sdk.async_api.order import Order as AsyncOrder
+from tests.helpers import ReyaTester
+from tests.helpers.builders import OrderBuilder
+from tests.helpers.market_config import SpotTestConfig
+from tests.market_data.md_ws_recorder import MarketDataRecorder
+from tests.market_data.poll import wait_until
+
+logger = logging.getLogger("reya.integration_tests")
+
+# Finest fractional values WETHRUSD (tick 0.01 / step 0.001) admits, chosen
+# non-round so any reformatting is visible. Distinct prices per scenario so the
+# depth levels never collide.
+ROUNDTRIP_PX = "10.13"
+ROUNDTRIP_QTY = "0.617"
+AGG_PX = "11.24"
+AGG_QTY_A = "0.1"
+AGG_QTY_B = "0.2"
+AGG_QTY_SUM = "0.3"  # NOT "0.30000000000000004": aggregation must be exact.
+
+
+async def _fetch_json(url: str) -> Any:
+    async with httpx.AsyncClient(timeout=10.0, verify=False) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+
+def _raw_order_entry(recorder: MarketDataRecorder, order_id: str) -> Optional[dict[str, Any]]:
+    for entry in recorder.raw_order_entries():
+        if entry.get("orderId") == order_id:
+            return entry
+    return None
+
+
+def _latest_raw_bid_level(recorder: MarketDataRecorder, px: str) -> Optional[dict[str, Any]]:
+    """Latest raw wire bid-level dict for ``px`` (highest frame index wins, since
+    depth updates are absolute per-level statements)."""
+    best: Optional[dict[str, Any]] = None
+    best_index = -1
+    for level, index in recorder.raw_depth_update_levels("bids"):
+        if level.get("px") == px and index > best_index:
+            best, best_index = level, index
+    return best
+
+
+def _typed_order_event(recorder: MarketDataRecorder, order_id: str) -> Optional[AsyncOrder]:
+    matches = [o for o in recorder.order_change_events() if o.order_id == order_id]
+    return matches[-1] if matches else None
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_precision_roundtrip(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    logger.info("=" * 80)
+    logger.info("M1 DECIMAL PRECISION ROUND-TRIP: %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    address = spot_tester.owner_wallet_address
+    assert address is not None
+    base_url = spot_tester.client.config.api_url
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    recorder = MarketDataRecorder(
+        ws_url, address=address, symbol=symbol, subscribe_order_changes=True, subscribe_depth=True
+    )
+    recorder.connect()
+    try:
+        assert await wait_until(
+            lambda: recorder.order_changes_snapshot is not None and recorder.depth_snapshot_copy() is not None,
+            timeout=15.0,
+        ), "did not receive both subscribe snapshots"
+
+        # ---- Scenario A: single-order exact round-trip -------------------
+        params = OrderBuilder.from_config(spot_config).buy().price(ROUNDTRIP_PX).qty(ROUNDTRIP_QTY).gtc().build()
+        order_id = await spot_tester.orders.create_limit(params)
+        assert order_id, "create_limit returned no order_id"
+
+        assert await wait_until(
+            lambda: _typed_order_event(recorder, order_id) is not None
+            and any(o.status.value == "OPEN" for o in recorder.order_change_events() if o.order_id == order_id),
+            timeout=15.0,
+        ), "orderChanges OPEN for the precision order never arrived"
+
+        # orderChanges — parsed model keeps the exact decimal string (as a str).
+        typed_order = _typed_order_event(recorder, order_id)
+        assert typed_order is not None
+        assert isinstance(typed_order.limit_px, str) and isinstance(typed_order.qty, str), "px/qty are not str"
+        assert typed_order.limit_px == ROUNDTRIP_PX, f"parsed limitPx {typed_order.limit_px!r} != {ROUNDTRIP_PX!r}"
+        assert typed_order.qty == ROUNDTRIP_QTY, f"parsed qty {typed_order.qty!r} != {ROUNDTRIP_QTY!r}"
+
+        # orderChanges — raw wire string (pre-Pydantic).
+        raw_order = _raw_order_entry(recorder, order_id)
+        assert raw_order is not None, "recorder captured no raw orderChanges entry for the order"
+        assert raw_order.get("limitPx") == ROUNDTRIP_PX, f"raw wire limitPx {raw_order.get('limitPx')!r}"
+        assert raw_order.get("qty") == ROUNDTRIP_QTY, f"raw wire qty {raw_order.get('qty')!r}"
+        logger.info("orderChanges px/qty exact on raw wire AND parsed model: %s / %s", ROUNDTRIP_PX, ROUNDTRIP_QTY)
+
+        # depth — level shows the exact decimal on both views.
+        assert await wait_until(
+            lambda: _latest_raw_bid_level(recorder, ROUNDTRIP_PX) is not None, timeout=15.0
+        ), "depth update for the precision bid never arrived"
+        raw_level = _latest_raw_bid_level(recorder, ROUNDTRIP_PX)
+        assert raw_level is not None
+        assert raw_level.get("px") == ROUNDTRIP_PX, f"raw wire depth px {raw_level.get('px')!r}"
+        assert raw_level.get("qty") == ROUNDTRIP_QTY, f"raw wire depth qty {raw_level.get('qty')!r}"
+
+        typed_level = next(
+            (lvl for frame in recorder.depth_updates() for lvl in frame.bids if lvl.px == ROUNDTRIP_PX),
+            None,
+        )
+        assert typed_level is not None, "parsed depth level for the precision bid not found"
+        assert isinstance(typed_level.px, str) and isinstance(typed_level.qty, str)
+        assert typed_level.px == ROUNDTRIP_PX and typed_level.qty == ROUNDTRIP_QTY
+        logger.info("depth px/qty exact on raw wire AND parsed model: %s / %s", ROUNDTRIP_PX, ROUNDTRIP_QTY)
+
+        # REST projections carry the same exact decimal string.
+        rest_open = await _fetch_json(f"{base_url.rstrip('/')}/wallet/{address}/openOrders")
+        rest_orders = rest_open if isinstance(rest_open, list) else rest_open.get("data", [])
+        rest_order = next((o for o in rest_orders if o.get("orderId") == order_id), None)
+        assert rest_order is not None, "REST openOrders missing the precision order"
+        assert (
+            rest_order.get("limitPx") == ROUNDTRIP_PX and rest_order.get("qty") == ROUNDTRIP_QTY
+        ), f"REST openOrders px/qty {rest_order.get('limitPx')!r}/{rest_order.get('qty')!r}"
+        rest_depth = await _fetch_json(f"{base_url.rstrip('/')}/market/{symbol}/depth")
+        rest_bid = next((b for b in (rest_depth.get("bids") or []) if b.get("px") == ROUNDTRIP_PX), None)
+        assert rest_bid is not None and rest_bid.get("qty") == ROUNDTRIP_QTY, f"REST depth bid {rest_bid!r}"
+        logger.info("REST openOrders + depth agree exactly: OK")
+
+        # ---- Scenario B: float-hostile aggregation (0.1 + 0.2 == 0.3) ----
+        agg_a = OrderBuilder.from_config(spot_config).buy().price(AGG_PX).qty(AGG_QTY_A).gtc().build()
+        agg_b = OrderBuilder.from_config(spot_config).buy().price(AGG_PX).qty(AGG_QTY_B).gtc().build()
+        id_a = await spot_tester.orders.create_limit(agg_a)
+        id_b = await spot_tester.orders.create_limit(agg_b)
+        assert id_a and id_b, "both aggregation orders must be created"
+
+        async def _agg_level_settled() -> bool:
+            level = _latest_raw_bid_level(recorder, AGG_PX)
+            return level is not None and level.get("qty") == AGG_QTY_SUM
+
+        assert await wait_until(_agg_level_settled, timeout=15.0), (
+            "aggregated depth qty at "
+            f"{AGG_PX} never settled to the exact {AGG_QTY_SUM!r} "
+            f"(latest raw level: {_latest_raw_bid_level(recorder, AGG_PX)!r}) — float coercion in aggregation?"
+        )
+        agg_raw = _latest_raw_bid_level(recorder, AGG_PX)
+        assert agg_raw is not None and agg_raw.get("qty") == AGG_QTY_SUM
+        # A float sum of 0.1 + 0.2 would serialize as "0.30000000000000004".
+        assert "0000000" not in str(agg_raw.get("qty")), f"aggregated qty looks float-derived: {agg_raw.get('qty')!r}"
+
+        rest_depth2 = await _fetch_json(f"{base_url.rstrip('/')}/market/{symbol}/depth")
+        rest_agg = next((b for b in (rest_depth2.get("bids") or []) if b.get("px") == AGG_PX), None)
+        assert rest_agg is not None and rest_agg.get("qty") == AGG_QTY_SUM, f"REST aggregated qty {rest_agg!r}"
+        assert Decimal(str(rest_agg.get("qty"))) == Decimal(AGG_QTY_SUM)
+        logger.info(
+            "M1 PASS: exact decimal round-trip on wire+model+REST; 0.1+0.2 aggregates to exactly %s", AGG_QTY_SUM
+        )
+    finally:
+        recorder.close()
+        await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_resync_close.py
+++ b/tests/market_data/test_resync_close.py
@@ -277,3 +277,157 @@ async def test_resync_close(spot_config: SpotTestConfig, spot_tester: ReyaTester
     finally:
         fresh.close()
         await spot_tester.orders.close_all(fail_if_none=False)
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_resync_excludes_phantom_order(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    """M2 (T3 sibling) — a resync must NOT resurrect an order cancelled during the
+    reconnect window.
+
+    The dangerous failure mode of a feed reset is a *phantom* order: order A is
+    resting when the feed drops, A is cancelled while the client is disconnected
+    (before it resubscribes), and the fresh snapshot then re-delivers the stale A
+    as though it were still open. Sequence:
+
+    1. rest order A; subscribe → snapshot contains A,
+    2. restart the ME and wait for its write path to recover,
+    3. while the stateful WS is disconnected / not yet resubscribed, cancel A
+       (the ME is up, so the cancel lands),
+    4. reconnect + resubscribe → the fresh snapshot must EXCLUDE A and no
+       subsequent diff may re-open it, and
+    5. REST ``openOrders`` must agree.
+
+    Gated like T3 (needs ``LOCALNET_KUBECONFIG`` + kubectl) so it only ever bounces
+    a localnet stack this run owns.
+    """
+    kubeconfig = _kubeconfig()
+    if not kubeconfig or shutil.which("kubectl") is None:
+        pytest.skip(
+            "M2 needs LOCALNET_KUBECONFIG + kubectl to restart the matching engine; "
+            "opt-in so it never bounces a shared/remote stack."
+        )
+
+    logger.info("=" * 80)
+    logger.info("M2 RESYNC PHANTOM-ORDER EXCLUSION: %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    address = spot_tester.owner_wallet_address
+    assert address is not None
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    # (1) rest order A at a distinct safe-no-match price and subscribe.
+    phantom_px = int(spot_config.get_safe_no_match_buy_price()) + 5
+    phantom_params = OrderBuilder.from_config(spot_config).buy().price(str(phantom_px)).gtc().build()
+    phantom_id = await spot_tester.orders.create_limit(phantom_params)
+    assert phantom_id, "phantom order A must be created"
+
+    recorder = MarketDataRecorder(ws_url, address=address, symbol=symbol, subscribe_order_changes=True)
+    recorder.connect()
+    try:
+        assert await wait_until(
+            lambda: recorder.order_changes_snapshot is not None
+            and any(o.order_id == phantom_id for o in recorder.order_changes_snapshot_orders()),
+            timeout=15.0,
+        ), "subscribe snapshot did not contain order A before the restart"
+        logger.info("snapshot contains phantom order A=%s", phantom_id)
+
+        # (2) bounce the ME.
+        await asyncio.to_thread(_restart_matching_engine, kubeconfig)
+
+        # The stateful feed should signal the reset (1012 close or inline FEED_RESET).
+        got_signal = await wait_until(
+            lambda: recorder.has_close_code(1012) or _feed_reset_seen(recorder), timeout=180.0, interval=0.5
+        )
+        logger.info("post-restart resync signal observed=%s closes=%s", got_signal, recorder.close_events())
+    finally:
+        # Ensure the stateful subscription is fully torn down BEFORE we cancel A, so
+        # the cancel truly happens in the disconnected window.
+        recorder.close()
+
+    # (3) wait for the ME write path, then cancel A while nothing is subscribed.
+    assert await _wait_for_me_stable(spot_tester, spot_config), (
+        "matching engine did not resume serving writes after restart within budget "
+        "(localnet Finding-B snapshot-GET race — ping e2e-localnet to bounce it)"
+    )
+
+    reseeded = any(o.order_id == phantom_id for o in await spot_tester.client.get_open_orders())
+    logger.info("order A %s the ME restart (reseeded=%s)", "survived" if reseeded else "did not survive", reseeded)
+
+    async def _cancel_phantom() -> bool:
+        try:
+            await spot_tester.client.cancel_order(order_id=phantom_id, symbol=symbol, account_id=spot_tester.account_id)
+            return True
+        except ApiException as exc:
+            # If A was not reseeded it is already gone — the exclusion contract still
+            # holds; a "not found" cancel is an acceptable no-op here.
+            if not reseeded:
+                logger.info("cancel of A skipped (already absent post-restart): %s", type(exc).__name__)
+                return True
+            return False
+
+    assert await wait_until(_cancel_phantom, timeout=60.0, interval=2.0), "could not cancel order A during the window"
+
+    # REST must no longer show A (cancel landed / A never came back).
+    async def _rest_excludes_a() -> bool:
+        return all(o.order_id != phantom_id for o in await spot_tester.client.get_open_orders())
+
+    assert await wait_until(_rest_excludes_a, timeout=30.0), "REST openOrders still shows the cancelled order A"
+
+    # (4) reconnect + resubscribe: the fresh snapshot must EXCLUDE A.
+    fresh = MarketDataRecorder(ws_url, address=address, symbol=symbol, subscribe_order_changes=True)
+    fresh.connect()
+    try:
+        assert await wait_until(
+            lambda: fresh.order_changes_snapshot is not None, timeout=30.0
+        ), "did not receive fresh orderChanges snapshot after reconnect"
+
+        snap_ids = {o.order_id for o in fresh.order_changes_snapshot_orders()}
+        assert phantom_id not in snap_ids, f"PHANTOM: fresh snapshot re-delivered the cancelled order A ({phantom_id})"
+        logger.info("fresh snapshot correctly EXCLUDES cancelled order A; snapshot ids=%s", sorted(snap_ids))
+
+        # (5) prove the feed is live and A never gets re-opened by a later diff:
+        # place a fresh order C, confirm C arrives, and assert A never appears OPEN.
+        probe_px = int(spot_config.get_safe_no_match_buy_price()) + 9
+        probe_params = OrderBuilder.from_config(spot_config).buy().price(str(probe_px)).gtc().build()
+        probe_holder: dict[str, str] = {}
+
+        async def _place_probe() -> bool:
+            try:
+                oid = await spot_tester.orders.create_limit(probe_params)
+            except (ApiException, OSError, RuntimeError):
+                return False
+            if oid:
+                probe_holder["id"] = oid
+                return True
+            return False
+
+        assert await wait_until(_place_probe, timeout=60.0, interval=2.0), "could not place live-feed probe order C"
+        probe_id = probe_holder["id"]
+
+        assert await wait_until(
+            lambda: any(o.order_id == probe_id for o in fresh.order_change_events()), timeout=20.0
+        ), "fresh feed never delivered probe order C — cannot prove A absence is non-vacuous"
+
+        # A must NEVER surface as OPEN on the fresh feed (snapshot or any diff).
+        a_reopened = [
+            o
+            for o in fresh.order_change_events()
+            if o.order_id == phantom_id and (o.status.value if hasattr(o.status, "value") else str(o.status)) == "OPEN"
+        ]
+        assert not a_reopened, f"PHANTOM: a post-resync diff re-opened the cancelled order A: {phantom_id}"
+
+        # And REST still agrees A is gone.
+        assert all(
+            o.order_id != phantom_id for o in await spot_tester.client.get_open_orders()
+        ), "REST openOrders re-listed the cancelled order A"
+        logger.info("M2 PASS: cancelled order A excluded from fresh snapshot + all diffs; REST agrees")
+    finally:
+        fresh.close()
+        await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_resync_close.py
+++ b/tests/market_data/test_resync_close.py
@@ -216,7 +216,7 @@ async def test_resync_close(spot_config: SpotTestConfig, spot_tester: ReyaTester
         )
 
         if recorder.has_close_code(1012):
-            code, reason = next((c, r) for c, r in closes if c == 1012)
+            reason = next(r for c, r in closes if c == 1012)
             reason_l = (reason or "").lower()
             assert (
                 reason is None or "resync" in reason_l or "reset" in reason_l

--- a/tests/market_data/test_resync_close.py
+++ b/tests/market_data/test_resync_close.py
@@ -1,0 +1,279 @@
+"""T3 — matching-engine resync (1012) close handling.
+
+With live depth + orderChanges subscriptions, restarts the matching engine the
+way the localnet infra does (``kubectl rollout restart`` against the k3d stack,
+following the existing ``tests/helpers/localnet_fee_v3.py`` kubectl pattern) and
+asserts the resync contract:
+
+* the market-data feed signals a reset — via a **1012** close on the stateful
+  channels ("feed resync … (reset)") and/or the API-layer **FEED_RESET** path
+  documented on ``Order.cancelReason`` (resting orders re-delivered as CANCELLED
+  then re-published),
+* after reconnect+resubscribe the fresh snapshots are internally consistent
+  (orderChanges snapshot == REST openOrders; depth snapshot == REST depth), and
+* subsequent diffs resume on the fresh connection.
+
+Requires ``LOCALNET_KUBECONFIG`` (skip-by-default otherwise): only a localnet run
+that owns the stack should bounce the ME, so this stays opt-in and never fires
+against a shared/remote deployment. The test records which resync mechanism the
+live stack actually used and asserts on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import subprocess  # nosec B404
+import time
+
+import pytest
+
+from sdk.open_api.exceptions import ApiException
+from tests.helpers import ReyaTester
+from tests.helpers.builders import OrderBuilder
+from tests.helpers.market_config import SpotTestConfig
+from tests.market_data.local_book import LocalBook, depth_sides
+from tests.market_data.md_ws_recorder import MarketDataRecorder
+from tests.market_data.poll import wait_until
+
+logger = logging.getLogger("reya.integration_tests")
+
+_ME_DEPLOYMENT = "reya-localnet-matching-engine"
+_NAMESPACE = "reya-localnet"
+_CONTEXT = "k3d-reya-localnet"
+
+
+def _kubeconfig() -> str | None:
+    return os.environ.get("LOCALNET_KUBECONFIG")
+
+
+def _feed_reset_seen(recorder: MarketDataRecorder) -> bool:
+    for frame in recorder.order_change_frames:
+        for order in frame:
+            reason = getattr(order, "cancel_reason", None)
+            if reason is None:
+                continue
+            reason_text = reason.value if hasattr(reason, "value") else str(reason)
+            if "FEED_RESET" in reason_text.upper():
+                return True
+    return False
+
+
+def _restart_matching_engine(kubeconfig: str) -> None:
+    kubectl = shutil.which("kubectl")
+    if kubectl is None:
+        raise RuntimeError("kubectl is required to restart the matching engine")
+    common = [kubectl, "--kubeconfig", kubeconfig, "--context", _CONTEXT, "-n", _NAMESPACE]
+    logger.info("Restarting matching engine via kubectl rollout restart ...")
+    restart = subprocess.run(  # nosec B603
+        [*common, "rollout", "restart", f"deployment/{_ME_DEPLOYMENT}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if restart.returncode != 0:
+        raise RuntimeError(f"rollout restart failed: {restart.stderr.strip()}")
+    status = subprocess.run(  # nosec B603
+        [*common, "rollout", "status", f"deployment/{_ME_DEPLOYMENT}", "--timeout=240s"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=260,
+    )
+    if status.returncode != 0:
+        raise RuntimeError(f"rollout status did not converge: {status.stderr.strip() or status.stdout.strip()}")
+    logger.info("Matching engine rollout complete: %s", status.stdout.strip())
+
+
+async def _wait_for_me_stable(tester: ReyaTester, config: SpotTestConfig, timeout: float = 150.0) -> bool:
+    """Confirm the ME write path actually serves orders after the restart.
+
+    ``kubectl rollout status`` returning success is not sufficient: for a short
+    window after the new ME pod is Ready, the API/bun-socket are still
+    re-establishing their TCP connection to it, so writes transiently return
+    ``UNAVAILABLE_MATCHING_ENGINE_ERROR`` (and on this localnet the Finding-B
+    snapshot-GET race can re-crash the pod once or twice). Land two probe
+    create+cancel cycles a few seconds apart before relying on the ME.
+    """
+    deadline = time.monotonic() + timeout
+    probe_px = str(int(config.get_safe_no_match_buy_price()) + 7)
+    consecutive = 0
+    while time.monotonic() < deadline:
+        try:
+            params = OrderBuilder.from_config(config).buy().price(probe_px).gtc().build()
+            oid = await tester.orders.create_limit(params)
+            if oid:
+                await tester.client.cancel_order(order_id=oid, symbol=config.symbol, account_id=tester.account_id)
+                consecutive += 1
+                if consecutive >= 2:
+                    logger.info("ME write path stable after restart")
+                    return True
+        except (ApiException, OSError, RuntimeError) as exc:
+            consecutive = 0
+            logger.info("ME not yet serving writes (%s); retrying", type(exc).__name__)
+        await asyncio.sleep(3.0)
+    return False
+
+
+async def _assert_snapshot_consistent_with_rest(
+    recorder: MarketDataRecorder, tester: ReyaTester, symbol: str, label: str
+) -> None:
+    """Fresh subscribe feed is internally consistent with REST:
+
+    - orderChanges snapshot == REST openOrders (exact), and
+    - the depth snapshot reconciled with the diffs that immediately follow it
+      converges to REST ``/depth``. The snapshot is a point-in-time cursor, so a
+      diff can land between it and the REST read (an order enters the depth
+      stream just after the snapshot); reconciling snapshot+diffs (the same
+      continuity contract T2 checks) is the robust equality.
+    """
+
+    async def _order_changes_consistent() -> bool:
+        if recorder.order_changes_snapshot is None:
+            return False
+        snap_ids = {o.order_id for o in recorder.order_changes_snapshot_orders()}
+        rest_ids = {o.order_id for o in await tester.client.get_open_orders()}
+        return snap_ids == rest_ids
+
+    async def _depth_consistent() -> bool:
+        snap = recorder.depth_snapshot_copy()
+        if snap is None:
+            return False
+        book = LocalBook.from_snapshot(snap)
+        for frame in recorder.depth_updates():
+            book.apply(frame)
+        rest = await tester.data.market_depth(symbol)
+        rest_bids, rest_asks = depth_sides(rest)
+        return book.bids_sorted() == rest_bids and book.asks_sorted() == rest_asks
+
+    assert await wait_until(
+        _order_changes_consistent, timeout=20.0
+    ), f"[{label}] orderChanges snapshot != REST openOrders"
+    assert await wait_until(
+        _depth_consistent, timeout=20.0
+    ), f"[{label}] depth snapshot+diffs did not reconcile to REST depth"
+    logger.info("[%s] fresh snapshots consistent with REST", label)
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_resync_close(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    kubeconfig = _kubeconfig()
+    if not kubeconfig or shutil.which("kubectl") is None:
+        pytest.skip(
+            "T3 needs LOCALNET_KUBECONFIG + kubectl to restart the matching engine; "
+            "opt-in so it never bounces a shared/remote stack."
+        )
+
+    logger.info("=" * 80)
+    logger.info("T3 RESYNC (1012) CLOSE HANDLING: %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    address = spot_tester.owner_wallet_address
+    assert address is not None
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    # Pre-restart resting state so the snapshot is non-trivial.
+    px = int(spot_config.get_safe_no_match_buy_price())
+    pre_params = OrderBuilder.from_config(spot_config).buy().price(str(px)).gtc().build()
+    pre_id = await spot_tester.orders.create_limit(pre_params)
+    assert pre_id, "pre-restart order must be created"
+
+    recorder = MarketDataRecorder(
+        ws_url, address=address, symbol=symbol, subscribe_order_changes=True, subscribe_depth=True
+    )
+    recorder.connect()
+    try:
+        assert await wait_until(
+            lambda: recorder.order_changes_snapshot is not None and recorder.depth_snapshot_copy() is not None,
+            timeout=15.0,
+        ), "did not receive both subscribe snapshots before restart"
+        await _assert_snapshot_consistent_with_rest(recorder, spot_tester, symbol, "pre-restart")
+
+        # --- bounce the matching engine ---
+        await asyncio.to_thread(_restart_matching_engine, kubeconfig)
+
+        # --- observe the resync signal on the live subscriptions ---
+        def _resync_signalled() -> bool:
+            return recorder.has_close_code(1012) or _feed_reset_seen(recorder)
+
+        got_signal = await wait_until(_resync_signalled, timeout=180.0, interval=0.5)
+        closes = recorder.close_events()
+        feed_reset = _feed_reset_seen(recorder)
+        logger.info("post-restart: closes=%s feed_reset_inline=%s", closes, feed_reset)
+        assert got_signal, (
+            "no resync signal after ME restart: expected a 1012 close on the stateful "
+            f"channels or inline FEED_RESET cancellations; closes={closes}"
+        )
+
+        if recorder.has_close_code(1012):
+            code, reason = next((c, r) for c, r in closes if c == 1012)
+            reason_l = (reason or "").lower()
+            assert (
+                reason is None or "resync" in reason_l or "reset" in reason_l
+            ), f"1012 close reason did not describe a resync: {reason!r}"
+            logger.info("observed 1012 resync close: reason=%r", reason)
+    finally:
+        recorder.close()
+
+    # Gate on the ME write path actually recovering before asserting resumption:
+    # the API/bun-socket reconnect to the new ME lags rollout-status success.
+    assert await _wait_for_me_stable(spot_tester, spot_config), (
+        "matching engine did not resume serving writes after restart within budget "
+        "(localnet Finding-B snapshot-GET race — ping e2e-localnet to bounce it)"
+    )
+
+    # --- reconnect + resubscribe: server must deliver a fresh consistent snapshot ---
+    fresh = MarketDataRecorder(
+        ws_url, address=address, symbol=symbol, subscribe_order_changes=True, subscribe_depth=True
+    )
+    fresh.connect()
+    try:
+        assert await wait_until(
+            lambda: fresh.order_changes_snapshot is not None and fresh.depth_snapshot_copy() is not None,
+            timeout=30.0,
+        ), "did not receive fresh snapshots after reconnect+resubscribe"
+        await _assert_snapshot_consistent_with_rest(fresh, spot_tester, symbol, "post-resync")
+
+        # --- diffs resume on the fresh connection ---
+        base_frames = len(fresh.depth_updates())
+        resume_px = int(spot_config.get_safe_no_match_buy_price()) + 3
+        resume_params = OrderBuilder.from_config(spot_config).buy().price(str(resume_px)).gtc().build()
+        resume_holder: dict[str, str] = {}
+
+        async def _place_resume() -> bool:
+            try:
+                oid = await spot_tester.orders.create_limit(resume_params)
+            except (ApiException, OSError, RuntimeError):
+                return False
+            if oid:
+                resume_holder["id"] = oid
+                return True
+            return False
+
+        assert await wait_until(
+            _place_resume, timeout=60.0, interval=2.0
+        ), "could not place post-resync order (ME write path unstable)"
+        resume_id = resume_holder["id"]
+
+        def _order_change_resumed() -> bool:
+            return any(o.order_id == resume_id for o in fresh.order_change_events())
+
+        def _depth_resumed() -> bool:
+            return len(fresh.depth_updates()) > base_frames
+
+        assert await wait_until(_order_change_resumed, timeout=20.0), "orderChanges diffs did not resume post-resync"
+        assert await wait_until(_depth_resumed, timeout=20.0), "depth diffs did not resume post-resync"
+        logger.info("T3 PASS: resync signalled, fresh snapshots consistent, diffs resumed")
+    finally:
+        fresh.close()
+        await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_slow_consumer_close.py
+++ b/tests/market_data/test_slow_consumer_close.py
@@ -18,8 +18,6 @@ deliberately blocks its own reader thread to create backpressure.
 
 from __future__ import annotations
 
-from typing import Optional
-
 import asyncio
 import logging
 import os
@@ -46,7 +44,7 @@ class _StalledDepthConsumer:
         self._symbol = symbol
         self._stall_seconds = stall_seconds
         self._stalled_once = False
-        self.closes: list[tuple[Optional[int], Optional[str]]] = []
+        self.closes: list[tuple[int | None, str | None]] = []
         self._lock = threading.Lock()
         self._socket = ReyaSocket(url=url, on_open=self._on_open, on_message=self._on_message, on_close=self._on_close)
 
@@ -69,12 +67,12 @@ class _StalledDepthConsumer:
             self._stalled_once = True
             time.sleep(self._stall_seconds)
 
-    def _on_close(self, _ws, code: Optional[int], reason: Optional[str]) -> None:
+    def _on_close(self, _ws, code: int | None, reason: str | None) -> None:
         with self._lock:
             self.closes.append((code, reason))
         logger.info("stalled consumer close: code=%s reason=%r", code, reason)
 
-    def close_events(self) -> list[tuple[Optional[int], Optional[str]]]:
+    def close_events(self) -> list[tuple[int | None, str | None]]:
         with self._lock:
             return list(self.closes)
 

--- a/tests/market_data/test_slow_consumer_close.py
+++ b/tests/market_data/test_slow_consumer_close.py
@@ -1,0 +1,164 @@
+"""T4 — 1013 slow-consumer / backpressure close (opt-in stress).
+
+Contract: a stateful channel (depth / orderChanges) whose client stops draining
+while the server keeps producing can be closed with code **1013**, reason
+"slow consumer — resubscribe for fresh snapshot". Correct client behaviour is to
+reconnect + resubscribe for a fresh snapshot.
+
+Why skip-by-default: the server's per-connection outbound bound (~1 MB) is hard
+to overflow quickly on localnet, and inducing it requires a deliberately stalled
+reader plus a heavy depth-churn generator that pollutes shared state. So this is
+opt-in via ``REYA_MD_STRESS_1013=1`` (churn size tunable via
+``REYA_MD_STRESS_ORDERS``, default 400). When it does close, we assert the code
+is 1013 and that reconnect+resubscribe yields a fresh snapshot.
+
+The stalled consumer is built inline (not via ``MarketDataRecorder``) because it
+deliberately blocks its own reader thread to create backpressure.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import asyncio
+import logging
+import os
+import threading
+import time
+
+import pytest
+
+from sdk.reya_websocket import ReyaSocket
+from tests.helpers import ReyaTester
+from tests.helpers.builders import OrderBuilder
+from tests.helpers.market_config import SpotTestConfig
+from tests.market_data.md_ws_recorder import MarketDataRecorder
+from tests.market_data.poll import wait_until
+
+logger = logging.getLogger("reya.integration_tests")
+
+
+class _StalledDepthConsumer:
+    """Subscribes to depth, then blocks its reader thread so the server's
+    outbound buffer for this connection backs up (slow consumer)."""
+
+    def __init__(self, url: str, symbol: str, stall_seconds: float) -> None:
+        self._symbol = symbol
+        self._stall_seconds = stall_seconds
+        self._stalled_once = False
+        self.closes: list[tuple[Optional[int], Optional[str]]] = []
+        self._lock = threading.Lock()
+        self._socket = ReyaSocket(url=url, on_open=self._on_open, on_message=self._on_message, on_close=self._on_close)
+
+    def connect(self) -> None:
+        self._socket.connect()
+
+    def close(self) -> None:
+        try:
+            self._socket.close()
+        except (OSError, RuntimeError):  # pragma: no cover
+            pass
+
+    def _on_open(self, ws) -> None:
+        ws.market.depth(self._symbol).subscribe()
+
+    def _on_message(self, _ws, _message) -> None:
+        # Block the reader thread once, after the subscribe handshake, so the
+        # socket stops draining and the server accumulates unsent depth frames.
+        if not self._stalled_once:
+            self._stalled_once = True
+            time.sleep(self._stall_seconds)
+
+    def _on_close(self, _ws, code: Optional[int], reason: Optional[str]) -> None:
+        with self._lock:
+            self.closes.append((code, reason))
+        logger.info("stalled consumer close: code=%s reason=%r", code, reason)
+
+    def close_events(self) -> list[tuple[Optional[int], Optional[str]]]:
+        with self._lock:
+            return list(self.closes)
+
+
+async def _generate_depth_churn(tester: ReyaTester, config: SpotTestConfig, n_orders: int) -> None:
+    """Flood the depth channel: many resting bids at distinct prices, then cancel."""
+    base = int(config.get_safe_no_match_buy_price())
+    order_ids: list[str] = []
+    for i in range(n_orders):
+        params = OrderBuilder.from_config(config).buy().price(str(base + i)).gtc().build()
+        try:
+            oid = await tester.orders.create_limit(params)
+            if oid:
+                order_ids.append(oid)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("churn create %d failed (continuing): %s", i, exc)
+        if i % 25 == 0:
+            await asyncio.sleep(0)  # yield without slowing the flood much
+    for oid in order_ids:
+        try:
+            await tester.client.cancel_order(order_id=oid, symbol=config.symbol, account_id=tester.account_id)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            logger.debug("churn cancel failed (continuing): %s", exc)
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_slow_consumer_close(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    if os.environ.get("REYA_MD_STRESS_1013") != "1":
+        pytest.skip(
+            "T4 is an opt-in stress test (set REYA_MD_STRESS_1013=1): the ~1 MB outbound "
+            "bound is hard to overflow on localnet and the churn pollutes shared state."
+        )
+
+    logger.info("=" * 80)
+    logger.info("T4 SLOW-CONSUMER (1013) CLOSE: %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+    n_orders = int(os.environ.get("REYA_MD_STRESS_ORDERS", "400"))
+
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    # Stall long enough for the server to fill this connection's outbound buffer.
+    consumer = _StalledDepthConsumer(ws_url, symbol, stall_seconds=20.0)
+    consumer.connect()
+    await asyncio.sleep(1.0)  # let the subscribe handshake land before the flood
+
+    try:
+        await _generate_depth_churn(spot_tester, spot_config, n_orders)
+
+        got_1013 = await wait_until(
+            lambda: any(code == 1013 for code, _ in consumer.close_events()),
+            timeout=40.0,
+            interval=0.5,
+        )
+        closes = consumer.close_events()
+        if not got_1013:
+            pytest.skip(
+                "1013 not induced on this localnet within the churn budget "
+                f"(closes={closes}); backpressure bound not reached. Increase REYA_MD_STRESS_ORDERS to retry."
+            )
+
+        code, reason = next((c, r) for c, r in closes if c == 1013)
+        reason_l = (reason or "").lower()
+        assert (
+            reason is None or "slow" in reason_l or "consumer" in reason_l
+        ), f"1013 reason did not describe a slow consumer: {reason!r}"
+        logger.info("observed 1013 slow-consumer close: reason=%r", reason)
+    finally:
+        consumer.close()
+
+    # Reconnect + resubscribe -> fresh consistent snapshot (correct client recovery).
+    fresh = MarketDataRecorder(ws_url, symbol=symbol, subscribe_depth=True)
+    fresh.connect()
+    try:
+        assert await wait_until(
+            lambda: fresh.depth_snapshot_copy() is not None, timeout=15.0
+        ), "reconnect after 1013 did not yield a fresh depth snapshot"
+        logger.info("T4 PASS: 1013 close induced; reconnect delivered a fresh snapshot")
+    finally:
+        fresh.close()
+        await spot_tester.orders.close_all(fail_if_none=False)

--- a/tests/market_data/test_snapshot_open_orders.py
+++ b/tests/market_data/test_snapshot_open_orders.py
@@ -113,7 +113,7 @@ async def test_snapshot_matches_open_orders(spot_config: SpotTestConfig, spot_te
         )
 
         # And the fields are the exact ones we placed (not just internally consistent).
-        placed_pairs = {(px, qty) for px, qty in _ORDERS}
+        placed_pairs = set(_ORDERS)
         snap_pairs = {(o.limit_px, o.qty) for o in snapshot_orders}
         assert snap_pairs == placed_pairs, f"snapshot px/qty {snap_pairs} != placed {placed_pairs}"
         logger.info("S1 PASS: snapshot of %d orders == REST openOrders exactly (ids + fields)", len(snapshot_orders))

--- a/tests/market_data/test_snapshot_open_orders.py
+++ b/tests/market_data/test_snapshot_open_orders.py
@@ -1,0 +1,122 @@
+"""S1 — the orderChanges subscribe-snapshot IS the open-orders state (non-empty).
+
+The ``walletOrderChanges`` subscribe handshake returns a snapshot of the wallet's
+currently-resting orders; the documented contract is that this snapshot equals
+``GET /v2/wallet/{address}/openOrders`` at subscribe time. T3 checks this only in
+passing (and often on an empty book); this test makes the non-trivial case
+explicit: rest three distinct orders first, then subscribe and assert the
+snapshot's order ids AND per-order fields equal REST ``openOrders`` exactly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import pytest
+
+from sdk.async_api.order import Order as AsyncOrder
+from sdk.open_api.models.order import Order as RestOrder
+from tests.helpers import ReyaTester
+from tests.helpers.builders import OrderBuilder
+from tests.helpers.market_config import SpotTestConfig
+from tests.market_data.md_ws_recorder import MarketDataRecorder
+from tests.market_data.poll import wait_until
+
+logger = logging.getLogger("reya.integration_tests")
+
+# Three distinct resting bids (distinct px AND qty) so the field comparison is
+# non-trivial. All safe-no-match (far below oracle) and tick/step-aligned.
+_ORDERS = [("10.13", "0.111"), ("11.17", "0.222"), ("12.19", "0.333")]
+
+
+def _enum(value: object) -> object:
+    return value.value if hasattr(value, "value") else value
+
+
+def _snapshot_fingerprint(order: AsyncOrder | RestOrder) -> tuple[object, ...]:
+    """Stable per-order fields present on BOTH the async snapshot order and the
+    REST order. ``sequenceNumber`` is intentionally excluded — snapshot orders
+    never carry one (the boundary is ``snapshotSequenceNumber``)."""
+    return (
+        order.order_id,
+        order.symbol,
+        order.limit_px,
+        order.qty,
+        _enum(order.side),
+        _enum(order.status),
+        _enum(order.order_type),
+        _enum(order.time_in_force),
+    )
+
+
+@pytest.mark.localnet
+@pytest.mark.spot
+@pytest.mark.market_data
+@pytest.mark.websocket
+@pytest.mark.asyncio
+async def test_snapshot_matches_open_orders(spot_config: SpotTestConfig, spot_tester: ReyaTester):
+    logger.info("=" * 80)
+    logger.info("S1 SUBSCRIBE-SNAPSHOT == REST openOrders (non-empty): %s", spot_config.symbol)
+    logger.info("=" * 80)
+
+    symbol = spot_config.symbol
+    address = spot_tester.owner_wallet_address
+    assert address is not None
+    ws_url = os.environ.get("REYA_WS_URL", "wss://ws.reya.xyz/")
+
+    await spot_tester.orders.close_all(fail_if_none=False)
+
+    created: set[str] = set()
+    for px, qty in _ORDERS:
+        params = OrderBuilder.from_config(spot_config).buy().price(px).qty(qty).gtc().build()
+        oid = await spot_tester.orders.create_limit(params)
+        assert oid, f"create_limit returned no id for {px}/{qty}"
+        created.add(oid)
+
+    # REST must show all three before we subscribe, so the snapshot is non-empty.
+    async def _rest_has_all() -> bool:
+        rest_ids = {o.order_id for o in await spot_tester.client.get_open_orders() if o.symbol == symbol}
+        return created.issubset(rest_ids)
+
+    assert await wait_until(_rest_has_all, timeout=20.0), "REST openOrders did not converge to the three resting orders"
+
+    recorder = MarketDataRecorder(ws_url, address=address, subscribe_order_changes=True)
+    recorder.connect()
+    try:
+        # Snapshot ids must match REST ids for this wallet exactly (a point-in-time
+        # cursor, so poll to let both settle to the same set).
+        async def _ids_agree() -> bool:
+            if recorder.order_changes_snapshot is None:
+                return False
+            snap_ids = {o.order_id for o in recorder.order_changes_snapshot_orders()}
+            rest_ids = {o.order_id for o in await spot_tester.client.get_open_orders() if o.symbol == symbol}
+            return bool(snap_ids) and snap_ids == rest_ids == created
+
+        assert await wait_until(_ids_agree, timeout=20.0), (
+            "orderChanges snapshot ids != REST openOrders ids; "
+            f"snapshot={sorted(o.order_id for o in recorder.order_changes_snapshot_orders())} created={sorted(created)}"
+        )
+
+        snapshot_orders = recorder.order_changes_snapshot_orders()
+        assert len(snapshot_orders) == len(
+            _ORDERS
+        ), f"snapshot carried {len(snapshot_orders)} orders, expected {len(_ORDERS)}"
+
+        rest_orders = [o for o in await spot_tester.client.get_open_orders() if o.symbol == symbol]
+        snap_fp = {_snapshot_fingerprint(o) for o in snapshot_orders}
+        rest_fp = {_snapshot_fingerprint(o) for o in rest_orders}
+        assert snap_fp == rest_fp, (
+            "snapshot fields differ from REST openOrders:\n"
+            f"  only in snapshot: {snap_fp - rest_fp}\n"
+            f"  only in REST:     {rest_fp - snap_fp}"
+        )
+
+        # And the fields are the exact ones we placed (not just internally consistent).
+        placed_pairs = {(px, qty) for px, qty in _ORDERS}
+        snap_pairs = {(o.limit_px, o.qty) for o in snapshot_orders}
+        assert snap_pairs == placed_pairs, f"snapshot px/qty {snap_pairs} != placed {placed_pairs}"
+        logger.info("S1 PASS: snapshot of %d orders == REST openOrders exactly (ids + fields)", len(snapshot_orders))
+    finally:
+        recorder.close()
+        await spot_tester.orders.close_all(fail_if_none=False)


### PR DESCRIPTION
## Review packet
- **What & why:** Localnet e2e coverage for the market-data dissemination serving contract (reya-chain#197 + off-chain#2801): orderChanges lossless batching + ordering, depth snapshot+absolute-diff continuity incl. the new REST `?limit`, and the 1012 "feed resync" close/reconnect/fresh-snapshot recovery (captured live). A 1013 slow-consumer stress test ships opt-in (skip-by-default; the ~1MB bound is not reliably inducible on localnet). Tests only — no SDK library changes.
- **Blast radius:** test suite only; new `localnet` marker in pyproject.
- **Verified:** isort/black/flake8/mypy-strict clean; run twice against live localnet (single-target AND dual-Redis topology): T1+T2+T3 all passed (T3 across real ME rollout restarts); verbatim close captured: `1012 "feed resync — resubscribe for fresh snapshot (reset)"`.
- **Human focus:** T3 is gated on LOCALNET_KUBECONFIG (it restarts the ME — never runs against a shared/remote stack by default); confirm the gating convention. Finding for the SDK backlog: `ReyaSocket` does not auto-reconnect on 1012/1013 (caller-owned recovery — matches the documented contract), and the generated client lacks the depth `limit` param until the specs regen.
- **Not covered:** T4 (1013) opt-in only; requires a host with memory headroom.