### PR TITLE
fix(PRO-198): close REST and WebSocket coverage gaps

### DIFF
--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -353,7 +353,7 @@ class ReyaSocket(WebSocketApp):
             ]
 
             if payloads:
-                logger.info(f"Restoring {len(payloads)} WebSocket subscription(s)")
+                logger.info(f"Checking {len(payloads)} WebSocket subscription(s) for restoration")
 
         for channel, payload in payloads:
             with self._subscription_lock:

--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -178,7 +178,8 @@ class ReyaSocket(WebSocketApp):
 
             # Parse into typed model (raises WebSocketDataError on failure)
             typed_message = self._parse_message(raw)
-            self._received_message_this_run = True
+            if not isinstance(typed_message, ErrorMessagePayload):
+                self._received_message_this_run = True
 
             # Call user callback or default with typed message
             if self._user_on_message is not None:

--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -314,8 +314,8 @@ class ReyaSocket(WebSocketApp):
         with self._subscription_lock:
             self.active_subscriptions.add(channel)
             self._subscription_payloads[channel] = payload
-            self._sent_subscriptions_this_connection.add(channel)
             self.send(payload)
+            self._sent_subscriptions_this_connection.add(channel)
 
     def send_unsubscribe(self, channel: str, **kwargs) -> None:
         """Send an unsubscription message.

--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -134,6 +134,8 @@ class ReyaSocket(WebSocketApp):
         # Initialize thread attribute
         self._thread: Optional[threading.Thread] = None
         self._stop_event = threading.Event()
+        self._lifecycle_lock = threading.Lock()
+        self._is_running = False
 
         # Store user callbacks for wrapping
         self._user_on_message = on_message
@@ -150,8 +152,7 @@ class ReyaSocket(WebSocketApp):
         self._subscription_payloads: dict[str, str] = {}
         self._subscription_lock = threading.RLock()
         self._sent_subscriptions_this_connection: set[str] = set()
-        self._has_connected_once = False
-        self._opened_this_run = False
+        self._received_message_this_run = False
 
         super().__init__(
             url=url,
@@ -177,6 +178,7 @@ class ReyaSocket(WebSocketApp):
 
             # Parse into typed model (raises WebSocketDataError on failure)
             typed_message = self._parse_message(raw)
+            self._received_message_this_run = True
 
             # Call user callback or default with typed message
             if self._user_on_message is not None:
@@ -332,18 +334,13 @@ class ReyaSocket(WebSocketApp):
             self.send(json.dumps(message))
 
     def _handle_open(self, ws: WebSocket) -> None:
-        """Run the open callback and restore subscriptions after reconnecting."""
-        is_reconnect = self._has_connected_once
-        self._has_connected_once = True
-        self._opened_this_run = True
-
+        """Run the open callback and restore pending subscriptions."""
         try:
             # Preserve WebSocketApp's lifecycle semantics: user callbacks run
             # for both the initial connection and every subsequent reconnect.
             self._open_callback(ws)
         finally:
-            if is_reconnect:
-                self._restore_subscriptions()
+            self._restore_subscriptions()
 
     def _restore_subscriptions(self) -> None:
         """Replay subscriptions not already sent by the reconnect callback."""
@@ -381,30 +378,43 @@ class ReyaSocket(WebSocketApp):
             else:
                 sslopt = {"cert_reqs": ssl.CERT_NONE}
 
-        if self._thread is not None and self._thread.is_alive():
-            raise RuntimeError("WebSocket connection is already running")
+        thread = None
+        with self._lifecycle_lock:
+            if self._is_running:
+                raise RuntimeError("WebSocket connection is already running")
 
-        self._stop_event.clear()
+            self._is_running = True
+            self._stop_event.clear()
+            if not blocking:
+                thread = threading.Thread(target=self._run_connection, args=(sslopt,), daemon=True)
+                self._thread = thread
+
         logger.info(f"Connecting to {self.url}")
-
         if blocking:
-            # Run the WebSocket directly (blocking)
-            self._run_forever_with_reconnect(sslopt)
+            self._run_connection(sslopt)
         else:
-            # Run the WebSocket in a thread (non-blocking)
-            self._thread = threading.Thread(
-                target=self._run_forever_with_reconnect,
-                args=(sslopt,),
-            )
-            self._thread.daemon = True
-            self._thread.start()
+            try:
+                assert thread is not None
+                thread.start()
+            except BaseException:
+                with self._lifecycle_lock:
+                    self._is_running = False
+                raise
+
+    def _run_connection(self, sslopt) -> None:
+        """Own one blocking or background connection lifecycle."""
+        try:
+            self._run_forever_with_reconnect(sslopt)
+        finally:
+            with self._lifecycle_lock:
+                self._is_running = False
 
     def _run_forever_with_reconnect(self, sslopt) -> None:
         """Run the socket, reconnecting with bounded exponential backoff."""
         failed_attempts = 0
 
         while not self._stop_event.is_set():
-            self._opened_this_run = False
+            self._received_message_this_run = False
             with self._subscription_lock:
                 self._sent_subscriptions_this_connection.clear()
 
@@ -420,7 +430,7 @@ class ReyaSocket(WebSocketApp):
             if self._stop_event.is_set():
                 return
 
-            if self._opened_this_run:
+            if self._received_message_this_run:
                 failed_attempts = 0
 
             if failed_attempts >= self.config.reconnect_attempts:

--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -133,24 +133,29 @@ class ReyaSocket(WebSocketApp):
 
         # Initialize thread attribute
         self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
 
-        # Store user callback for wrapping
+        # Store user callbacks for wrapping
         self._user_on_message = on_message
+        self._open_callback = on_open or self._default_on_open
 
         # Default handlers if none provided
-        if on_open is None:
-            on_open = self._default_on_open
         if on_error is None:
             on_error = self._default_on_error
         if on_close is None:
             on_close = self._default_on_close
 
-        # Track subscriptions
+        # Track subscription intent so it can be restored after reconnecting.
         self.active_subscriptions: set[str] = set()
+        self._subscription_payloads: dict[str, str] = {}
+        self._subscription_lock = threading.RLock()
+        self._sent_subscriptions_this_connection: set[str] = set()
+        self._has_connected_once = False
+        self._opened_this_run = False
 
         super().__init__(
             url=url,
-            on_open=on_open,
+            on_open=self._handle_open,
             on_message=self._wrap_message_handler(),
             on_error=on_error,
             on_close=on_close,
@@ -303,10 +308,14 @@ class ReyaSocket(WebSocketApp):
             channel: The channel to subscribe to.
             **kwargs: Additional subscription parameters.
         """
-        self.active_subscriptions.add(channel)
         message = {"type": "subscribe", "channel": channel, **kwargs}
+        payload = json.dumps(message)
         logger.info(f"Subscribing to {channel}")
-        self.send(json.dumps(message))
+        with self._subscription_lock:
+            self.active_subscriptions.add(channel)
+            self._subscription_payloads[channel] = payload
+            self._sent_subscriptions_this_connection.add(channel)
+            self.send(payload)
 
     def send_unsubscribe(self, channel: str, **kwargs) -> None:
         """Send an unsubscription message.
@@ -315,12 +324,42 @@ class ReyaSocket(WebSocketApp):
             channel: The channel to unsubscribe from.
             **kwargs: Additional unsubscription parameters.
         """
-        if channel in self.active_subscriptions:
-            self.active_subscriptions.remove(channel)
-
         message = {"type": "unsubscribe", "channel": channel, **kwargs}
         logger.info(f"Unsubscribing from {channel}")
-        self.send(json.dumps(message))
+        with self._subscription_lock:
+            self.active_subscriptions.discard(channel)
+            self._subscription_payloads.pop(channel, None)
+            self.send(json.dumps(message))
+
+    def _handle_open(self, ws: WebSocket) -> None:
+        """Run the open callback and restore subscriptions after reconnecting."""
+        is_reconnect = self._has_connected_once
+        self._has_connected_once = True
+        self._opened_this_run = True
+
+        try:
+            # Preserve WebSocketApp's lifecycle semantics: user callbacks run
+            # for both the initial connection and every subsequent reconnect.
+            self._open_callback(ws)
+        finally:
+            if is_reconnect:
+                self._restore_subscriptions()
+
+    def _restore_subscriptions(self) -> None:
+        """Replay subscriptions not already sent by the reconnect callback."""
+        with self._subscription_lock:
+            payloads = [
+                (channel, payload)
+                for channel, payload in self._subscription_payloads.items()
+                if channel not in self._sent_subscriptions_this_connection
+            ]
+
+            if payloads:
+                logger.info(f"Restoring {len(payloads)} WebSocket subscription(s)")
+
+            for channel, payload in payloads:
+                self.send(payload)
+                self._sent_subscriptions_this_connection.add(channel)
 
     def connect(self, sslopt=None, blocking=False) -> None:
         """Connect to the WebSocket server.
@@ -342,27 +381,67 @@ class ReyaSocket(WebSocketApp):
             else:
                 sslopt = {"cert_reqs": ssl.CERT_NONE}
 
+        if self._thread is not None and self._thread.is_alive():
+            raise RuntimeError("WebSocket connection is already running")
+
+        self._stop_event.clear()
         logger.info(f"Connecting to {self.url}")
 
         if blocking:
             # Run the WebSocket directly (blocking)
-            self.run_forever(
-                sslopt=sslopt,
-                ping_interval=self.config.ping_interval,
-                ping_timeout=self.config.ping_timeout,
-            )
+            self._run_forever_with_reconnect(sslopt)
         else:
             # Run the WebSocket in a thread (non-blocking)
             self._thread = threading.Thread(
-                target=self.run_forever,
-                kwargs={
-                    "sslopt": sslopt,
-                    "ping_interval": self.config.ping_interval,
-                    "ping_timeout": self.config.ping_timeout,
-                },
+                target=self._run_forever_with_reconnect,
+                args=(sslopt,),
             )
             self._thread.daemon = True
             self._thread.start()
+
+    def _run_forever_with_reconnect(self, sslopt) -> None:
+        """Run the socket, reconnecting with bounded exponential backoff."""
+        failed_attempts = 0
+
+        while not self._stop_event.is_set():
+            self._opened_this_run = False
+            with self._subscription_lock:
+                self._sent_subscriptions_this_connection.clear()
+
+            try:
+                self.run_forever(
+                    sslopt=sslopt,
+                    ping_interval=self.config.ping_interval,
+                    ping_timeout=self.config.ping_timeout,
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("WebSocket connection loop failed")
+
+            if self._stop_event.is_set():
+                return
+
+            if self._opened_this_run:
+                failed_attempts = 0
+
+            if failed_attempts >= self.config.reconnect_attempts:
+                logger.error(
+                    f"WebSocket reconnect attempts exhausted after {self.config.reconnect_attempts} attempt(s)"
+                )
+                return
+
+            failed_attempts += 1
+            delay = self.config.reconnect_delay * (2 ** (failed_attempts - 1))
+            logger.info(
+                f"Reconnecting WebSocket in {delay} second(s) "
+                f"(attempt {failed_attempts}/{self.config.reconnect_attempts})"
+            )
+            if self._stop_event.wait(delay):
+                return
+
+    def close(self, **kwargs) -> None:
+        """Stop reconnecting and close the active WebSocket connection."""
+        self._stop_event.set()
+        super().close(**kwargs)
 
     def _default_on_open(self, _ws):
         """Default handler for connection open events."""

--- a/sdk/reya_websocket/socket.py
+++ b/sdk/reya_websocket/socket.py
@@ -355,7 +355,12 @@ class ReyaSocket(WebSocketApp):
             if payloads:
                 logger.info(f"Restoring {len(payloads)} WebSocket subscription(s)")
 
-            for channel, payload in payloads:
+        for channel, payload in payloads:
+            with self._subscription_lock:
+                if self._subscription_payloads.get(channel) != payload:
+                    continue
+                if channel in self._sent_subscriptions_this_connection:
+                    continue
                 self.send(payload)
                 self._sent_subscriptions_this_connection.add(channel)
 

--- a/tests/api_contract/test_spot_market_summaries.py
+++ b/tests/api_contract/test_spot_market_summaries.py
@@ -1,0 +1,41 @@
+"""Public REST contract coverage for spot market summaries."""
+
+import time
+
+import pytest
+
+from tests.helpers import ReyaTester
+
+pytestmark = [pytest.mark.rest_api, pytest.mark.spot]
+
+
+async def test_spot_market_summary_resolves(reya_tester: ReyaTester):
+    """The single-market endpoint returns the current spot summary shape."""
+    definitions = await reya_tester.client.reference.get_spot_market_definitions()
+    assert definitions, "spotMarketDefinitions returned nothing"
+    symbol = definitions[0].symbol
+
+    summary = await reya_tester.client.markets.get_spot_market_summary(symbol)
+
+    assert summary.symbol == symbol
+    assert float(summary.volume24h) >= 0
+    assert summary.updated_at > int(time.time() * 1000) - 2 * 24 * 60 * 60 * 1000
+    if summary.px_change24h is not None:
+        assert abs(float(summary.px_change24h)) < 10**18
+    if summary.oracle_price is not None:
+        assert float(summary.oracle_price) > 0
+
+
+async def test_spot_markets_summary_resolves(reya_tester: ReyaTester):
+    """The all-markets endpoint includes every configured spot market."""
+    definitions = await reya_tester.client.reference.get_spot_market_definitions()
+    expected_symbols = {definition.symbol for definition in definitions}
+    assert expected_symbols, "spotMarketDefinitions returned nothing"
+
+    summaries = await reya_tester.client.markets.get_spot_markets_summary()
+
+    assert summaries
+    by_symbol = {summary.symbol: summary for summary in summaries}
+    assert expected_symbols <= by_symbol.keys()
+    for symbol in expected_symbols:
+        assert float(by_symbol[symbol].volume24h) >= 0

--- a/tests/helpers/reya_tester/websocket.py
+++ b/tests/helpers/reya_tester/websocket.py
@@ -21,6 +21,7 @@ from sdk.async_api.error_message_payload import ErrorMessagePayload
 from sdk.async_api.execution_bust import ExecutionBust as AsyncExecutionBust
 from sdk.async_api.market_depth_update_payload import MarketDepthUpdatePayload
 from sdk.async_api.market_execution_bust_update_payload import MarketExecutionBustUpdatePayload
+from sdk.async_api.market_perp_execution_update_payload import MarketPerpExecutionUpdatePayload
 from sdk.async_api.market_spot_execution_update_payload import MarketSpotExecutionUpdatePayload
 from sdk.async_api.order import Order as AsyncOrder
 from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
@@ -77,6 +78,7 @@ class WebSocketState:
         self.market_execution_busts: dict[str, EventStore[AsyncExecutionBust]] = {}
 
         # Market-level stores (by symbol)
+        self.market_perp_executions: dict[str, EventStore[AsyncPerpExecution]] = {}
         self.market_spot_executions: dict[str, EventStore[AsyncSpotExecution]] = {}
         self.depth: dict[str, Depth] = {}
 
@@ -134,6 +136,7 @@ class WebSocketState:
         self.positions.clear()
         self.orders.clear()
         self.balances.clear()
+        self.market_perp_executions.clear()
         self.market_spot_executions.clear()
         self.market_execution_busts.clear()
         self.depth.clear()
@@ -175,6 +178,13 @@ class WebSocketState:
         self._t.websocket.market.spot_executions(symbol).subscribe()
         logger.info(f"Subscribed to market spot executions for {symbol}")
 
+    def subscribe_to_market_perp_executions(self, symbol: str) -> None:
+        """Subscribe to market-level perp executions for a specific symbol."""
+        if self._t.websocket is None:
+            raise RuntimeError("WebSocket not connected - call setup() first")
+        self._t.websocket.market.perp_executions(symbol).subscribe()
+        logger.info(f"Subscribed to market perp executions for {symbol}")
+
     def subscribe_to_market_execution_busts(self, symbol: str) -> None:
         """Subscribe to market-level execution busts for a specific symbol (spot or perp)."""
         if self._t.websocket is None:
@@ -207,6 +217,16 @@ class WebSocketState:
             self.market_spot_executions.clear()
             logger.debug("Cleared all market spot executions")
 
+    def clear_market_perp_executions(self, symbol: str | None = None) -> None:
+        """Clear market perp executions. If symbol provided, clear only that symbol."""
+        if symbol:
+            if symbol in self.market_perp_executions:
+                self.market_perp_executions[symbol].clear()
+            logger.debug(f"Cleared market perp executions for {symbol}")
+        else:
+            self.market_perp_executions.clear()
+            logger.debug("Cleared all market perp executions")
+
     def on_open(self, ws) -> None:
         """Handle WebSocket connection open."""
         logger.info("WebSocket opened, subscribing to trade feeds")
@@ -238,8 +258,8 @@ class WebSocketState:
         elif isinstance(message, SubscribedMessagePayload):
             self._handle_subscribed(message)
 
-        # Handle perp executions
-        elif isinstance(message, WalletPerpExecutionUpdatePayload):
+        # Handle perp executions (market or wallet level)
+        elif isinstance(message, (MarketPerpExecutionUpdatePayload, WalletPerpExecutionUpdatePayload)):
             self._handle_perp_executions(message)
 
         # Handle spot executions (market or wallet level)
@@ -292,6 +312,16 @@ class WebSocketState:
 
             logger.info(f"Stored market spot executions snapshot for {symbol}: {len(data)} execution(s)")
 
+        if "/market/" in message.channel and "perpExecutions" in message.channel and message.contents:
+            symbol = message.channel.split("/")[3]  # /v2/market/{symbol}/perpExecutions
+            data = message.contents.get("data", [])
+            store = self.market_perp_executions.setdefault(symbol, EventStore())
+
+            for item in data:
+                store.add(AsyncPerpExecution.model_validate(item))
+
+            logger.info(f"Stored market perp executions snapshot for {symbol}: {len(data)} execution(s)")
+
         # Handle initial snapshot for balances channel
         if "balances" in message.channel and message.contents:
             data = message.contents.get("data", [])
@@ -311,8 +341,12 @@ class WebSocketState:
             self.orders.add(order)
         logger.info(f"Stored orderChanges snapshot: {len(message.contents.data)} order(s)")
 
-    def _handle_perp_executions(self, message: WalletPerpExecutionUpdatePayload) -> None:
-        """Handle perp execution updates."""
+    def _handle_perp_executions(
+        self, message: MarketPerpExecutionUpdatePayload | WalletPerpExecutionUpdatePayload
+    ) -> None:
+        """Handle perp execution updates (market or wallet level)."""
+        is_market_channel = "/market/" in message.channel
+
         for trade in message.data:
             logger.info(
                 f"📊 Perp execution received: seq={trade.sequence_number}, "
@@ -320,7 +354,11 @@ class WebSocketState:
                 f"symbol={trade.symbol}, "
                 f"side={trade.side.value if hasattr(trade.side, 'value') else trade.side}, qty={trade.qty}"
             )
-            self.perp_executions.add(trade)
+            if is_market_channel:
+                symbol = message.channel.split("/")[3]
+                self.market_perp_executions.setdefault(symbol, EventStore()).add(trade)
+            else:
+                self.perp_executions.add(trade)
 
     def _handle_spot_executions(
         self, message: MarketSpotExecutionUpdatePayload | WalletSpotExecutionUpdatePayload

--- a/tests/perp/test_market_perp_executions.py
+++ b/tests/perp/test_market_perp_executions.py
@@ -1,6 +1,7 @@
 """Market-level perp execution WebSocket coverage."""
 
 import asyncio
+from decimal import Decimal
 
 import pytest
 
@@ -36,12 +37,17 @@ async def test_ws_market_perp_executions_realtime(
     baseline_sequence = max((event.sequence_number for event in store), default=0) if store else 0
 
     await perp_market_config.refresh_order_book(perp_taker_tester.data)
-    usable_bid = perp_market_config.get_usable_bid_price_for_qty(perp_market_config.min_qty)
-    usable_ask = perp_market_config.get_usable_ask_price_for_qty(perp_market_config.min_qty)
-    if usable_bid is not None or usable_ask is not None:
-        pytest.skip("external liquidity is present, so the guarded test accounts cannot cross deterministically")
+    if perp_market_config.has_any_external_liquidity:
+        maker_price = perp_market_config.maker_bid_above_external_bid()
+        if maker_price is None:
+            pytest.skip("the external spread has no tick available for an isolated maker bid")
+    else:
+        maker_price = perp_market_config.limit_price("0.99")
 
-    crossing_price = str(perp_market_config.price(0.99))
+    if not perp_market_config.circuit_breaker_floor <= maker_price <= perp_market_config.circuit_breaker_ceiling:
+        pytest.skip("the isolated maker bid would fall outside the market circuit breaker")
+
+    crossing_price = str(maker_price)
     maker_order_id = None
     try:
         maker_order_id = await perp_maker_tester.orders.create_limit(
@@ -55,6 +61,10 @@ async def test_ws_market_perp_executions_realtime(
         )
         assert maker_order_id is not None
         await perp_maker_tester.wait.for_order_creation(maker_order_id)
+        await asyncio.sleep(0.1)
+        depth = await perp_maker_tester.data.market_depth(symbol)
+        best_bid = Decimal(depth.bids[0].px) if depth and depth.bids else None
+        assert best_bid == maker_price, "the guarded maker order must be best bid before the taker crosses"
 
         taker_order_id = await perp_taker_tester.orders.create_limit(
             LimitOrderParameters(

--- a/tests/perp/test_market_perp_executions.py
+++ b/tests/perp/test_market_perp_executions.py
@@ -73,8 +73,7 @@ async def test_ws_market_perp_executions_realtime(
             store = perp_taker_tester.ws.market_perp_executions.get(symbol)
             if store is not None:
                 market_event = store.find_last(
-                    lambda event: event.sequence_number > baseline_sequence
-                    and event.taker_order_id == taker_order_id
+                    lambda event: event.sequence_number > baseline_sequence and event.taker_order_id == taker_order_id
                 )
             if market_event is not None:
                 break

--- a/tests/perp/test_market_perp_executions.py
+++ b/tests/perp/test_market_perp_executions.py
@@ -1,7 +1,6 @@
 """Market-level perp execution WebSocket coverage."""
 
 import asyncio
-from decimal import Decimal
 
 import pytest
 
@@ -38,16 +37,9 @@ async def test_ws_market_perp_executions_realtime(
 
     await perp_market_config.refresh_order_book(perp_taker_tester.data)
     if perp_market_config.has_any_external_liquidity:
-        maker_price = perp_market_config.maker_bid_above_external_bid()
-        if maker_price is None:
-            pytest.skip("the external spread has no tick available for an isolated maker bid")
-    else:
-        maker_price = perp_market_config.limit_price("0.99")
+        pytest.skip("external liquidity is present, so the guarded test accounts cannot cross safely")
 
-    if not perp_market_config.circuit_breaker_floor <= maker_price <= perp_market_config.circuit_breaker_ceiling:
-        pytest.skip("the isolated maker bid would fall outside the market circuit breaker")
-
-    crossing_price = str(maker_price)
+    crossing_price = perp_market_config.limit_price_str("0.99")
     maker_order_id = None
     try:
         maker_order_id = await perp_maker_tester.orders.create_limit(
@@ -57,14 +49,11 @@ async def test_ws_market_perp_executions_realtime(
                 limit_px=crossing_price,
                 qty=perp_market_config.min_qty,
                 time_in_force=TimeInForce.GTC,
+                post_only=True,
             )
         )
         assert maker_order_id is not None
         await perp_maker_tester.wait.for_order_creation(maker_order_id)
-        await asyncio.sleep(0.1)
-        depth = await perp_maker_tester.data.market_depth(symbol)
-        best_bid = Decimal(depth.bids[0].px) if depth and depth.bids else None
-        assert best_bid == maker_price, "the guarded maker order must be best bid before the taker crosses"
 
         taker_order_id = await perp_taker_tester.orders.create_limit(
             LimitOrderParameters(

--- a/tests/perp/test_market_perp_executions.py
+++ b/tests/perp/test_market_perp_executions.py
@@ -1,0 +1,88 @@
+"""Market-level perp execution WebSocket coverage."""
+
+import asyncio
+
+import pytest
+
+from sdk.open_api.models.order_status import OrderStatus
+from sdk.open_api.models.time_in_force import TimeInForce
+from sdk.reya_rest_api.models import LimitOrderParameters
+from tests.helpers import ReyaTester
+from tests.helpers.market_config import PerpTestConfig
+
+
+@pytest.mark.perp
+@pytest.mark.websocket
+@pytest.mark.maker_taker
+@pytest.mark.asyncio
+async def test_ws_market_perp_executions_realtime(
+    perp_market_config: PerpTestConfig,
+    perp_maker_tester: ReyaTester,
+    perp_taker_tester: ReyaTester,
+) -> None:
+    """A crossing trade emits a new event on the public market channel."""
+    symbol = perp_market_config.symbol
+    if symbol != "ETHRUSDPERP":
+        pytest.skip("the shared perp position guard currently restores ETHRUSDPERP only")
+
+    await perp_maker_tester.orders.close_all(fail_if_none=False)
+    await perp_taker_tester.orders.close_all(fail_if_none=False)
+
+    perp_taker_tester.ws.clear_market_perp_executions(symbol)
+    perp_taker_tester.ws.subscribe_to_market_perp_executions(symbol)
+    await asyncio.sleep(0.3)
+
+    store = perp_taker_tester.ws.market_perp_executions.get(symbol)
+    baseline_sequence = max((event.sequence_number for event in store), default=0) if store else 0
+
+    await perp_market_config.refresh_order_book(perp_taker_tester.data)
+    usable_bid = perp_market_config.get_usable_bid_price_for_qty(perp_market_config.min_qty)
+    usable_ask = perp_market_config.get_usable_ask_price_for_qty(perp_market_config.min_qty)
+    if usable_bid is not None or usable_ask is not None:
+        pytest.skip("external liquidity is present, so the guarded test accounts cannot cross deterministically")
+
+    crossing_price = str(perp_market_config.price(0.99))
+    maker_order_id = None
+    try:
+        maker_order_id = await perp_maker_tester.orders.create_limit(
+            LimitOrderParameters(
+                symbol=symbol,
+                is_buy=True,
+                limit_px=crossing_price,
+                qty=perp_market_config.min_qty,
+                time_in_force=TimeInForce.GTC,
+            )
+        )
+        assert maker_order_id is not None
+        await perp_maker_tester.wait.for_order_creation(maker_order_id)
+
+        taker_order_id = await perp_taker_tester.orders.create_limit(
+            LimitOrderParameters(
+                symbol=symbol,
+                is_buy=False,
+                limit_px=crossing_price,
+                qty=perp_market_config.min_qty,
+                time_in_force=TimeInForce.IOC,
+            )
+        )
+        assert taker_order_id is not None
+        await perp_maker_tester.wait.for_order_state(maker_order_id, OrderStatus.FILLED, timeout=10)
+
+        market_event = None
+        for _ in range(40):
+            store = perp_taker_tester.ws.market_perp_executions.get(symbol)
+            if store is not None:
+                market_event = store.find_last(
+                    lambda event: event.sequence_number > baseline_sequence
+                    and event.taker_order_id == taker_order_id
+                )
+            if market_event is not None:
+                break
+            await asyncio.sleep(0.25)
+
+        assert market_event is not None, f"expected a new market perp execution event for {symbol}"
+        assert market_event.symbol == symbol
+        assert market_event.sequence_number > baseline_sequence
+    finally:
+        await perp_maker_tester.orders.close_all(fail_if_none=False)
+        await perp_taker_tester.orders.close_all(fail_if_none=False)

--- a/tests/validation/test_market_perp_execution_state.py
+++ b/tests/validation/test_market_perp_execution_state.py
@@ -1,0 +1,68 @@
+"""Offline coverage for market-level perp execution state routing."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sdk.async_api.market_perp_execution_update_payload import MarketPerpExecutionUpdatePayload
+from sdk.async_api.subscribed_message_payload import SubscribedMessagePayload
+from tests.helpers.reya_tester.websocket import WebSocketState
+
+pytestmark = pytest.mark.offline
+
+SYMBOL = "ETHRUSDPERP"
+CHANNEL = f"/v2/market/{SYMBOL}/perpExecutions"
+EXECUTION = {
+    "exchangeId": 2,
+    "symbol": SYMBOL,
+    "takerAccountId": 42,
+    "makerAccountId": 43,
+    "takerOrderId": "1001",
+    "makerOrderId": "1002",
+    "qty": "0.01",
+    "side": "B",
+    "price": "3000",
+    "takerFee": "0.1",
+    "type": "ORDER_MATCH",
+    "timestamp": 1_700_000_000_000,
+    "sequenceNumber": 99,
+}
+
+
+def _state(websocket: Any = None) -> WebSocketState:
+    return WebSocketState(cast(Any, SimpleNamespace(websocket=websocket)))
+
+
+def test_market_perp_subscription_uses_the_public_market_channel() -> None:
+    websocket = MagicMock()
+    state = _state(websocket)
+
+    state.subscribe_to_market_perp_executions(SYMBOL)
+
+    websocket.market.perp_executions.assert_called_once_with(SYMBOL)
+    websocket.market.perp_executions.return_value.subscribe.assert_called_once_with()
+
+
+def test_market_perp_snapshot_and_updates_stay_out_of_the_wallet_store() -> None:
+    state = _state()
+    state.on_message(
+        None,
+        SubscribedMessagePayload.model_validate(
+            {"type": "subscribed", "channel": CHANNEL, "contents": {"data": [EXECUTION]}}
+        ),
+    )
+    state.on_message(
+        None,
+        MarketPerpExecutionUpdatePayload.model_validate(
+            {"type": "channel_data", "timestamp": 1_700_000_000_001, "channel": CHANNEL, "data": [EXECUTION]}
+        ),
+    )
+
+    market_events = state.market_perp_executions[SYMBOL]
+    assert len(market_events) == 2
+    assert market_events.last is not None
+    assert market_events.last.sequence_number == 99
+    assert len(state.perp_executions) == 0

--- a/tests/validation/test_websocket_reconnect.py
+++ b/tests/validation/test_websocket_reconnect.py
@@ -145,6 +145,28 @@ def test_unsubscribed_channel_is_not_restored(monkeypatch: pytest.MonkeyPatch) -
     assert socket.active_subscriptions == set()
 
 
+def test_failed_subscribe_send_is_replayed_after_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
+    channel = "/v2/market/ETHRUSDPERP/perpExecutions"
+    socket = ReyaSocket(config=_config(), on_open=lambda _ws: None)
+
+    def fail_send(_payload: str) -> None:
+        raise OSError("connection unavailable")
+
+    monkeypatch.setattr(socket, "send", fail_send)
+    with pytest.raises(OSError, match="connection unavailable"):
+        socket.send_subscribe(channel, batched=True)
+
+    assert channel in socket.active_subscriptions
+    assert channel not in socket._sent_subscriptions_this_connection
+
+    monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
+    socket._has_connected_once = True
+    socket._handle_open(socket)
+
+    assert sent == [{"type": "subscribe", "channel": channel, "batched": True}]
+
+
 def test_reconnect_uses_bounded_exponential_backoff(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/validation/test_websocket_reconnect.py
+++ b/tests/validation/test_websocket_reconnect.py
@@ -1,0 +1,189 @@
+"""Offline tests for WebSocket reconnect and subscription recovery."""
+
+# pylint: disable=protected-access
+
+from __future__ import annotations
+
+from typing import Any
+
+import json
+import logging
+import threading
+
+import pytest
+
+from sdk.reya_websocket.config import WebSocketConfig
+from sdk.reya_websocket.socket import ReyaSocket
+
+pytestmark = pytest.mark.offline
+
+
+def _config(*, reconnect_attempts: int = 3, reconnect_delay: int = 0) -> WebSocketConfig:
+    return WebSocketConfig(
+        url="wss://example.invalid",
+        reconnect_attempts=reconnect_attempts,
+        reconnect_delay=reconnect_delay,
+    )
+
+
+def test_reconnect_replays_the_full_subscription_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
+    open_count = 0
+    run_count = 0
+
+    def on_open(_ws: Any) -> None:
+        nonlocal open_count
+        open_count += 1
+        if open_count == 1:
+            socket.send_subscribe(
+                "/v2/wallet/0xabc/orderChanges",
+                batched=True,
+                snapshot={"depth": 25},
+            )
+
+    socket = ReyaSocket(config=_config(), on_open=on_open)
+    monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+        if run_count == 2:
+            socket.close()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect(blocking=True)
+
+    expected = {
+        "type": "subscribe",
+        "channel": "/v2/wallet/0xabc/orderChanges",
+        "batched": True,
+        "snapshot": {"depth": 25},
+    }
+    assert sent == [expected, expected]
+    assert open_count == 2
+    assert run_count == 2
+
+
+def test_reconnect_callback_subscription_is_not_duplicated(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
+    open_count = 0
+    run_count = 0
+
+    def on_open(_ws: Any) -> None:
+        nonlocal open_count
+        open_count += 1
+        socket.send_subscribe("/v2/assetOraclePrices", batched=open_count == 2)
+
+    socket = ReyaSocket(config=_config(), on_open=on_open)
+    monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+        if run_count == 2:
+            socket.close()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect(blocking=True)
+
+    assert sent == [
+        {
+            "type": "subscribe",
+            "channel": "/v2/assetOraclePrices",
+            "batched": False,
+        },
+        {
+            "type": "subscribe",
+            "channel": "/v2/assetOraclePrices",
+            "batched": True,
+        },
+    ]
+
+
+def test_unsubscribed_channel_is_not_restored(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, Any]] = []
+    open_count = 0
+    run_count = 0
+
+    def on_open(_ws: Any) -> None:
+        nonlocal open_count
+        open_count += 1
+        if open_count == 1:
+            socket.send_subscribe("/v2/perpMarkets/summary", batched=True)
+
+    socket = ReyaSocket(config=_config(), on_open=on_open)
+    monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+        if run_count == 1:
+            socket.send_unsubscribe("/v2/perpMarkets/summary")
+        else:
+            socket.close()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect(blocking=True)
+
+    assert sent == [
+        {
+            "type": "subscribe",
+            "channel": "/v2/perpMarkets/summary",
+            "batched": True,
+        },
+        {
+            "type": "unsubscribe",
+            "channel": "/v2/perpMarkets/summary",
+        },
+    ]
+    assert socket.active_subscriptions == set()
+
+
+def test_reconnect_uses_bounded_exponential_backoff(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    run_count = 0
+    delays: list[float] = []
+    socket = ReyaSocket(config=_config(reconnect_attempts=3, reconnect_delay=2))
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+
+    def record_wait(delay: float) -> bool:
+        delays.append(delay)
+        return False
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+    monkeypatch.setattr(socket._stop_event, "wait", record_wait)
+
+    with caplog.at_level(logging.ERROR, logger="reya.websocket"):
+        socket.connect(blocking=True)
+
+    assert run_count == 4
+    assert delays == [2, 4, 8]
+    assert "reconnect attempts exhausted after 3 attempt(s)" in caplog.text
+
+
+def test_close_interrupts_reconnect_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_run_finished = threading.Event()
+    socket = ReyaSocket(config=_config(reconnect_delay=60))
+
+    def run_forever(**_kwargs: Any) -> None:
+        first_run_finished.set()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect()
+    assert first_run_finished.wait(timeout=1)
+
+    socket.close()
+    assert socket._thread is not None
+    socket._thread.join(timeout=1)
+    assert not socket._thread.is_alive()

--- a/tests/validation/test_websocket_reconnect.py
+++ b/tests/validation/test_websocket_reconnect.py
@@ -161,10 +161,55 @@ def test_failed_subscribe_send_is_replayed_after_reconnect(monkeypatch: pytest.M
     assert channel not in socket._sent_subscriptions_this_connection
 
     monkeypatch.setattr(socket, "send", lambda payload: sent.append(json.loads(payload)))
-    socket._has_connected_once = True
     socket._handle_open(socket)
 
     assert sent == [{"type": "subscribe", "channel": channel, "batched": True}]
+
+
+def test_connect_rejects_a_second_connection_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_started = threading.Event()
+    allow_return = threading.Event()
+    socket = ReyaSocket(config=_config())
+
+    def run_forever(**_kwargs: Any) -> None:
+        run_started.set()
+        assert allow_return.wait(timeout=1)
+        socket._stop_event.set()
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+
+    socket.connect()
+    assert run_started.wait(timeout=1)
+    with pytest.raises(RuntimeError, match="already running"):
+        socket.connect(blocking=True)
+
+    allow_return.set()
+    assert socket._thread is not None
+    socket._thread.join(timeout=1)
+    assert not socket._thread.is_alive()
+
+
+def test_open_without_a_message_does_not_reset_reconnect_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_count = 0
+    delays: list[float] = []
+    socket = ReyaSocket(config=_config(reconnect_attempts=3, reconnect_delay=2), on_open=lambda _ws: None)
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+
+    def record_wait(delay: float) -> bool:
+        delays.append(delay)
+        return False
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+    monkeypatch.setattr(socket._stop_event, "wait", record_wait)
+
+    socket.connect(blocking=True)
+
+    assert run_count == 4
+    assert delays == [2, 4, 8]
 
 
 def test_reconnect_uses_bounded_exponential_backoff(

--- a/tests/validation/test_websocket_reconnect.py
+++ b/tests/validation/test_websocket_reconnect.py
@@ -212,6 +212,31 @@ def test_open_without_a_message_does_not_reset_reconnect_budget(monkeypatch: pyt
     assert delays == [2, 4, 8]
 
 
+def test_error_message_does_not_reset_reconnect_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_count = 0
+    delays: list[float] = []
+    socket = ReyaSocket(config=_config(reconnect_attempts=3, reconnect_delay=2), on_open=lambda _ws: None)
+    handle_message = socket._wrap_message_handler()
+
+    def run_forever(**_kwargs: Any) -> None:
+        nonlocal run_count
+        run_count += 1
+        socket._handle_open(socket)
+        handle_message(socket, json.dumps({"type": "error", "message": "subscription rejected"}))
+
+    def record_wait(delay: float) -> bool:
+        delays.append(delay)
+        return False
+
+    monkeypatch.setattr(socket, "run_forever", run_forever)
+    monkeypatch.setattr(socket._stop_event, "wait", record_wait)
+
+    socket.connect(blocking=True)
+
+    assert run_count == 4
+    assert delays == [2, 4, 8]
+
+
 def test_reconnect_uses_bounded_exponential_backoff(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/validation/test_websocket_reconnect.py
+++ b/tests/validation/test_websocket_reconnect.py
@@ -145,6 +145,34 @@ def test_unsubscribed_channel_is_not_restored(monkeypatch: pytest.MonkeyPatch) -
     assert socket.active_subscriptions == set()
 
 
+def test_restore_rechecks_subscription_intent_between_sends(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_channel = "/v2/perpMarkets/summary"
+    second_channel = "/v2/assetOraclePrices"
+    socket = ReyaSocket(config=_config(), on_open=lambda _ws: None)
+    first_payload = json.dumps({"type": "subscribe", "channel": first_channel})
+    second_payload = json.dumps({"type": "subscribe", "channel": second_channel})
+    socket.active_subscriptions.update((first_channel, second_channel))
+    socket._subscription_payloads.update({first_channel: first_payload, second_channel: second_payload})
+    sent: list[dict[str, Any]] = []
+
+    def send(payload: str) -> None:
+        message = json.loads(payload)
+        sent.append(message)
+        if message == {"type": "subscribe", "channel": first_channel}:
+            socket.send_unsubscribe(second_channel)
+
+    monkeypatch.setattr(socket, "send", send)
+
+    socket._restore_subscriptions()
+
+    assert sent == [
+        {"type": "subscribe", "channel": first_channel},
+        {"type": "unsubscribe", "channel": second_channel},
+    ]
+    assert second_channel not in socket.active_subscriptions
+    assert second_channel not in socket._sent_subscriptions_this_connection
+
+
 def test_failed_subscribe_send_is_replayed_after_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
     sent: list[dict[str, Any]] = []
     channel = "/v2/market/ETHRUSDPERP/perpExecutions"


### PR DESCRIPTION
## Review packet
- **What & why:** Fixes PRO-198 by closing the remaining SDK v2 REST/WebSocket coverage gaps on `feat/perpOB`. It ports Artur Begyan's reconnect/subscription-replay work from stale draft #73 with authorship preserved, adds market-level perp execution coverage, and covers both spot-summary REST shapes. This stays in one PR because those are the ticket's coupled closure criteria and the reconnect draft is being superseded rather than stacked.
- **Blast radius:** Production behavior changes are confined to the SDK WebSocket connection hot path: subscription intent/replay, reconnect backoff, duplicate-loop prevention, and close interruption. REST endpoints, generated schemas, signing, settlement, persistence, and matching semantics are unchanged; the remaining files are live/offline tests and their WebSocket state helper.
- **Verified:** `poetry run pytest -m offline -q` — 251 passed, 373 deselected; focused reconnect + market-state tests — 12 passed; `poetry run pytest tests/api_contract/test_spot_market_summaries.py -q` — 2 live tests passed against configured staging; focused devnet1 run of all three new live tests — 2 passed, 1 safety-precondition skip in 288.84s (spot summaries passed; market-perp execution skipped on external liquidity); `make lint` — formatting, flake8, Bandit, pylint, mypy, Poetry, and workflow validation passed; GitHub `pre-commit (3.10)` passed on final head `b5bb907`. Test diff-stat: `tests/api_contract/test_spot_market_summaries.py` +41; `tests/perp/test_market_perp_executions.py` +86; `tests/validation/test_market_perp_execution_state.py` +68; `tests/validation/test_websocket_reconnect.py` +309; supporting `tests/helpers/reya_tester/websocket.py` +43/-5. Two fix rounds plus final delta confirmation ran across generic correctness/regression, recovery/concurrency, and simplification lenses: first-open replay, atomic lifecycle ownership, handshake/error churn retry bounds, and external-counterparty position safety were fixed; final delta had no findings. Claude Opus then completed a high-effort full review and returned APPROVE with no P0-P2 findings. Its P3 batch-wide replay-lock finding was fixed with per-item intent revalidation and a regression test; Claude's delta review returned APPROVE. Its remaining cosmetic log-accuracy observation was also addressed; there are no unresolved Claude findings.
- **Human focus:** Confirm that a successfully parsed non-error frame is the right threshold for resetting consecutive reconnect failures; inspect callback-then-replay ordering and per-connection dedup in `ReyaSocket`; confirm the isolated-book precondition is the right safety tradeoff for the live perp execution test. <!-- author: confirm these are the right spots -->
- **Not covered:** The live perp execution body could not run against configured staging because its existing ETH fixture receives no `markPrice` and the legacy depth route rejects `ETHRUSDPERP`; on devnet1 it reached the isolated-book guard and skipped because external ETH liquidity was present. The event-on-crossing path therefore still needs an isolated devnet book or dedicated market: the API cannot atomically pin a counterparty and the shared guard cannot repair one-sided external fills. The ticket's lower-priority mocked REST transport faults, deliberate execution-bust generation/policy (PRO-838/PRO-1006), and REST-to-WS concurrency semantics are explicitly waived. Test CI runs on `feat/perpOB` via `.github/workflows/pylint.yml`; version-consistency CI will not run on this base because it is filtered to `main`/`develop`. No specs changed, and spec drift was not separately machine-checked. <!-- author: confirm/extend -->

---

## Decision appendix

- This PR supersedes draft #73 on its stale base while preserving its original authorship.
- The ticket lower-priority extras are explicitly waived: mocked REST transport faults belong in an isolated transport suite; deliberate execution-bust generation/policy is covered by PRO-838 and PRO-1006; REST-to-WS execution races test concurrency semantics rather than endpoint coverage.
- The live perp test refuses external liquidity and only crosses the two guarded test accounts, preventing one-sided position leakage.
