### PR TITLE
test(api): cover read-endpoint snapshots, capture WS error frames, and name what is not covered

### DIFF
--- a/tests/api_contract/test_read_endpoints.py
+++ b/tests/api_contract/test_read_endpoints.py
@@ -1,0 +1,91 @@
+"""Read-endpoint contract: the snapshot paths a UI hits on load.
+
+These broke twice on devnet in one day and the suite stayed green both
+times:
+
+  * ``/v2/assetDefinitions`` 500'd for every caller, because a collateral
+    registered on-chain had no asset identity off-chain.
+  * the WS ``accountBalances`` snapshot failed for a wallet holding that
+    collateral, while REST was already fixed -- the websocket builds the
+    snapshot itself rather than proxying REST.
+
+Neither was caught, for two independent reasons this module addresses:
+
+1. Nothing asserted the WS snapshot SUCCEEDS. The harness subscribes to
+   the wallet channels and only ever reads the data stores, so a server
+   error frame was dropped silently for the whole session.
+2. The test wallets hold rUSD and wETH only. The failure needs a wallet
+   holding the collateral that cannot be resolved, so the path was never
+   executed regardless of assertions.
+
+(1) is fixed here and in the WS harness. (2) cannot be fixed by asserting
+harder -- it needs a wallet that holds the asset -- so the per-asset test
+below SKIPS with the asset named, making the hole visible in the report
+instead of leaving a green run that proves less than it appears to.
+"""
+
+import pytest
+
+from tests.helpers import ReyaTester
+
+pytestmark = [pytest.mark.rest_api, pytest.mark.balance]
+
+
+async def _asset_definitions(tester: ReyaTester):
+    return await tester.client.reference.get_asset_definitions()
+
+
+async def test_asset_definitions_resolves(reya_tester: ReyaTester):
+    """Every configured collateral must render. A collateral with no asset
+    identity used to take the whole endpoint down with it."""
+    definitions = await _asset_definitions(reya_tester)
+    assert definitions, "assetDefinitions returned nothing"
+    for d in definitions:
+        assert d.asset, f"asset definition without an asset: {d}"
+        assert d.decimals is not None, f"{d.asset} has no decimals"
+
+
+async def test_wallet_balances_rest_resolves(reya_tester: ReyaTester):
+    """REST balances must resolve every collateral the wallet holds."""
+    balances = await reya_tester.client.get_account_balances()
+    for b in balances:
+        assert b.asset, f"balance row without an asset: {b}"
+        assert b.real_balance is not None, f"{b.asset} balance did not resolve"
+
+
+async def test_wallet_balances_ws_snapshot_has_no_error_frame(reya_tester: ReyaTester):
+    """The WS wallet channels must not answer a subscribe with an error.
+
+    The session fixture already subscribes to the wallet channels, so by
+    the time this runs any snapshot failure has already been reported --
+    and, before the harness captured error frames, silently discarded.
+    """
+    errors = [e for e in reya_tester.ws.errors if "/wallet/" in (getattr(e, "channel", None) or "")]
+    assert not errors, "WS wallet channels returned error frames: " + "; ".join(
+        f"{e.channel}: {e.message}" for e in errors
+    )
+
+
+async def test_every_configured_asset_is_exercised_by_some_balance(
+    reya_tester: ReyaTester,
+):
+    """Name the assets this suite cannot vouch for.
+
+    The balance transform runs per held collateral, so an asset the test
+    wallet does not hold is never exercised no matter how many assertions
+    run. Rather than pass quietly, report which assets are uncovered --
+    that list is exactly the blind spot that let both incidents through.
+    """
+    definitions = await _asset_definitions(reya_tester)
+    configured = {str(d.asset).upper() for d in definitions}
+    balances = await reya_tester.client.get_account_balances()
+    held = {str(b.asset).upper() for b in balances}
+
+    uncovered = sorted(configured - held)
+    if uncovered:
+        pytest.skip(
+            "test wallet holds none of: "
+            + ", ".join(uncovered)
+            + " -- their balance/snapshot path is NOT exercised by this suite. "
+            "Fund a test account with them to close the gap."
+        )

--- a/tests/helpers/reya_tester/websocket.py
+++ b/tests/helpers/reya_tester/websocket.py
@@ -17,6 +17,7 @@ from decimal import Decimal
 from sdk.async_api.account_balance import AccountBalance as AsyncAccountBalance
 from sdk.async_api.account_balance_update_payload import AccountBalanceUpdatePayload
 from sdk.async_api.depth import Depth
+from sdk.async_api.error_message_payload import ErrorMessagePayload
 from sdk.async_api.execution_bust import ExecutionBust as AsyncExecutionBust
 from sdk.async_api.market_depth_update_payload import MarketDepthUpdatePayload
 from sdk.async_api.market_execution_bust_update_payload import MarketExecutionBustUpdatePayload
@@ -58,6 +59,13 @@ class WebSocketState:
         self.perp_executions: EventStore[AsyncPerpExecution] = EventStore()
         self.spot_executions: EventStore[AsyncSpotExecution] = EventStore(key_fn=lambda x: str(x.taker_order_id))
         self.balance_updates: EventStore[AsyncAccountBalance] = EventStore()
+
+        # Server-sent error frames. The harness previously dropped these on the
+        # floor: a channel could fail its snapshot for the whole session and no
+        # test would notice, because subscribe() is fire-and-forget and every
+        # assertion looks at the DATA stores. A wallet holding a collateral the
+        # backend cannot resolve produced exactly that silence.
+        self.errors: list[ErrorMessagePayload] = []
 
         # Keyed stores: direct lookup by key
         self.positions: EventStore[AsyncPosition] = EventStore(key_fn=lambda x: x.symbol)
@@ -217,6 +225,11 @@ class WebSocketState:
         Uses EventStore for unified state tracking.
         """
         logger.info(f"Received message: {type(message).__name__}")
+
+        if isinstance(message, ErrorMessagePayload):
+            logger.error(f"WS error frame: channel={getattr(message, 'channel', None)} {message.message}")
+            self.errors.append(message)
+            return
 
         # Handle subscribed messages with initial snapshots
         if isinstance(message, OrderChangesSubscribedPayload):


### PR DESCRIPTION
## Why

Two devnet read paths broke in one day and **this suite stayed green for both**:

| what broke | why the suite missed it |
| -- | -- |
| `/v2/assetDefinitions` 500'd for every caller | no test asserted it resolves |
| WS `accountBalances` snapshot failed for a wallet holding the unresolvable collateral | error frames were discarded; test wallets don't hold that collateral |

The websocket **builds that snapshot itself** rather than proxying REST, so fixing the api left it broken — reported by Costin after the api was already green.

## Two independent causes, addressed differently

**1. Nothing asserted the WS snapshot succeeds.** The harness subscribes to the wallet channels and only ever reads the *data* stores — `subscribe()` is fire-and-forget, so a server error frame was dropped on the floor for the whole session. `WebSocketState` now captures `ErrorMessagePayload` frames, and a test asserts no wallet channel answered a subscribe with an error.

Verified by feeding the handler the exact frame from the incident:
```
captured: 1
channel : /v2/wallet/0xae17.../accountBalances
would the assertion fire? True
```

**2. The test wallets hold rUSD and wETH only.** The failing transform runs **per held collateral**, so the broken path was never executed regardless of assertions. Asserting harder cannot fix this — it needs a wallet that holds the asset.

## Not papering over (2)

The last test diffs configured assets against the wallet's holdings and **skips naming the uncovered ones**. On devnet today:

```
SKIPPED: test wallet holds none of: SRUSD -- their balance/snapshot path
is NOT exercised by this suite. Fund a test account with them to close the gap.
```

That is exactly the blind spot both incidents came through. A green run that silently proves less than it appears to is worse than a named skip.

**Closing it properly means funding a test account with each configured collateral** — an environment change, not a test change, so it's called out rather than hidden.

## Tests

New module: 3 passed, 1 skipped (the named gap). Offline suite 239 passed. pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
