### PR TITLE
test(engine): skip when the order would cross, and report cancel reasons instead of guessing

### DIFF
--- a/tests/engine/test_gtt_lifecycle.py
+++ b/tests/engine/test_gtt_lifecycle.py
@@ -115,9 +115,7 @@ async def test_gtt_reaped_at_expiry(
     # the defect this test hunts, while a USER_CANCEL / MASS_CANCEL from another
     # actor on this shared account means the precondition was removed and the
     # behaviour simply cannot be observed.
-    await assert_resting_or_explain(
-        maker, order_id, label=f"[{market_type}]", expires_after=expires_after
-    )
+    await assert_resting_or_explain(maker, order_id, label=f"[{market_type}]", expires_after=expires_after)
 
     # Upper bound: reaped within a finite window AFTER expiry — no explicit cancel.
     await maker.wait.for_order_state(order_id, OrderStatus.CANCELLED, timeout=REAP_WAIT_TIMEOUT_S)
@@ -175,9 +173,7 @@ async def test_gtc_survives_while_gtt_is_reaped(
         remaining = (expires_after - GTT_REAP_PRE_EXPIRY_MARGIN_S) - time.time()
         if remaining > 0:
             await asyncio.sleep(remaining)
-        await assert_resting_or_explain(
-            maker, gtt_id, label=f"[{market_type}]", expires_after=expires_after
-        )
+        await assert_resting_or_explain(maker, gtt_id, label=f"[{market_type}]", expires_after=expires_after)
         gtc_pre = await maker.data.open_order(gtc.order_id)
         assert gtc_pre is not None and gtc_pre.status == OrderStatus.OPEN, f"[{market_type}] GTC must rest"
 

--- a/tests/engine/test_gtt_lifecycle.py
+++ b/tests/engine/test_gtt_lifecycle.py
@@ -39,7 +39,7 @@ from tests.helpers.gtt_timing import (
 )
 from tests.helpers.liquidity_detector import skip_if_external_config_liquidity
 from tests.helpers.market_config import PerpTestConfig, SpotTestConfig
-from tests.helpers.order_lifecycle import rest_gtc, rest_gtt, wait_for_order_fields
+from tests.helpers.order_lifecycle import assert_resting_or_explain, rest_gtc, rest_gtt, wait_for_order_fields
 from tests.helpers.reya_tester import logger
 from tests.helpers.settlement import SettlementProbe
 
@@ -111,10 +111,12 @@ async def test_gtt_reaped_at_expiry(
     remaining = (expires_after - GTT_REAP_PRE_EXPIRY_MARGIN_S) - time.time()
     if remaining > 0:
         await asyncio.sleep(remaining)
-    early = await maker.data.open_order(order_id)
-    assert early is not None and early.status == OrderStatus.OPEN, (
-        f"[{market_type}] GTT was reaped BEFORE its expiresAfter "
-        f"(observed gone at ~{int(time.time())} < {expires_after})"
+    # Reports the cancel REASON when the order is gone: an early GTT_EXPIRED is
+    # the defect this test hunts, while a USER_CANCEL / MASS_CANCEL from another
+    # actor on this shared account means the precondition was removed and the
+    # behaviour simply cannot be observed.
+    await assert_resting_or_explain(
+        maker, order_id, label=f"[{market_type}]", expires_after=expires_after
     )
 
     # Upper bound: reaped within a finite window AFTER expiry — no explicit cancel.
@@ -173,11 +175,10 @@ async def test_gtc_survives_while_gtt_is_reaped(
         remaining = (expires_after - GTT_REAP_PRE_EXPIRY_MARGIN_S) - time.time()
         if remaining > 0:
             await asyncio.sleep(remaining)
-        gtt_pre = await maker.data.open_order(gtt_id)
+        await assert_resting_or_explain(
+            maker, gtt_id, label=f"[{market_type}]", expires_after=expires_after
+        )
         gtc_pre = await maker.data.open_order(gtc.order_id)
-        assert (
-            gtt_pre is not None and gtt_pre.status == OrderStatus.OPEN
-        ), f"[{market_type}] GTT must rest before expiry"
         assert gtc_pre is not None and gtc_pre.status == OrderStatus.OPEN, f"[{market_type}] GTC must rest"
 
         # The GTT is auto-reaped at its expiry (no explicit cancel)...

--- a/tests/helpers/liquidity_detector.py
+++ b/tests/helpers/liquidity_detector.py
@@ -368,9 +368,7 @@ async def skip_if_external_liquidity(
     )
 
 
-async def skip_if_order_would_cross(
-    config, tester, *, price: Decimal | str | float, is_buy: bool, reason: str
-) -> None:
+async def skip_if_order_would_cross(config, tester, *, price: Decimal | str | float, is_buy: bool, reason: str) -> None:
     """Skip only when a resting order at THIS price on THIS side would cross
     external liquidity.
 

--- a/tests/helpers/liquidity_detector.py
+++ b/tests/helpers/liquidity_detector.py
@@ -368,6 +368,37 @@ async def skip_if_external_liquidity(
     )
 
 
+async def skip_if_order_would_cross(
+    config, tester, *, price: Decimal | str | float, is_buy: bool, reason: str
+) -> None:
+    """Skip only when a resting order at THIS price on THIS side would cross
+    external liquidity.
+
+    The two guards above skip on ANY external liquidity, which is right for
+    tests needing an empty book (deterministic fills, self-match) but far too
+    blunt for tests that merely need their own order to REST: an order well
+    outside the touch rests perfectly happily while a market-making bot quotes
+    around mid. Using the blunt guard there trades false failures for false
+    skips -- it silently deletes real coverage.
+
+    So ask the precise question instead: is there external size at this price
+    or better on the opposite side? Only then would the order fill instead of
+    rest.
+    """
+    await config.refresh_order_book(tester.data)
+    detector = LiquidityDetector(float(config.oracle_price))
+    state = await detector.get_order_book_state(tester.data, config.symbol)
+    # A buy crosses resting ASKS at or below its price; a sell crosses BIDS at
+    # or above it.
+    opposite = "ask" if is_buy else "bid"
+    crossing_qty = detector.get_qty_at_price_or_better(state, opposite, Decimal(str(price)))
+    if crossing_qty > 0:
+        pytest.skip(
+            f"Skipping: {crossing_qty} external {opposite} qty at {price} or better "
+            f"would fill this order instead of resting it. {reason}"
+        )
+
+
 async def skip_if_external_config_liquidity(config, tester, reason: str) -> None:
     """Config-flavoured twin of `skip_if_external_liquidity` for tests that
     hold a `MarketTestConfig`: refreshes the config's cached book via the

--- a/tests/helpers/order_lifecycle.py
+++ b/tests/helpers/order_lifecycle.py
@@ -11,12 +11,15 @@ when the modify, post-only and orderbook suites all needed them."""
 from __future__ import annotations
 
 import asyncio
+
+import pytest
 import time
 from decimal import Decimal
 
 from tests.helpers.liquidity_detector import skip_if_order_would_cross
 from sdk.async_api.order import Order as AsyncOrder
 from sdk.open_api.models.order import Order
+from sdk.open_api.models.order_status import OrderStatus
 from sdk.open_api.models.perp_execution import PerpExecution
 from sdk.open_api.models.spot_execution import SpotExecution
 from tests.helpers import ReyaTester
@@ -327,3 +330,56 @@ async def wait_for_ws_order_change(
         f"No WS orderChange with px={limit_px} qty={qty} for order {order_id} within {timeout_s}s; "
         f"last seen: {last_seen}"
     )
+
+async def assert_resting_or_explain(
+    tester,
+    order_id,
+    *,
+    label: str,
+    expires_after: int,
+) -> None:
+    """Assert an order is still resting, and when it is NOT, say WHY.
+
+    The naive form of this check -- ``assert order is not None`` -- reads any
+    disappearance as the reaper firing early, because that is the bug the
+    caller is hunting. On a shared environment that is usually wrong: the
+    order is far more often cancelled by somebody else's mass-cancel, a COD
+    deadline, or the risk engine. The cancel reason distinguishes them
+    unambiguously and is already on the WS order, so an assertion that omits
+    it turns a one-line answer into an investigation.
+
+    GTT_EXPIRED before ``expires_after`` is the real defect and FAILS loudly.
+    Every other reason means the environment removed the precondition rather
+    than the engine misbehaving, so the test SKIPS naming the reason -- same
+    philosophy as the liquidity guards above.
+    """
+    order = await tester.data.open_order(order_id)
+    if order is not None and order.status == OrderStatus.OPEN:
+        return
+
+    ws_order = tester.ws.orders.get(str(order_id))
+    reason = getattr(ws_order, "cancel_reason", None)
+    now = int(time.time())
+    early_by = expires_after - now
+
+    if reason is None:
+        pytest.fail(
+            f"{label} order {order_id} vanished {early_by}s before its expiry "
+            f"({now} < {expires_after}) and no cancel reason reached the WS "
+            f"client -- cannot tell an early reap from an external cancel."
+        )
+
+    if str(getattr(reason, "value", reason)).upper().endswith("GTT_EXPIRED"):
+        pytest.fail(
+            f"{label} GTT was reaped EARLY: cancelled GTT_EXPIRED at {now}, "
+            f"{early_by}s before its expiresAfter ({expires_after}). This is "
+            f"the matching engine reaping ahead of the deadline."
+        )
+
+    pytest.skip(
+        f"{label} order {order_id} was cancelled by "
+        f"{getattr(reason, 'value', reason)} {early_by}s before "
+        f"its expiry -- something outside this test removed it (shared "
+        f"environment), so the reap behaviour cannot be observed."
+    )
+

--- a/tests/helpers/order_lifecycle.py
+++ b/tests/helpers/order_lifecycle.py
@@ -11,12 +11,11 @@ when the modify, post-only and orderbook suites all needed them."""
 from __future__ import annotations
 
 import asyncio
-
-import pytest
 import time
 from decimal import Decimal
 
-from tests.helpers.liquidity_detector import skip_if_order_would_cross
+import pytest
+
 from sdk.async_api.order import Order as AsyncOrder
 from sdk.open_api.models.order import Order
 from sdk.open_api.models.order_status import OrderStatus
@@ -24,6 +23,7 @@ from sdk.open_api.models.perp_execution import PerpExecution
 from sdk.open_api.models.spot_execution import SpotExecution
 from tests.helpers import ReyaTester
 from tests.helpers.builders import OrderBuilder
+from tests.helpers.liquidity_detector import skip_if_order_would_cross
 from tests.helpers.market_config import MarketTestConfig, SpotTestConfig
 
 
@@ -331,6 +331,7 @@ async def wait_for_ws_order_change(
         f"last seen: {last_seen}"
     )
 
+
 async def assert_resting_or_explain(
     tester,
     order_id,
@@ -382,4 +383,3 @@ async def assert_resting_or_explain(
         f"its expiry -- something outside this test removed it (shared "
         f"environment), so the reap behaviour cannot be observed."
     )
-

--- a/tests/helpers/order_lifecycle.py
+++ b/tests/helpers/order_lifecycle.py
@@ -14,6 +14,7 @@ import asyncio
 import time
 from decimal import Decimal
 
+from tests.helpers.liquidity_detector import skip_if_order_would_cross
 from sdk.async_api.order import Order as AsyncOrder
 from sdk.open_api.models.order import Order
 from sdk.open_api.models.perp_execution import PerpExecution
@@ -84,11 +85,30 @@ async def rest_gtc(
     ``market_config.price(multiplier)`` on the config's symbol, wait for
     creation, return the fetched Order. Unifies the `rest_spot_gtc` /
     `rest_perp_gtc` split."""
+    # A maker order can only be MODIFIED, EXPIRED or CANCELLED if it actually
+    # RESTS. When someone else's liquidity (typically a market-making bot on
+    # the same env) sits inside the band, this order crosses it and fills
+    # instantly instead of resting -- and the caller then dies in
+    # `for_order_creation` with the opaque "Order X not created after 10
+    # seconds", which points at order creation rather than at the book.
+    #
+    # Guarded HERE rather than per-test: every caller needs the order to rest,
+    # so the precondition belongs with the helper. The perp suites already
+    # skip on this via the same detector; the modify and GTT batteries reach
+    # the book through this helper and failed instead of skipping.
+    px_gtc = str(market_config.price(price_multiplier))
+    await skip_if_order_would_cross(
+        market_config,
+        tester,
+        price=px_gtc,
+        is_buy=is_buy,
+        reason="rest_gtc needs the maker order to REST.",
+    )
     builder = (
         OrderBuilder()
         .symbol(market_config.symbol)
         .side(is_buy)
-        .price(str(market_config.price(price_multiplier)))
+        .price(px_gtc)
         .qty(qty if qty is not None else market_config.min_qty)
         .gtc()
     )
@@ -122,7 +142,25 @@ async def rest_gtt(
     (default client deadline is now+60s) for tests that must not expire mid-run.
     Pass an absolute ``price`` (e.g. the re-fetched current mark) for crossing
     tests where the stale session-config price would drift off the perp band."""
+    # A maker order can only be MODIFIED, EXPIRED or CANCELLED if it actually
+    # RESTS. When someone else's liquidity (typically a market-making bot on
+    # the same env) sits inside the band, this order crosses it and fills
+    # instantly instead of resting -- and the caller then dies in
+    # `for_order_creation` with the opaque "Order X not created after 10
+    # seconds", which points at order creation rather than at the book.
+    #
+    # Guarded HERE rather than per-test: every caller needs the order to rest,
+    # so the precondition belongs with the helper. The perp suites already
+    # skip on this via the same detector; the modify and GTT batteries reach
+    # the book through this helper and failed instead of skipping.
     px = price if price is not None else str(market_config.price(price_multiplier))
+    await skip_if_order_would_cross(
+        market_config,
+        tester,
+        price=px,
+        is_buy=is_buy,
+        reason="rest_gtt needs the maker order to REST.",
+    )
     builder = (
         OrderBuilder()
         .symbol(market_config.symbol)


### PR DESCRIPTION
## Problem

The modify battery fails ~16 tests on devnet with an opaque error:

```
RuntimeError: Order 1874516031951601664 not created after 10 seconds
```

The order **is** created. It just **fills instantly instead of resting**, because a market-making bot is quoting on the same env — so the waiter never sees a resting order and times out pointing at order *creation* rather than at the book.

This isn't a new discovery: `tests/perp/test_position_management.py` documents the exact trap in a module comment, and the perp suites avoid it with `skip_if_external_liquidity`. The modify and GTT batteries reach the book through `rest_gtc` / `rest_gtt`, which had no guard — so they failed instead of skipping.

Confirmed live — a guarded suite skips with:
> `external ETHRUSDPERP liquidity present (likely a market-making bot on the same env)`

## Fix

Guard in the **helpers**, not per-test: every caller of `rest_gtc` / `rest_gtt` needs its order to REST, so the precondition belongs with the helper rather than being restated at 14 call sites.

### The obvious guard was wrong

Reusing the existing blunt `skip_if_external_config_liquidity` here **skips on ANY external liquidity**, which took the suite from `16 failed / 16 passed` to **`0 failed / 0 passed / 35 skipped`**. That trades false failures for false skips and silently deletes real coverage — an order well outside the touch rests perfectly happily while a bot quotes around mid.

So this adds **`skip_if_order_would_cross`**, which asks the precise question: *is there size at THIS price or better on the OPPOSITE side?* Only then would the order fill instead of rest. It reuses the detector's existing `get_qty_at_price_or_better`.

## Measured

| | failed | passed | skipped |
| -- | -- | -- | -- |
| before (no guard) | **16** | 16 | 3 |
| blunt guard | 0 | **0** | 35 |
| **price-aware guard** | **0** | **13** | 22 |

Offline suite still **239 passed**. The previously-guarded perp suites are unaffected — they call the detector directly rather than going through these helpers.

(13 vs 16 passing is book variance between runs — liquidity moves — not extra conservatism: the guard reads the same book data the blunt one does.)

## Not addressed here

The **session-scoped execution-busts guard** errors at teardown of *every* run, reporting a "settlement regression" with equal start/end counts `(100, 100)`. The `executionBusts` endpoint caps at **exactly 100**, so the guard compares two different capped windows — and on shared devnet accounts it cannot distinguish the run's own busts from anyone else's. Wants its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Second commit: GTT tests now report the cancel REASON

The GTT reap tests failed with what reads as a matching-engine correctness bug:

```
AssertionError: [perp] GTT was reaped BEFORE its expiresAfter
  (observed gone at ~1787682507 < 1787682522)
```

**It isn't one.** The order carried **`CancelReason.USER_CANCEL`**. The ME's reaper sets `GTT_EXPIRED`, so something outside the test cancelled it on the shared devnet account.

The assertion couldn't tell those apart. It sleeps from creation to `expiry − 15s`, then treats *any* disappearance as the reaper firing early — because that's the bug it hunts. It never polls in between, so "observed gone at expiry−15" only means "gone at some point before then", and the message asserts a cause the test never established. The cancel reason was on the WS order the whole time.

`assert_resting_or_explain` now reads it and splits the cases:

| observed | outcome |
| -- | -- |
| still resting | pass |
| `GTT_EXPIRED` before expiry | **FAIL loudly** — the real defect |
| any other reason | **SKIP**, naming it — the environment removed the precondition |
| no reason available | **FAIL** saying exactly that, rather than guessing |

**Verified live:** the perp case now skips with `cancelled by USER_CANCEL 15s before its expiry`, and the **spot case passes** — the reaper itself is fine. All four branches unit-checked; offline suite 239 passed.

### Why this matters beyond GTT

This assertion cost a 20-minute investigation to reach a one-line answer that was already in the data. Worth noting the same shape elsewhere: several suites assert "order should be gone / still here" without reading the reason, and on a shared environment that turns external interference into a product-bug-shaped failure.
