### PR TITLE
fix: preserve spot depth during order replacement

### DIFF
--- a/examples/websocket/spot/depth_market_maker.py
+++ b/examples/websocket/spot/depth_market_maker.py
@@ -660,9 +660,10 @@ async def cancel_and_replace_order(
     reason: str = "",
     max_retries: int = 3,
 ) -> bool:
-    """Cancel a specific order and replace it with a new one at a valid price.
+    """Replace a specific order with a new one at a valid price.
 
-    If order placement fails due to insufficient balance, retries with minimum quantity.
+    The replacement is placed before the existing order is cancelled so a
+    placement failure cannot remove liquidity from the book.
     """
     side = "bid" if order.is_buy else "ask"
 
@@ -678,84 +679,48 @@ async def cancel_and_replace_order(
         best_ask=best_ask,
     )
 
-    # Calculate available balance after cancelling this order
-    if order.is_buy:
-        freed_quote = order.price * order.qty
-        total_available_quote = available_quote + freed_quote
-        max_affordable_qty = total_available_quote / new_price if new_price > 0 else Decimal("0")
-        max_qty = min(MAX_ORDER_QTY, max_affordable_qty)
-    else:
-        freed_base = order.qty
-        total_available_base = available_base + freed_base
-        max_qty = min(MAX_ORDER_QTY, total_available_base)
-
-    if max_qty < market_params.min_order_qty:
-        logger.warning(f"[{cycle:04d}] Skipping {side} replacement - insufficient balance")
-        try:
-            await client.cancel_order(order_id=order.order_id, symbol=symbol, account_id=account_id)
-            logger.info(f"[{cycle:04d}] Cancelled {side} @ ${order.price} (no replacement - low balance)")
-        except RECOVERABLE_EXC as e:
-            error_str = str(e)
-            if "Order not found" in error_str or "CANCEL_ORDER_OTHER_ERROR" in error_str:
-                state.remove_order(order.order_id)
-                logger.info(f"[{cycle:04d}] Removed stale {side} @ ${order.price} from local state")
-            else:
-                logger.warning(f"[{cycle:04d}] Failed to cancel {side} @ ${order.price}: {e}")
+    available_balance = available_quote if order.is_buy else available_base
+    placed, _qty_used = await place_single_order(
+        client=client,
+        symbol=symbol,
+        price=str(new_price),
+        is_buy=order.is_buy,
+        market_params=market_params,
+        available_balance=available_balance,
+        max_retries=max_retries,
+    )
+    reason_str = f" ({reason})" if reason else ""
+    if not placed:
+        logger.warning(
+            f"[{cycle:04d}] Keeping existing {side} @ ${order.price}{reason_str} "
+            f"because replacement @ ${new_price} was not accepted"
+        )
         return False
 
-    new_qty = generate_random_qty(market_params.min_order_qty, max_qty, market_params.qty_step_size)
-
-    # Cancel the existing order first
     try:
         await client.cancel_order(
             order_id=order.order_id,
             symbol=symbol,
             account_id=account_id,
         )
-        reason_str = f" ({reason})" if reason else ""
         logger.info(
-            f"[{cycle:04d}] Cancelling {side} @ ${order.price}{reason_str} "
-            f"→ Adding new {side} @ ${new_price} qty={new_qty}"
+            f"[{cycle:04d}] Added replacement {side} @ ${new_price}{reason_str} "
+            f"→ Cancelled old {side} @ ${order.price}"
         )
     except RECOVERABLE_EXC as e:
         error_str = str(e)
         if "Order not found" in error_str or "CANCEL_ORDER_OTHER_ERROR" in error_str:
             state.remove_order(order.order_id)
-            logger.info(f"[{cycle:04d}] Removed stale {side} @ ${order.price} from local state")
-        else:
-            logger.warning(f"[{cycle:04d}] Failed to cancel {side} @ ${order.price}: {e}")
-        return False
-
-    await asyncio.sleep(0.1)
-
-    # Try to place the new order, retrying with min qty if balance issues
-    qty_to_use = new_qty
-    for attempt in range(max_retries):
-        try:
-            expires_after = int(time.time()) + GTT_LIFETIME_S
-            await client.create_limit_order(
-                LimitOrderParameters(
-                    symbol=symbol,
-                    is_buy=order.is_buy,
-                    limit_px=str(new_price),
-                    qty=qty_to_use,
-                    time_in_force=TimeInForce.GTT,
-                    expires_after=expires_after,
-                )
+            logger.info(
+                f"[{cycle:04d}] Replacement {side} @ ${new_price} is live; "
+                f"removed stale old {side} @ ${order.price} from local state"
             )
-            return True
-        except RECOVERABLE_EXC as e:
-            error_str = str(e).lower()
-            # Check if it's a balance-related error - retry with min qty
-            if "insufficient" in error_str or "balance" in error_str or "margin" in error_str:
-                if attempt < max_retries - 1:
-                    qty_to_use = str(market_params.min_order_qty)
-                    logger.debug(f"[{cycle:04d}] Retrying {side} @ ${new_price} with min qty={qty_to_use}")
-                    continue
-            logger.warning(f"[{cycle:04d}] Failed to place new {side} @ ${new_price}: {e}")
-            return False
-
-    return False
+        else:
+            logger.warning(
+                f"[{cycle:04d}] Replacement {side} @ ${new_price} is live, "
+                f"but failed to cancel old {side} @ ${order.price}: {e}"
+            )
+    return True
 
 
 async def adjust_orders(

--- a/tests/validation/test_spot_depth_market_maker.py
+++ b/tests/validation/test_spot_depth_market_maker.py
@@ -1,0 +1,123 @@
+"""Offline regression tests for the spot depth market maker."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+from sdk.reya_rest_api.models.orders import LimitOrderParameters
+
+pytestmark = pytest.mark.offline
+
+_depth_market_maker = import_module("examples.websocket.spot.depth_market_maker")
+MarketMakerState = getattr(_depth_market_maker, "MarketMakerState")
+MarketParams = getattr(_depth_market_maker, "MarketParams")
+OpenOrder = getattr(_depth_market_maker, "OpenOrder")
+cancel_and_replace_order = getattr(_depth_market_maker, "cancel_and_replace_order")
+
+
+class _RecordingClient:
+    def __init__(
+        self,
+        *,
+        create_error: Exception | None = None,
+        cancel_error: Exception | None = None,
+    ) -> None:
+        self.create_error = create_error
+        self.cancel_error = cancel_error
+        self.events: list[str] = []
+        self.created_order: LimitOrderParameters | None = None
+
+    async def create_limit_order(self, order: LimitOrderParameters) -> None:
+        self.events.append("place")
+        self.created_order = order
+        if self.create_error:
+            raise self.create_error
+
+    async def cancel_order(self, *, order_id: str, symbol: str, account_id: int) -> None:
+        del order_id, symbol, account_id
+        self.events.append("cancel")
+        if self.cancel_error:
+            raise self.cancel_error
+
+
+def _market_params() -> Any:
+    return MarketParams(
+        symbol="WETHRUSD",
+        base_asset="ETH",
+        quote_asset="RUSD",
+        tick_size=Decimal("0.01"),
+        min_order_qty=Decimal("0.001"),
+        qty_step_size=Decimal("0.001"),
+    )
+
+
+def _order() -> Any:
+    return OpenOrder(
+        order_id="existing-order",
+        price=Decimal("100"),
+        qty=Decimal("0.005"),
+        is_buy=True,
+    )
+
+
+def _state(order: Any) -> Any:
+    state = MarketMakerState()
+    state.open_orders[order.order_id] = order
+    return state
+
+
+async def _replace(client: _RecordingClient) -> tuple[bool, Any]:
+    order = _order()
+    state = _state(order)
+    result = await cancel_and_replace_order(
+        client=client,
+        symbol="WETHRUSD",
+        account_id=10000000002,
+        order=order,
+        reference_price=Decimal("100"),
+        market_params=_market_params(),
+        available_base=Decimal("1"),
+        available_quote=Decimal("1000"),
+        remaining_bids=[],
+        remaining_asks=[],
+        cycle=1,
+        state=state,
+    )
+    return result, state
+
+
+@pytest.mark.asyncio
+async def test_replacement_is_placed_before_existing_order_is_cancelled() -> None:
+    client = _RecordingClient()
+
+    result, _state_after = await _replace(client)
+
+    assert result is True
+    assert client.events == ["place", "cancel"]
+
+
+@pytest.mark.asyncio
+async def test_failed_replacement_preserves_existing_order() -> None:
+    client = _RecordingClient(create_error=OSError("placement unavailable"))
+
+    result, state = await _replace(client)
+
+    assert result is False
+    assert client.events == ["place"]
+    assert "existing-order" in state.open_orders
+
+
+@pytest.mark.asyncio
+async def test_cancel_failure_keeps_successful_replacement_live() -> None:
+    client = _RecordingClient(cancel_error=OSError("cancellation unavailable"))
+
+    result, state = await _replace(client)
+
+    assert result is True
+    assert client.events == ["place", "cancel"]
+    assert client.created_order is not None
+    assert "existing-order" in state.open_orders

--- a/tests/validation/test_spot_depth_market_maker.py
+++ b/tests/validation/test_spot_depth_market_maker.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from decimal import Decimal
 from importlib import import_module
-from typing import Any
 
 import pytest
 


### PR DESCRIPTION
## What

- place each replacement quote before cancelling the existing quote
- keep the existing quote when replacement placement fails
- keep the accepted replacement live when cancellation fails
- add offline regressions for placement/cancellation ordering and failure paths

## Why

The spot depth maker cancelled first and then attempted placement. A transient placement or local-balance failure therefore removed a live level without replacing it, allowing the ladder to drain over successive cycles.

## Impact

The script now prefers a temporary extra quote over an empty level. If a replacement cannot be accepted, the existing quote is preserved.

## Checks

- `poetry run pytest tests/validation/test_spot_depth_market_maker.py -q` — 3 passed
- `poetry run pytest -m offline -q` — 146 passed, 355 deselected
- `poetry run pre-commit run --all-files --verbose --show-diff-on-failure` — passed