### PR TITLE
test(ws-exec): extend the cancel-reason and shared-account fixes to the ws-exec twins

### DIFF
--- a/tests/engine/test_gtt_ws_exec.py
+++ b/tests/engine/test_gtt_ws_exec.py
@@ -39,6 +39,7 @@ from tests.helpers.gtt_timing import (
     GTT_REAP_EXPIRY_OFFSET_S,
     GTT_REAP_PRE_EXPIRY_MARGIN_S,
 )
+from tests.helpers.order_lifecycle import assert_resting_or_explain_rest
 from tests.helpers.ws_exec_market import WsExecMarket
 
 pytestmark = [pytest.mark.e2e, pytest.mark.gtt]
@@ -142,8 +143,10 @@ async def test_ws_exec_gtt_reaped_at_expiry(ws_exec_market: WsExecMarket):
     remaining = (expires_after - GTT_REAP_PRE_EXPIRY_MARGIN_S) - time.time()
     if remaining > 0:
         await asyncio.sleep(remaining)
-    open_ids = {o.order_id for o in await m.rest.get_open_orders()}
-    assert order_id in open_ids, f"[{m.market_type}] GTT was reaped BEFORE its expiresAfter"
+    # Reports the cancel REASON when the order is gone: an early GTT_EXPIRED is
+    # the defect this test hunts, while a USER_CANCEL / MASS_CANCEL from another
+    # actor on this shared account means the precondition was removed.
+    await assert_resting_or_explain_rest(m.rest, order_id, label=f"[{m.market_type}]", expires_after=expires_after)
 
     # Upper bound: reaped (drops out of openOrders) within a finite window after expiry.
     await _wait_for_order_gone(m.rest, order_id, timeout_s=GTT_REAP_PRE_EXPIRY_MARGIN_S + GTT_REAP_DETECT_BOUND_S + 10)

--- a/tests/helpers/order_lifecycle.py
+++ b/tests/helpers/order_lifecycle.py
@@ -383,3 +383,55 @@ async def assert_resting_or_explain(
         f"its expiry -- something outside this test removed it (shared "
         f"environment), so the reap behaviour cannot be observed."
     )
+
+
+async def assert_resting_or_explain_rest(
+    rest,
+    order_id,
+    *,
+    label: str,
+    expires_after: int,
+) -> None:
+    """REST-only twin of `assert_resting_or_explain`, for the ws-exec suites.
+
+    Those tests hold a raw ReyaTradingClient rather than a ReyaTester, so
+    there is no WS order store to read the cancel reason from. Order history
+    carries it, so fetch from there instead -- the point is the same: never
+    report "the reaper fired early" for an order somebody else cancelled.
+    """
+    open_ids = {str(o.order_id) for o in await rest.get_open_orders()}
+    if str(order_id) in open_ids:
+        return
+
+    reason = None
+    try:
+        history = await rest.get_order_history()
+        rows = getattr(history, "data", None) or history
+        for row in rows:
+            if str(getattr(row, "order_id", "")) == str(order_id):
+                reason = getattr(row, "cancel_reason", None)
+                break
+    except Exception:  # pylint: disable=broad-except
+        reason = None
+
+    now = int(time.time())
+    early_by = expires_after - now
+
+    if reason is None:
+        pytest.fail(
+            f"{label} order {order_id} left the book {early_by}s before its "
+            f"expiry ({now} < {expires_after}) and order history carried no "
+            f"cancel reason -- cannot tell an early reap from an external cancel."
+        )
+
+    if str(getattr(reason, "value", reason)).upper().endswith("GTT_EXPIRED"):
+        pytest.fail(
+            f"{label} GTT was reaped EARLY: cancelled GTT_EXPIRED at {now}, "
+            f"{early_by}s before its expiresAfter ({expires_after})."
+        )
+
+    pytest.skip(
+        f"{label} order {order_id} was cancelled by "
+        f"{getattr(reason, 'value', reason)} {early_by}s before its expiry -- "
+        f"something outside this test removed it (shared environment)."
+    )

--- a/tests/ws_exec/test_ws_exec.py
+++ b/tests/ws_exec/test_ws_exec.py
@@ -576,13 +576,29 @@ def _new_client_order_id() -> int:
 
 
 def _assert_cancelled_count(expected: int, actual: int | None, label: str) -> None:
-    """Hard-assert cancelledCount instead of just printing a WARN — the script
-    claims 'all flows passed' at the end, and a silent count mismatch
-    contradicts that."""
-    if actual != expected:
+    """Assert cancelAll cancelled AT LEAST the orders this flow opened.
+
+    Was an equality check, whose own error message named the reason it could
+    not hold: "If other orders were open on the account". The devnet accounts
+    are SHARED, so a mass cancel legitimately sweeps up somebody else's
+    resting orders and the count exceeds what this flow opened -- a failure
+    that says nothing about cancelAll.
+
+    Fewer than expected is still a real defect (orders this flow opened
+    survived a cancelAll) and still fails. The residual gap: if a cancelAll
+    swept only foreign orders and none of ours, the count could clear this
+    bar. Closing that needs per-id verification, which the mass-cancel
+    response does not carry -- it returns a count, not ids.
+    """
+    if actual is None or actual < expected:
         raise RuntimeError(
-            f"[{label}] cancelledCount mismatch: expected {expected}, got {actual}. "
-            "If other orders were open on the account, narrow the test scope and re-run."
+            f"[{label}] cancelledCount {actual} is below the {expected} order(s) "
+            f"this flow opened — a cancelAll left some of them resting."
+        )
+    if actual > expected:
+        print(
+            f"  [{label}] cancelledCount={actual} > {expected} opened here — "
+            "other orders were resting on this shared account (not a failure)"
         )
 
 


### PR DESCRIPTION
## Why

The lifecycle suites were fixed in #83/#85; **their ws-exec twins were not**, and the remaining suite failures concentrated there.

## 1. `test_gtt_ws_exec` — report the cancel reason

It asserted `order_id in open_ids` with the message *"GTT was reaped BEFORE its expiresAfter"* — the same claim #85 showed to be wrong on a shared account, where the order is usually cancelled by somebody else (`CancelReason.USER_CANCEL`, not `GTT_EXPIRED`).

The ws-exec suites hold a raw `ReyaTradingClient` rather than a `ReyaTester`, so there's no WS store to read the reason from. Added a **REST twin** of `assert_resting_or_explain` that reads `cancel_reason` from order history instead. Same split:

| observed | outcome |
| -- | -- |
| `GTT_EXPIRED` before expiry | **FAIL** — the real defect |
| any other reason | **SKIP**, naming it |
| no reason available | **FAIL**, saying exactly that |

## 2. `_assert_cancelled_count` — tolerate foreign orders

It required `cancelAll` to cancel **exactly** the number of orders the flow opened. Its own error message named why that can't hold — *"If other orders were open on the account"* — and the devnet accounts are shared, so a mass cancel legitimately sweeps up foreign orders.

Now asserts **at least** the flow's own count. Verified all four cases:

```
ours all cancelled + foreign  -> PASSED (logs that foreign orders were present)
exactly ours                  -> PASSED
some of ours survived         -> RAISED
none reported (None)          -> RAISED
```

**Residual gap, noted in the docstring:** a `cancelAll` that swept only foreign orders and none of ours would clear this bar. Closing that needs per-id verification, which the mass-cancel response doesn't carry — it returns a count, not ids.

## Result

Those two suites: **16 passed, 1 failed** (`test_perp_ioc_open_and_close`, untouched here), down from 3 failing. Offline suite 239 passed, pre-commit clean.

Worth noting the earlier "3 failed" reading included **transport flakes** (`raw recv failed: Connection timed out`), not logic failures — the ws-exec transport is itself intermittent on devnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
