### PR TITLE
fix: let callers specify the collateral token for deposit and withdraw

### DIFF
--- a/sdk/reya_rpc/actions/deposit.py
+++ b/sdk/reya_rpc/actions/deposit.py
@@ -1,8 +1,11 @@
+from typing import Optional
+
 from dataclasses import dataclass
 
 from eth_abi import encode
 
 from sdk.reya_rpc.types import CommandType
+from sdk.reya_rpc.utils.collateral_token import resolve_collateral_token
 from sdk.reya_rpc.utils.execute_core_commands import execute_core_commands
 
 
@@ -11,34 +14,49 @@ class DepositParams:
     """Data class to store deposit parameters."""
 
     account_id: int  # ID of the margin account receiving the deposit
-    amount: int  # Deposit amount in rUSD (scaled by 10^6)
+    amount: int  # Deposit amount, scaled by the token's own decimals (10^6 for rUSD)
+    token_address: Optional[str] = None  # Collateral token; defaults to the configured rUSD
 
 
 def deposit(config: dict, params: DepositParams):
     """
-    Deposits rUSD into a margin account on Reya DEX.
+    Deposits collateral into a margin account on Reya DEX.
+
+    The token defaults to the rUSD instance in ``config``. Deployments whose collateral is a
+    different address must pass ``token_address``: on a local deployment, depositing the wrong
+    token was observed to succeed and create a balance row that the risk engine did not count,
+    leaving the account looking funded while margining at zero, with every order rejected for
+    insufficient margin. The SDK cannot detect that for you - see ``utils/collateral_token.py``
+    for why - so the caller owns this choice, and ``amount`` is scaled by the chosen token's
+    decimals.
 
     Args:
         config (dict): Configuration dictionary containing Web3 contract instances and IDs. Check out config.py for more details.
-        params (DepositParams): Deposit parameters including margin account ID and deposit amount.
+        params (DepositParams): Deposit parameters including margin account ID, deposit amount, and optional collateral token.
 
     Returns:
         dict: Contains transaction receipt of the deposit transaction.
+
+    Raises:
+        InvalidTokenAddressError: If ``token_address`` is not a valid address. Raised before
+            any funds move.
     """
 
     # Retrieve relevant fields from config
     w3 = config["w3"]
     account = config["w3account"]
     core = config["w3contracts"]["core"]
-    rusd = config["w3contracts"]["rusd"]
 
-    # Execute the transaction to approve rUSD to be spent by the core contract
-    tx_hash = rusd.functions.approve(core.address, params.amount).transact({"from": account.address})
+    # Resolve the collateral token before approving or spending anything
+    token = resolve_collateral_token(config, params.token_address)
+
+    # Execute the transaction to approve the collateral token to be spent by the core contract
+    tx_hash = token.functions.approve(core.address, params.amount).transact({"from": account.address})
     tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-    print(f"Approved rUSD to core: {tx_receipt['transactionHash'].hex()}")
+    print(f"Approved {token.address} to core: {tx_receipt['transactionHash'].hex()}")
 
     # Encode deposit parameters for the contract call
-    inputs_encoded = encode(["(address,uint256)"], [[rusd.address, params.amount]])
+    inputs_encoded = encode(["(address,uint256)"], [[token.address, params.amount]])
 
     # Build the deposit command to be executed using core
     command = (CommandType.Deposit.value, inputs_encoded, 0, 0)

--- a/sdk/reya_rpc/actions/withdraw.py
+++ b/sdk/reya_rpc/actions/withdraw.py
@@ -1,9 +1,12 @@
+from typing import Optional
+
 from dataclasses import dataclass
 
 from eth_abi import encode
 from web3.types import TxReceipt
 
 from sdk.reya_rpc.types import CommandType
+from sdk.reya_rpc.utils.collateral_token import resolve_collateral_token
 from sdk.reya_rpc.utils.execute_core_commands import execute_core_commands
 
 
@@ -12,26 +15,34 @@ class WithdrawParams:
     """Data class to store withdrawal parameters."""
 
     account_id: int  # ID of the margin account performing the withdrawal
-    amount: int  # Withdrawal amount in rUSD (scaled by 10^6)
+    amount: int  # Withdrawal amount, scaled by the token's own decimals (10^6 for rUSD)
+    token_address: Optional[str] = None  # Collateral token; defaults to the configured rUSD
 
 
 def withdraw(config: dict, params: WithdrawParams) -> dict[str, TxReceipt]:
     """
-    Withdraws rUSD from a margin account on Reya DEX.
+    Withdraws collateral from a margin account on Reya DEX.
+
+    Mirrors :func:`~sdk.reya_rpc.actions.deposit.deposit`: the token defaults to the configured
+    rUSD, and deployments using a different collateral token pass it explicitly. This is also
+    the recovery path for funds already deposited under a non-default token.
 
     Args:
         config (dict): Configuration dictionary containing Web3 contract instances and IDs. Check out config.py for more details.
-        params (WithdrawParams): Withdrawal parameters including margin account ID and withdrawal amount.
+        params (WithdrawParams): Withdrawal parameters including margin account ID, withdrawal amount, and optional collateral token.
 
     Returns:
         dict: Contains transaction receipt of the withdrawal transaction.
+
+    Raises:
+        InvalidTokenAddressError: If ``token_address`` is not a valid address.
     """
 
-    # Retrieve rUSD contract from config
-    rusd = config["w3contracts"]["rusd"]
+    # Resolve the collateral token before building the command
+    token = resolve_collateral_token(config, params.token_address)
 
     # Encode withdrawal parameters for the contract call
-    inputs_encoded = encode(["(address,uint256)"], [[rusd.address, params.amount]])
+    inputs_encoded = encode(["(address,uint256)"], [[token.address, params.amount]])
 
     # Build the withdrawal command to be executed using core
     command = (CommandType.Withdraw.value, inputs_encoded, 0, 0)

--- a/sdk/reya_rpc/exceptions.py
+++ b/sdk/reya_rpc/exceptions.py
@@ -19,3 +19,7 @@ class TransactionReceiptError(ReyaRpcError):
 
 class BridgeFeeExceededError(ReyaRpcError):
     """Raised when bridge fee exceeds the specified limit."""
+
+
+class InvalidTokenAddressError(ReyaRpcError):
+    """Raised when a caller-supplied token address is not a valid Ethereum address."""

--- a/sdk/reya_rpc/utils/collateral_token.py
+++ b/sdk/reya_rpc/utils/collateral_token.py
@@ -1,0 +1,63 @@
+"""Resolution of the collateral token used by margin-account actions.
+
+There is deliberately no on-chain check that the token is the one the account actually uses as
+collateral. Neither of the reads core offers can express that safely today, both observed
+against mainnet core 0xA763B6a5E09378434406C003daE6487FbbDc1a80:
+
+- ``getUsdNodeMarginInfo(accountId).collateral`` came back as the zero address for accounts 2
+  and 1000, both of which hold balances, so a comparison against it would never fire. It reads
+  as an aggregate folded from a zero-initialised accumulator whose ``collateral`` is never
+  assigned, which would make the zero universal rather than particular to those two accounts.
+- ``getNodeMarginInfo(accountId, token)`` does discriminate - on account 1000 it returned rUSD
+  for rUSD and reverted 0x96f103cd for USDC and for an unrelated token - but that selector is
+  ``CollateralIsNotQuote``, raised for any collateral that is not the pool's *quote*. Supporting
+  collaterals are legitimate, margin-contributing, and non-quote, so they revert identically to
+  a wholly wrong asset and rejecting on the revert would block valid deposits. This function is
+  also absent from the trimmed ``abis/CoreProxy.json``; it was called out-of-band.
+
+Until a read separates those cases, the caller names the token and owns the choice.
+"""
+
+from typing import Optional, cast
+
+import json
+import os
+
+from web3 import Web3
+from web3.contract import Contract
+
+from sdk.reya_rpc.exceptions import InvalidTokenAddressError
+
+_ABIS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "abis")
+
+with open(os.path.join(_ABIS_DIR, "Erc20.json"), encoding="utf-8") as _f:
+    erc20_abi = json.load(_f)
+
+
+def resolve_collateral_token(config: dict, token_address: Optional[str] = None) -> Contract:
+    """
+    Resolve the ERC-20 contract a margin-account action should move.
+
+    Defaults to the rUSD instance in ``config``, which is what every caller got before
+    ``token_address`` existed. Deployments whose collateral is a different address pass it
+    explicitly rather than silently moving the wrong asset.
+
+    Args:
+        config (dict): Configuration dictionary containing Web3 contract instances.
+        token_address (Optional[str]): Token to use. Defaults to the configured rUSD.
+
+    Returns:
+        Contract: The ERC-20 contract instance to deposit or withdraw.
+
+    Raises:
+        InvalidTokenAddressError: If ``token_address`` is not a valid Ethereum address.
+    """
+    if token_address is None:
+        return cast(Contract, config["w3contracts"]["rusd"])
+
+    try:
+        checksummed = Web3.to_checksum_address(token_address)
+    except (ValueError, TypeError) as error:
+        raise InvalidTokenAddressError(f"'{token_address}' is not a valid token address.") from error
+
+    return cast(Contract, config["w3"].eth.contract(address=checksummed, abi=erc20_abi))

--- a/tests/rpc/test_collateral_token.py
+++ b/tests/rpc/test_collateral_token.py
@@ -1,0 +1,194 @@
+"""Tests for collateral-token selection in deposit/withdraw."""
+
+from importlib import import_module
+from unittest.mock import MagicMock
+
+import pytest
+from eth_abi import encode
+
+from sdk.reya_rpc.actions.deposit import DepositParams, deposit
+from sdk.reya_rpc.actions.withdraw import WithdrawParams, withdraw
+from sdk.reya_rpc.exceptions import InvalidTokenAddressError
+from sdk.reya_rpc.utils.collateral_token import resolve_collateral_token
+
+pytestmark = pytest.mark.offline
+
+# actions/__init__.py re-exports these names, shadowing the submodules, so string-path
+# monkeypatching would resolve to the functions. Grab the module objects instead.
+deposit_module = import_module("sdk.reya_rpc.actions.deposit")
+withdraw_module = import_module("sdk.reya_rpc.actions.withdraw")
+
+RUSD_ADDRESS = "0x9DE724e7b3facF87Ce39465D3D712717182e3e55"
+LOCAL_COLLATERAL_ADDRESS = "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+CORE_ADDRESS = "0xC6fB022962e1426F4e0ec9D2F8861c57926E9f72"
+ACCOUNT_ID = 42
+MALFORMED_ADDRESS = "not-an-address"
+AMOUNT = 100_000_000
+
+
+def _token_contract(address: str) -> MagicMock:
+    """An ERC-20 contract stub."""
+    token = MagicMock()
+    token.address = address
+    return token
+
+
+class _Harness:
+    """A config dict plus handles on every token stub the code under test can reach."""
+
+    def __init__(self):
+        self.rusd = _token_contract(RUSD_ADDRESS)
+        self.tokens = {RUSD_ADDRESS: self.rusd}
+
+        core = MagicMock()
+        core.address = CORE_ADDRESS
+
+        self.w3 = MagicMock()
+        self.w3.eth.contract.side_effect = self._mint
+
+        self.config: dict = {
+            "w3": self.w3,
+            "w3account": MagicMock(address="0x000000000000000000000000000000000000dEaD"),
+            "w3contracts": {"core": core, "rusd": self.rusd},
+        }
+        self.captured: dict = {}
+
+    def _mint(self, address: str, **_kwargs) -> MagicMock:
+        return self.tokens.setdefault(address, _token_contract(address))
+
+    def token(self, address: str) -> MagicMock:
+        """The stub for an address, minting it so a test can assert it was never touched."""
+        return self.tokens.setdefault(address, _token_contract(address))
+
+    def recorder(self):
+        """Stand in for execute_core_commands: record commands, return a receipt-shaped stub."""
+
+        def execute(_config: dict, _account_id: int, commands: list):
+            self.captured["commands"] = commands
+            return {"transactionHash": MagicMock()}
+
+        return execute
+
+    def explode(self):
+        """Stand in for execute_core_commands when the test asserts it is never reached."""
+
+        def execute(_config: dict, _account_id: int, _commands: list):
+            pytest.fail("execute_core_commands must not run when the token address is rejected")
+
+        return execute
+
+    def encoded(self, address: str, amount: int = AMOUNT) -> bytes:
+        return encode(["(address,uint256)"], [[address, amount]])
+
+
+class TestResolveCollateralToken:
+    """Token selection and address validation."""
+
+    def test_defaults_to_configured_rusd(self):
+        harness = _Harness()
+
+        token = resolve_collateral_token(harness.config)
+
+        assert token is harness.rusd
+        harness.w3.eth.contract.assert_not_called()
+
+    def test_explicit_address_overrides_the_default(self):
+        harness = _Harness()
+
+        token = resolve_collateral_token(harness.config, LOCAL_COLLATERAL_ADDRESS)
+
+        assert token.address == LOCAL_COLLATERAL_ADDRESS
+        assert token is not harness.rusd
+
+    def test_lowercase_address_is_checksummed(self):
+        harness = _Harness()
+
+        token = resolve_collateral_token(harness.config, LOCAL_COLLATERAL_ADDRESS.lower())
+
+        assert token.address == LOCAL_COLLATERAL_ADDRESS
+
+    def test_explicit_token_is_built_with_the_erc20_abi(self):
+        harness = _Harness()
+
+        resolve_collateral_token(harness.config, LOCAL_COLLATERAL_ADDRESS)
+
+        abi = harness.w3.eth.contract.call_args.kwargs["abi"]
+        assert {entry.get("name") for entry in abi} >= {"approve", "decimals", "balanceOf"}
+
+    @pytest.mark.parametrize("bad", [MALFORMED_ADDRESS, "0x1234", ""])
+    def test_malformed_address_raises_the_named_error(self, bad):
+        harness = _Harness()
+
+        with pytest.raises(InvalidTokenAddressError, match="not a valid token address"):
+            resolve_collateral_token(harness.config, bad)
+
+
+class TestDeposit:
+    """deposit() approves and encodes the resolved token."""
+
+    def test_default_path_is_unchanged(self, monkeypatch):
+        harness = _Harness()
+        monkeypatch.setattr(deposit_module, "execute_core_commands", harness.recorder())
+
+        deposit(harness.config, DepositParams(account_id=ACCOUNT_ID, amount=AMOUNT))
+
+        harness.rusd.functions.approve.assert_called_once_with(CORE_ADDRESS, AMOUNT)
+        assert harness.captured["commands"][0][1] == harness.encoded(RUSD_ADDRESS)
+
+    def test_explicit_token_is_approved_and_encoded(self, monkeypatch):
+        harness = _Harness()
+        monkeypatch.setattr(deposit_module, "execute_core_commands", harness.recorder())
+
+        deposit(
+            harness.config,
+            DepositParams(account_id=ACCOUNT_ID, amount=AMOUNT, token_address=LOCAL_COLLATERAL_ADDRESS),
+        )
+
+        harness.token(LOCAL_COLLATERAL_ADDRESS).functions.approve.assert_called_once_with(CORE_ADDRESS, AMOUNT)
+        harness.rusd.functions.approve.assert_not_called()
+        assert harness.captured["commands"][0][1] == harness.encoded(LOCAL_COLLATERAL_ADDRESS)
+
+    def test_bad_address_approves_nothing_and_executes_nothing(self, monkeypatch):
+        """Fails if resolution is ever reordered after the approve."""
+        harness = _Harness()
+        monkeypatch.setattr(deposit_module, "execute_core_commands", harness.explode())
+
+        with pytest.raises(InvalidTokenAddressError):
+            deposit(
+                harness.config, DepositParams(account_id=ACCOUNT_ID, amount=AMOUNT, token_address=MALFORMED_ADDRESS)
+            )
+
+        harness.rusd.functions.approve.assert_not_called()
+
+
+class TestWithdraw:
+    """withdraw() mirrors deposit(), and is the recovery path for a non-default token."""
+
+    def test_default_path_is_unchanged(self, monkeypatch):
+        harness = _Harness()
+        monkeypatch.setattr(withdraw_module, "execute_core_commands", harness.recorder())
+
+        withdraw(harness.config, WithdrawParams(account_id=ACCOUNT_ID, amount=AMOUNT))
+
+        assert harness.captured["commands"][0][1] == harness.encoded(RUSD_ADDRESS)
+        harness.rusd.functions.approve.assert_not_called()
+
+    def test_explicit_token_is_encoded(self, monkeypatch):
+        harness = _Harness()
+        monkeypatch.setattr(withdraw_module, "execute_core_commands", harness.recorder())
+
+        withdraw(
+            harness.config,
+            WithdrawParams(account_id=ACCOUNT_ID, amount=AMOUNT, token_address=LOCAL_COLLATERAL_ADDRESS),
+        )
+
+        assert harness.captured["commands"][0][1] == harness.encoded(LOCAL_COLLATERAL_ADDRESS)
+
+    def test_bad_address_executes_nothing(self, monkeypatch):
+        harness = _Harness()
+        monkeypatch.setattr(withdraw_module, "execute_core_commands", harness.explode())
+
+        with pytest.raises(InvalidTokenAddressError):
+            withdraw(
+                harness.config, WithdrawParams(account_id=ACCOUNT_ID, amount=AMOUNT, token_address=MALFORMED_ADDRESS)
+            )


### PR DESCRIPTION
## Review packet

- **What & why:** `deposit()` took its ERC-20 unconditionally from `config["w3contracts"]["rusd"]`, a per-deployment address. Where that is not the margin account's actual collateral the deposit still succeeds and still creates a balance row, but the risk engine does not count it — the account looks funded, margins at zero, and every subsequent order is rejected for insufficient margin with nothing pointing back at the deposit. `DepositParams`/`WithdrawParams` gain an optional `token_address` defaulting to the previous rUSD lookup. No design doc; found while building authoritative account funding for a Localnet risk gate.
- **Blast radius:** Fund path (collateral in/out), on-chain. Two SDK actions + one new resolver + one new exception. No API surface, no persistence, no hot path. Default path is unchanged by identity — `resolve_collateral_token(config, None)` returns the *same object* as before, so the same contract is approved and the same `(address,uint256)` bytes are encoded, with no added RPC call. Every in-repo caller (`examples/rpc/*`) passes `account_id=`/`amount=` by keyword and the new field is trailing with a default, so this is not a breaking change.
- **Verified:** `pytest tests/rpc/` → **13 passed**; full `pytest -m offline` → **159 passed, 355 deselected** (nothing else disturbed). `mypy --config-file pyproject.toml ./ --exclude "sdk/async_api|sdk/async_exec_api"` → **clean, 274 files** — this is the exact repo-wide command the pre-commit hook runs, and the first review round caught that my initial version broke it. `black --check`, `isort --check-only`, `flake8 --ignore=E501,E203,W503`, `pylint --rcfile=pyproject.toml` → all clean, pylint 10.00/10. **CI check:** on base `feat/perpOB`, `pylint.yml` (`Lint` → `make pre-commit`) triggers on `pull_request` with no branch filter, so lint **does** gate this PR; `version-consistency.yml` is scoped to `main`/`develop` and will **not** run; the repo has **no pytest workflow at all**, so the test evidence above is local-only and CI will never re-run it. **Test files:** `tests/rpc/__init__.py` (new, empty) + `tests/rpc/test_collateral_token.py` (new, 188 lines) — no pre-existing test was modified. **CI: `pre-commit (3.10)` green on the final head.** (It went red once: bandit's `B106` heuristic flags a string literal passed to a kwarg named `token_address`; bandit was not installed locally, so I installed it, replaced the literal with a named constant, and confirmed with a probe that bandit still catches the old form — i.e. the fix is real, not bandit skipping the file.) **Review rounds: 3.** Round 1 raised two majors — a repo-wide mypy break, and that the decimals check I first shipped could not detect the bug it was written for (config carries two 6-decimal tokens, `rusd` and `usdc`). Round 2 raised a decisive major: the replacement check, built on `getUsdNodeMarginInfo(accountId).collateral`, was **dead code** — I confirmed independently against mainnet core `0xA763B6…1a80` that funded accounts 2 and 1000 both return the zero address there, so the guard could never fire while its docstrings, exception and tests advertised protection that did not exist. Resolution: removed the validation entirely rather than ship an inert guard. Round 3 found no majors and confirmed no residual false-advertising; its minors on unreceipted claims were fixed by grounding each one.
- **Human focus:** <!-- author: confirm these are the right spots -->
  1. **The central judgement call: shipping the escape hatch without a guard.** I verified `getNodeMarginInfo(accountId, token)` *does* discriminate (rUSD passes, USDC and an unrelated token revert `0x96f103cd`), but `AccountExposure.sol:192-193` raises that same `CollateralIsNotQuote` for **any** non-quote collateral — and supporting collaterals are legitimate and margin-contributing. Rejecting on that revert would block valid deposits, so I did not. If you consider supporting-collateral deposits out of scope for this SDK path, the check becomes safe and worth a follow-up (it needs an ABI entry — `getNodeMarginInfo` is absent from the trimmed `CoreProxy.json`).
  2. **`withdraw()` came along deliberately.** Shipping this on `deposit` alone would be a one-way door: collateral deposited under a non-default token could not be retrieved. It is also why a symmetric collateral *equality* check would have been actively harmful — it would reject the exact call that recovers stranded funds.
  3. **The failure-mode claim in `deposit()`'s docstring** is attributed to a local-deployment observation, not re-verified by me. If the wrong-token deposit actually reverts on mainnet-configured core, that wording should soften further.
- **Not covered:** <!-- author: confirm/extend -->
  - **No live chain run.** Another session owns the Localnet cluster, so the end-to-end "funded account can actually trade" path is unexercised. All contract interaction in the tests is mocked; the only real chain traffic was read-only `eth_call`s to public mainnet RPC to settle the two design questions above.
  - **No CI test coverage, ever** — the repo has no pytest workflow, so these 13 tests run only when someone runs them locally. `tests/rpc` is also not in `Makefile`'s `E2E_TEST_PATHS`; it is reachable via the registered `offline` marker.
  - **Siblings left unchanged** (reported, not fixed): `actions/transfer.py:31`, `actions/stake.py:30`, `actions/bridge_out.py:116,130` all still hardcode `rusd`, and `actions/bridge_in.py:158` hardcodes `usdc` — same hazard class. Root cause is `config.py:24,26,38,40`, where `rusd_address`/`usdc_address` are defined only for chains 1729 and 89346162; `get_config()` raises `InvalidChainIdError` for anything else including 31337, which is why local callers hand-roll config dicts and why the escape hatch here is an argument rather than a config entry. `bridge_in.py:128` shows the better long-term shape — it resolves its source-chain token from chain via `vault.functions.token()`.
  - **Concurrent work:** a separate session owns `feat/localnet-risk-gate-sdk-accommodation`, touching `sdk/reya_rest_api/client.py`, `config.py`, `tests/conftest.py`, `tests/engine/`, `tests/helpers/`, `tests/parity/`, `tests/validation/`. This PR touches **none** of those — it is confined to `sdk/reya_rpc/` plus a new `tests/rpc/`. No conflict expected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
