### PR TITLE
docs: add OpenChainBench live RPC latency benchmark link

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 This project is licensed under the MIT License - see the LICENSE file for details.
 
+## Network Resources
+
+- [OpenChainBench live latency benchmark](https://openchainbench.com/benchmarks/reya-rpc) — independent p50/p90/p99 latency measurements for free Reya RPC endpoints, updated every 60 s
+
 ## Support
 
 For any questions or support, please open a ticket on [Discord](https://discord.com/invite/reyaxyz).


### PR DESCRIPTION
Adds a **Network Resources** section to the README with a link to the independent RPC latency benchmark on [OpenChainBench](https://openchainbench.com/benchmarks/reya-rpc).

The benchmark probes the free public Reya RPC endpoints every 60 s and reports p50/p90/p99 latency — useful for SDK users and integrators choosing which endpoint to connect to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Network Resources section with a link to the live latency benchmark for Reya RPC endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->