### PR TITLE
fix: recover WebSocket subscriptions after disconnect

### DIFF
--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -131,24 +131,29 @@ class ReyaSocket(WebSocketApp):
 
         # Initialize thread attribute
         self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
 
-        # Store user callback for wrapping
+        # Store user callbacks for wrapping
         self._user_on_message = on_message
+        self._open_callback = on_open or self._default_on_open
 
         # Default handlers if none provided
-        if on_open is None:
-            on_open = self._default_on_open
         if on_error is None:
             on_error = self._default_on_error
         if on_close is None:
             on_close = self._default_on_close
 
-        # Track subscriptions
+        # Track subscription intent so it can be restored after reconnecting.
         self.active_subscriptions: set[str] = set()
+        self._subscription_payloads: dict[str, str] = {}
+        self._subscription_lock = threading.RLock()
+        self._sent_subscriptions_this_connection: set[str] = set()
+        self._has_connected_once = False
+        self._opened_this_run = False
 
         super().__init__(
             url=url,
-            on_open=on_open,
+            on_open=self._handle_open,
             on_message=self._wrap_message_handler(),
             on_error=on_error,
             on_close=on_close,
@@ -299,10 +304,14 @@ class ReyaSocket(WebSocketApp):
             channel: The channel to subscribe to.
             **kwargs: Additional subscription parameters.
         """
-        self.active_subscriptions.add(channel)
         message = {"type": "subscribe", "channel": channel, **kwargs}
+        payload = json.dumps(message)
         logger.info(f"Subscribing to {channel}")
-        self.send(json.dumps(message))
+        with self._subscription_lock:
+            self.active_subscriptions.add(channel)
+            self._subscription_payloads[channel] = payload
+            self._sent_subscriptions_this_connection.add(channel)
+            self.send(payload)
 
     def send_unsubscribe(self, channel: str, **kwargs) -> None:
         """Send an unsubscription message.
@@ -311,12 +320,42 @@ class ReyaSocket(WebSocketApp):
             channel: The channel to unsubscribe from.
             **kwargs: Additional unsubscription parameters.
         """
-        if channel in self.active_subscriptions:
-            self.active_subscriptions.remove(channel)
-
         message = {"type": "unsubscribe", "channel": channel, **kwargs}
         logger.info(f"Unsubscribing from {channel}")
-        self.send(json.dumps(message))
+        with self._subscription_lock:
+            self.active_subscriptions.discard(channel)
+            self._subscription_payloads.pop(channel, None)
+            self.send(json.dumps(message))
+
+    def _handle_open(self, ws: WebSocket) -> None:
+        """Run the open callback and restore subscriptions after reconnecting."""
+        is_reconnect = self._has_connected_once
+        self._has_connected_once = True
+        self._opened_this_run = True
+
+        try:
+            # Preserve WebSocketApp's lifecycle semantics: user callbacks run
+            # for both the initial connection and every subsequent reconnect.
+            self._open_callback(ws)
+        finally:
+            if is_reconnect:
+                self._restore_subscriptions()
+
+    def _restore_subscriptions(self) -> None:
+        """Replay subscriptions not already sent by the reconnect callback."""
+        with self._subscription_lock:
+            payloads = [
+                (channel, payload)
+                for channel, payload in self._subscription_payloads.items()
+                if channel not in self._sent_subscriptions_this_connection
+            ]
+
+            if payloads:
+                logger.info(f"Restoring {len(payloads)} WebSocket subscription(s)")
+
+            for channel, payload in payloads:
+                self.send(payload)
+                self._sent_subscriptions_this_connection.add(channel)
 
     def connect(self, sslopt=None, blocking=False) -> None:
         """Connect to the WebSocket server.
@@ -338,27 +377,67 @@ class ReyaSocket(WebSocketApp):
             else:
                 sslopt = {"cert_reqs": ssl.CERT_NONE}
 
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("WebSocket connection is already running")
+
+        self._stop_event.clear()
         logger.info(f"Connecting to {self.url}")
 
         if blocking:
             # Run the WebSocket directly (blocking)
-            self.run_forever(
-                sslopt=sslopt,
-                ping_interval=self.config.ping_interval,
-                ping_timeout=self.config.ping_timeout,
-            )
+            self._run_forever_with_reconnect(sslopt)
         else:
             # Run the WebSocket in a thread (non-blocking)
             self._thread = threading.Thread(
-                target=self.run_forever,
-                kwargs={
-                    "sslopt": sslopt,
-                    "ping_interval": self.config.ping_interval,
-                    "ping_timeout": self.config.ping_timeout,
-                },
+                target=self._run_forever_with_reconnect,
+                args=(sslopt,),
             )
             self._thread.daemon = True
             self._thread.start()
+
+    def _run_forever_with_reconnect(self, sslopt) -> None:
+        """Run the socket, reconnecting with bounded exponential backoff."""
+        failed_attempts = 0
+
+        while not self._stop_event.is_set():
+            self._opened_this_run = False
+            with self._subscription_lock:
+                self._sent_subscriptions_this_connection.clear()
+
+            try:
+                self.run_forever(
+                    sslopt=sslopt,
+                    ping_interval=self.config.ping_interval,
+                    ping_timeout=self.config.ping_timeout,
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("WebSocket connection loop failed")
+
+            if self._stop_event.is_set():
+                return
+
+            if self._opened_this_run:
+                failed_attempts = 0
+
+            if failed_attempts >= self.config.reconnect_attempts:
+                logger.error(
+                    f"WebSocket reconnect attempts exhausted after {self.config.reconnect_attempts} attempt(s)"
+                )
+                return
+
+            failed_attempts += 1
+            delay = self.config.reconnect_delay * (2 ** (failed_attempts - 1))
+            logger.info(
+                f"Reconnecting WebSocket in {delay} second(s) "
+                f"(attempt {failed_attempts}/{self.config.reconnect_attempts})"
+            )
+            if self._stop_event.wait(delay):
+                return
+
+    def close(self, **kwargs) -> None:
+        """Stop reconnecting and close the active WebSocket connection."""
+        self._stop_event.set()
+        super().close(**kwargs)
 
     def _default_on_open(self, _ws):
         """Default handler for connection open events."""

--- a/tests/validation/test_websocket_reconnect.py
+++ b/tests/validation/test_websocket_reconnect.py
@@ -1,0 +1,189 @@
+"""Offline tests for WebSocket reconnect and subscription recovery."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from typing import Any
+
+import json
+import logging
+import threading
+
+import pytest
+
+from sdk.reya_websocket.config import WebSocketConfig
+from sdk.reya_websocket.socket import ReyaSocket
+
+pytestmark = pytest.mark.offline
+
+
+def _config(*, reconnect_attempts: int = 3, reconnect_delay: int = 0) -> WebSocketConfig:
+    return WebSocketConfig(
+        url="wss://example.invalid",
+        reconnect_attempts=reconnect_attempts,
+        reconnect_delay=reconnect_delay,
+    )
+
+
+def test_reconnect_replays_the_full_subscription_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
+    open_count = 0
+    run_count = 0
+
+    def on_open(_ws: Any) -> None:
+        nonlocal open_count
+        open_count += 1
+        if open_count == 1:
+            socket.send_subscribe(
+                "/v2/wallet/0xabc/orderChanges",
+                batched=True,
+                snapshot={"depth": 25},
+            )
+
+    socket = ReyaSocket(config=_config(), on_open=on_open)
+    monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+        if run_count == 2:
+            socket.close()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect(blocking=True)
+
+    expected = {
+        "type": "subscribe",
+        "channel": "/v2/wallet/0xabc/orderChanges",
+        "batched": True,
+        "snapshot": {"depth": 25},
+    }
+    assert sent == [expected, expected]
+    assert open_count == 2
+    assert run_count == 2
+
+
+def test_reconnect_callback_subscription_is_not_duplicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
+    open_count = 0
+    run_count = 0
+
+    def on_open(_ws: Any) -> None:
+        nonlocal open_count
+        open_count += 1
+        socket.send_subscribe("/v2/assetOraclePrices", batched=open_count == 2)
+
+    socket = ReyaSocket(config=_config(), on_open=on_open)
+    monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+        if run_count == 2:
+            socket.close()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect(blocking=True)
+
+    assert sent == [
+        {
+            "type": "subscribe",
+            "channel": "/v2/assetOraclePrices",
+            "batched": False,
+        },
+        {
+            "type": "subscribe",
+            "channel": "/v2/assetOraclePrices",
+            "batched": True,
+        },
+    ]
+
+
+def test_unsubscribed_channel_is_not_restored(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
+    open_count = 0
+    run_count = 0
+
+    def on_open(_ws: Any) -> None:
+        nonlocal open_count
+        open_count += 1
+        if open_count == 1:
+            socket.send_subscribe("/v2/perpMarkets/summary", batched=True)
+
+    socket = ReyaSocket(config=_config(), on_open=on_open)
+    monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+        if run_count == 1:
+            socket.send_unsubscribe("/v2/perpMarkets/summary")
+        else:
+            socket.close()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect(blocking=True)
+
+    assert sent == [
+        {
+            "type": "subscribe",
+            "channel": "/v2/perpMarkets/summary",
+            "batched": True,
+        },
+        {
+            "type": "unsubscribe",
+            "channel": "/v2/perpMarkets/summary",
+        },
+    ]
+    assert socket.active_subscriptions == set()
+
+
+def test_reconnect_uses_bounded_exponential_backoff(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    run_count = 0
+    delays: list[float] = []
+    socket = ReyaSocket(config=_config(reconnect_attempts=3, reconnect_delay=2))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+
+    def record_wait(delay: float) -> bool:
+        delays.append(delay)
+        return False
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+    monkeypatch.setattr(socket._stop_event, "wait", record_wait)
+
+    with caplog.at_level(logging.ERROR, logger="reya.websocket"):
+        socket.connect(blocking=True)
+
+    assert run_count == 4
+    assert delays == [2, 4, 8]
+    assert "reconnect attempts exhausted after 3 attempt(s)" in caplog.text
+
+
+def test_close_interrupts_reconnect_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_run_finished = threading.Event()
+    socket = ReyaSocket(config=_config(reconnect_delay=60))
+
+    def run_forever(**_kwargs: Any) -> None:
+        first_run_finished.set()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect()
+    assert first_run_finished.wait(timeout=1)
+
+    socket.close()
+    assert socket._thread is not None
+    socket._thread.join(timeout=1)
+    assert not socket._thread.is_alive()


### PR DESCRIPTION
## Summary

- reconnect automatically after unexpected WebSocket closure using the existing `reconnect_attempts` and `reconnect_delay` settings
- apply bounded exponential backoff and let `close()` interrupt a pending retry
- retain and replay the exact original subscription payload after reconnect, including options such as `batched`
- preserve `on_open` lifecycle callbacks without duplicating subscriptions they already restore

## Why

The reconnect settings existed in `WebSocketConfig`, but `ReyaSocket` never used them. A closed socket was only logged, leaving SDK consumers silently disconnected and their subscriptions unrecovered.

## Verification

- `pytest -m offline -q` — 148 passed
- `make lint` — passed (formatters, flake8, bandit, pylint, workflow validation, mypy)