### PR TITLE
test(cod): assert the test's own orders were cancelled, not that the account is empty

### DIFF
--- a/tests/engine/test_cod_lifecycle.py
+++ b/tests/engine/test_cod_lifecycle.py
@@ -80,18 +80,31 @@ def _assert_trigger_at_echo(response: CancelAllAfterResponse, timeout_ms: int, s
     )
 
 
-async def _wait_until_no_open_orders(tester: ReyaTester, timeout_s: float) -> None:
-    """Poll REST open orders until the account has none (bounded)."""
+async def _wait_until_orders_cancelled(tester: ReyaTester, order_ids: list, timeout_s: float) -> None:
+    """Poll REST until the orders THIS test rested are gone (bounded).
+
+    Deliberately scoped to `order_ids` rather than asserting the account has
+    zero open orders. What COD guarantees is that the orders resting when the
+    countdown fires get cancelled -- not that the account stays empty
+    afterwards. Those are the same claim only on an account nobody else
+    touches, and the devnet accounts are shared: measured on a failing run,
+    all 3 of the test's own orders WERE cancelled while 10-11 orders with
+    strictly newer snowflake ids (i.e. placed after the arm) kept the global
+    count above zero. The old assertion failed on somebody else's traffic and
+    read as a COD defect.
+    """
+    wanted = {str(o) for o in order_ids}
     deadline = time.time() + timeout_s
-    remaining: list = []
+    remaining: set = set()
     while time.time() < deadline:
-        remaining = await tester.client.get_open_orders()
+        open_ids = {str(o.order_id) for o in await tester.client.get_open_orders()}
+        remaining = wanted & open_ids
         if not remaining:
             return
         await asyncio.sleep(0.5)
     raise AssertionError(
-        f"Account {tester.account_id} still has {len(remaining)} open order(s) after {timeout_s}s: "
-        f"{[o.order_id for o in remaining]}"
+        f"Account {tester.account_id}: {len(remaining)} of this test's {len(wanted)} order(s) "
+        f"survived the COD fire after {timeout_s}s: {sorted(remaining)}"
     )
 
 
@@ -152,7 +165,7 @@ async def test_cod_fires_cancels_all_orders(
     await maker.arm_cod(timeout_ms=5_000)
 
     # timeout + scan granularity + clock-skew margin.
-    await _wait_until_no_open_orders(maker, timeout_s=5.0 + FIRE_MARGIN_S)
+    await _wait_until_orders_cancelled(maker, order_ids, timeout_s=5.0 + FIRE_MARGIN_S)
     logger.info(f"[{market_type}] ✅ COD fired: all orders cancelled")
 
     # The fire must also notify over WS: an orderChange with status CANCELLED
@@ -255,7 +268,7 @@ async def test_account_isolation(spot_config: SpotTestConfig, maker_tester: Reya
 
     try:
         await maker_tester.arm_cod(timeout_ms=5_000)
-        await _wait_until_no_open_orders(maker_tester, timeout_s=5.0 + FIRE_MARGIN_S)
+        await _wait_until_orders_cancelled(maker_tester, [maker_order_id], timeout_s=5.0 + FIRE_MARGIN_S)
         logger.info("✅ Account A's COD fired")
 
         assert await _order_is_open(taker_tester, taker_order_id), (
@@ -277,7 +290,7 @@ async def test_rearm_after_fire(spot_config: SpotTestConfig, spot_tester: ReyaTe
     await spot_tester.wait.for_order_creation(order_id)
 
     await spot_tester.arm_cod(timeout_ms=5_000)
-    await _wait_until_no_open_orders(spot_tester, timeout_s=5.0 + FIRE_MARGIN_S)
+    await _wait_until_orders_cancelled(spot_tester, [order_id], timeout_s=5.0 + FIRE_MARGIN_S)
     logger.info("✅ First COD fire completed")
 
     sent_at_ms = time.time() * 1000

--- a/tests/engine/test_cod_ws_exec.py
+++ b/tests/engine/test_cod_ws_exec.py
@@ -72,18 +72,27 @@ async def _wait_for_open_order(rest: ReyaTradingClient, order_id: str, timeout_s
     raise AssertionError(f"Order {order_id} not visible via REST within {timeout_s}s")
 
 
-async def _wait_until_no_open_orders(rest: ReyaTradingClient, timeout_s: float) -> None:
-    """Poll openOrders until the account has none — proves the fire emptied it."""
+async def _wait_until_orders_cancelled(rest: ReyaTradingClient, order_ids: list, timeout_s: float) -> None:
+    """Poll openOrders until the orders THIS test rested are gone.
+
+    Scoped to `order_ids` rather than "the account is empty": COD promises to
+    cancel what was resting when it fired, not that the account stays empty.
+    The devnet accounts are shared, so orders placed by anyone else after the
+    arm kept the global count above zero and failed this as if COD had not
+    fired. Mirrors _wait_until_orders_cancelled in test_cod_lifecycle.
+    """
+    wanted = {str(o) for o in order_ids}
     deadline = time.time() + timeout_s
-    remaining: list[Order] = []
+    remaining: set = set()
     while time.time() < deadline:
-        remaining = await rest.get_open_orders()
+        open_ids = {str(o.order_id) for o in await rest.get_open_orders()}
+        remaining = wanted & open_ids
         if not remaining:
             return
         await asyncio.sleep(0.5)
     raise AssertionError(
-        f"Account still has {len(remaining)} open order(s) {timeout_s}s after arming: "
-        f"{[o.order_id for o in remaining]}"
+        f"{len(remaining)} of this test's {len(wanted)} order(s) survived the COD fire "
+        f"after {timeout_s}s: {sorted(remaining)}"
     )
 
 
@@ -142,7 +151,7 @@ async def test_ws_exec_arm_fires_cancels_resting_order(ws_exec_market: WsExecMar
         assert armed.trigger_at is not None, f"[{m.market_type}] armed countdown must echo triggerAt: {armed}"
 
         # timeout + ME scan granularity + clock-skew margin.
-        await _wait_until_no_open_orders(m.rest, timeout_s=FIRE_TIMEOUT_MS / 1000 + FIRE_MARGIN_S)
+        await _wait_until_orders_cancelled(m.rest, [order_id], timeout_s=FIRE_TIMEOUT_MS / 1000 + FIRE_MARGIN_S)
         fired = True
         print(f"  [ws-exec {m.market_type}] COD fired: order {order_id} cancelled by the WS-armed countdown")
 


### PR DESCRIPTION
## What looked like a COD bug

All 6 cancel-on-disconnect tests failed on devnet:

```
AssertionError: Account 10000000002 still has 10 open order(s) after 8.0s
```

**COD fires correctly.** Measured on a failing run by comparing snowflake ids (which are time-ordered):

| | |
| -- | -- |
| orders the test placed | **3** |
| of those, still open after the fire | **0** — all cancelled |
| lingering orders | 10–11, **all with strictly newer ids** than the test's newest |

Every lingering order was placed **after the countdown had already armed**. They belong to somebody else on the shared devnet account.

## The assertion over-claimed

`_wait_until_no_open_orders` required the **account** to reach zero open orders. What COD guarantees is that the orders **resting when it fires** get cancelled. Those are the same claim only on an account nobody else touches — so on shared accounts the assertion could not pass however correctly the engine behaved, and its failure message blamed the engine.

Rescoped both copies (lifecycle + ws-exec) to the ids the test itself rested.

## Not now vacuous

Verified explicitly, because a scoped assertion is easy to weaken into one that always passes:

```
foreign orders remain, test's own gone  ->  PASSED
one of the test's OWN orders survives   ->  AssertionError: 1 of this test's 3
                                            order(s) survived the COD fire
```

The second case is the real defect this test exists to catch, and it still fails.

## Result

Both COD suites: **15 passed** (was 6 failing). Offline suite 239 passed, pre-commit clean. The remaining teardown error is the pre-existing execution-busts guard, untouched here.

## Pattern

Third cluster traced this way, and the same shape each time — the assertion claimed more than the feature promises, on an environment shared with other actors:

- **modify** — assumed a maker order would rest (it filled against a market-making bot)
- **GTT** — assumed disappearance meant the reaper fired early (it was `USER_CANCEL`)
- **COD** — assumes the account is exclusively the test's

None was a product defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
