### PR TITLE
test(sdk): cover makerless perp executions

### DIFF
--- a/tests/validation/test_generated_models.py
+++ b/tests/validation/test_generated_models.py
@@ -22,6 +22,7 @@ from sdk.async_api.order import Order as WsInfoOrder
 from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
 from sdk.async_api.order_changes_subscribed_payload import OrderChangesSubscribedPayload
 from sdk.async_api.order_status import OrderStatus as WsInfoOrderStatus
+from sdk.async_api.perp_execution import PerpExecution as WsInfoPerpExecution
 from sdk.async_api.spot_execution import SpotExecution as WsInfoSpotExecution
 from sdk.async_exec_api.cancel_reason import CancelReason as WsExecCancelReason
 from sdk.async_exec_api.create_order_request import CreateOrderRequest as WsExecCreateOrderRequest
@@ -42,6 +43,7 @@ from sdk.open_api import ModifyOrderResponse as RestModifyOrderResponse
 from sdk.open_api import Order as RestOrder
 from sdk.open_api import OrderHistoryList as RestOrderHistoryList
 from sdk.open_api import OrderStatus as RestOrderStatus
+from sdk.open_api import PerpExecution as RestPerpExecution
 from sdk.open_api import RequestErrorCode as RestRequestErrorCode
 from sdk.open_api import SpotExecution as RestSpotExecution
 from sdk.open_api.api.market_data_api import MarketDataApi
@@ -254,6 +256,21 @@ def _base_spot_execution_payload() -> dict[str, Any]:
         "timestamp": 1745000000,
         "sequenceNumber": 99,
         "fillId": "9001",
+    }
+
+
+def _makerless_perp_execution_payload(execution_type: str) -> dict[str, Any]:
+    return {
+        "exchangeId": 2,
+        "symbol": "ETHRUSDPERP",
+        "takerAccountId": 12345,
+        "qty": "1",
+        "side": "A",
+        "price": "2500",
+        "takerFee": "0",
+        "type": execution_type,
+        "timestamp": 1745000000,
+        "sequenceNumber": 99,
     }
 
 
@@ -805,6 +822,23 @@ def test_ws_info_spot_execution_uses_taker_field_names() -> None:
     assert serialized["takerAccountId"] == 12345
     assert serialized["takerOrderId"] == "490346525705109504"
     assert serialized["takerFee"] == "0"
+
+
+@pytest.mark.parametrize("execution_type", ["ADL", "MARKET_CLOSE"])
+def test_rest_perp_execution_accepts_omitted_maker_fields(execution_type: str) -> None:
+    execution = RestPerpExecution.from_dict(_makerless_perp_execution_payload(execution_type))
+
+    assert execution is not None
+    serialized = execution.to_dict()
+    assert not any(field.startswith("maker") for field in serialized)
+
+
+@pytest.mark.parametrize("execution_type", ["ADL", "MARKET_CLOSE"])
+def test_ws_info_perp_execution_accepts_omitted_maker_fields(execution_type: str) -> None:
+    execution = WsInfoPerpExecution.model_validate(_makerless_perp_execution_payload(execution_type))
+
+    serialized = execution.model_dump(mode="json", by_alias=True, exclude_none=True)
+    assert not any(field.startswith("maker") for field in serialized)
 
 
 def test_rest_execution_bust_uses_taker_field_names() -> None:


### PR DESCRIPTION
## Review packet
- **What & why:** PRO-892 showed that clients must accept makerless perp executions without any `maker*` properties. Generated REST and info-WebSocket models already declare those fields optional, so this PR adds contract tests for both `ADL` and `MARKET_CLOSE` instead of regenerating unchanged models. Each test also verifies serialization does not reintroduce maker keys.
- **Blast radius:** Generated-model compatibility tests only; no SDK runtime or generated source changes.
- **Verified:** Focused generated-model suite passed (50 tests); full offline suite passed (243 tests, 370 deselected); all applicable pre-commit hooks passed; GitHub `pre-commit (3.10)` passed. Test diff: `tests/validation/test_generated_models.py` +34/-0. One exact-diff review round found no major or minor issues.
- **Human focus:** Confirm test-only coverage is preferable to a no-op regeneration, and confirm both REST and info-WebSocket serialization assertions represent the supported client contract. <!-- author: confirm these are the right spots -->
- **Not covered:** No live API/WebSocket call was made; this pins model parsing/serialization while the producer behavior lives in off-chain PR #2913. CodeRabbit auto-review is disabled for this non-default base. <!-- author: confirm/extend -->

---

### Decision appendix

- Client-contract tier: add REST and info-WebSocket compatibility coverage without regenerating models because both generated surfaces already define maker fields as optional.

### Tracking

Fixes PRO-892 · [Linear issue](https://linear.app/reya-labs/issue/PRO-892/perpexecutions-serializes-maker-pnl-as-the-string-nan-on-adl-rows)

Companion PRs: [specs #89](https://github.com/Reya-Labs/reya-api-specs/pull/89), [off-chain #2913](https://github.com/Reya-Labs/reya-off-chain-monorepo/pull/2913), [docs #22](https://github.com/Reya-Labs/reya-docs/pull/22). No strict merge-order dependency.
