### PR TITLE
test: stop cleanup masking a skip, and add a two-run intersection runner

### DIFF
--- a/scripts/run_suite_twice.py
+++ b/scripts/run_suite_twice.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Run the integration suite twice and report only the failures common to both.
+
+Why this exists
+---------------
+Against shared devnet, a single run is not a reliable signal. Measured over
+three comparable runs of the SAME code:
+
+    run 1: 10 failed     run 2: 16 failed     run 3: 14 failed
+    33 distinct tests failed at least once
+      2 failed in ALL three runs
+     28 failed in exactly ONE run
+
+So ~85% of what a single run reports is noise: other engineers trading the
+same shared accounts, a market-making bot on the book, async settlement lag,
+and an intermittently flaky ws-exec transport. Chasing the failures from any
+one run moves the sample rather than reducing it.
+
+Intersecting two runs is the cheapest way to separate signal from noise -- it
+needs no environment changes and no test edits. A test that fails twice in a
+row is worth investigating; one that fails once usually is not.
+
+This is a MITIGATION, not a fix. The durable fix is exclusive per-run
+accounts, which removes the largest noise source outright. Until then, treat
+the intersection as the real result and the symmetric difference as a
+flakiness measurement worth watching: if it grows, the environment is getting
+noisier.
+
+Usage
+-----
+    poetry run python scripts/run_suite_twice.py
+    poetry run python scripts/run_suite_twice.py -m "not localnet and not spot"
+
+Exit code is 0 only when the intersection is empty.
+"""
+
+from __future__ import annotations
+
+import re
+
+# subprocess, not pytest.main(): the two runs must not share a process.
+# Session-scoped fixtures, module-level env reads and the SDK's cached
+# clients all persist in-process, so a second in-process run would inherit
+# the first one's state -- which is exactly the contamination this script
+# exists to measure. nosec B404: no shell, argv is a literal list.
+import subprocess  # nosec B404
+import sys
+
+FAILED_LINE = re.compile(r"^(?:FAILED|ERROR)\s+(\S+)")
+
+
+def run(pytest_args: list[str], label: str) -> tuple[set[str], str]:
+    """Run pytest once; return (failed test ids, summary line)."""
+    cmd = [
+        "poetry",
+        "run",
+        "pytest",
+        *pytest_args,
+        "-q",
+        "--no-header",
+        "--tb=no",
+        "-rf",
+        "-p",
+        "no:cacheprovider",
+    ]
+    print(f"\n=== {label}: {' '.join(cmd)}", flush=True)
+    # nosec B603: shell=False and cmd is a literal argv list; the only
+    # caller-supplied part is this script's own CLI args, already in the
+    # operator's shell.
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603
+    out = proc.stdout + proc.stderr
+
+    failed = set()
+    for line in out.splitlines():
+        m = FAILED_LINE.match(line)
+        if m:
+            # strip any " - <error>" suffix pytest appends
+            failed.add(m.group(1).split(" - ")[0])
+
+    summary = ""
+    for line in reversed(out.splitlines()):
+        if re.search(r"\d+ (passed|failed)", line):
+            summary = line.strip()
+            break
+
+    print(f"    {summary}", flush=True)
+    return failed, summary
+
+
+def main() -> int:
+    pytest_args = sys.argv[1:] or ["-m", "not localnet"]
+
+    first, first_summary = run(pytest_args, "run 1/2")
+    second, second_summary = run(pytest_args, "run 2/2")
+
+    both = sorted(first & second)
+    only_once = sorted(first ^ second)
+
+    print("\n" + "=" * 72)
+    print("  run 1: " + (first_summary or "(no summary)"))
+    print("  run 2: " + (second_summary or "(no summary)"))
+    print("=" * 72)
+
+    print(f"\nFAILED IN BOTH RUNS — treat as real ({len(both)}):")
+    for t in both:
+        print(f"  {t}")
+    if not both:
+        print("  (none)")
+
+    print(f"\nFailed in only one run — flaky/environmental ({len(only_once)}):")
+    for t in only_once:
+        print(f"  {t}")
+    if not only_once:
+        print("  (none)")
+
+    if only_once:
+        total = len(first | second)
+        pct = round(100 * len(only_once) / total)
+        print(
+            f"\nFlakiness: {len(only_once)} of {total} distinct failures ({pct}%) "
+            "did not reproduce. If this share is growing, the shared environment "
+            "is getting noisier -- that is the thing to fix, not these tests."
+        )
+
+    return 1 if both else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/engine/test_gtt_lifecycle.py
+++ b/tests/engine/test_gtt_lifecycle.py
@@ -25,6 +25,7 @@ from decimal import Decimal
 import pytest
 
 from sdk.async_api.cancel_reason import CancelReason as WsCancelReason
+from sdk.open_api.exceptions import ApiException
 from sdk.open_api.models.order_status import OrderStatus
 from sdk.open_api.models.time_in_force import TimeInForce
 from sdk.reya_rest_api.models import LimitOrderParameters
@@ -191,8 +192,22 @@ async def test_gtc_survives_while_gtt_is_reaped(
         logger.info(f"[{market_type}] ✅ GTC survived past the GTT reap horizon (never auto-cleared)")
     finally:
         # Always clean up the resting GTC (the GTT is already reaped).
-        await maker.client.cancel_order(symbol=market_config.symbol, account_id=maker.account_id, order_id=gtc.order_id)
-        await maker.wait.for_order_state(gtc.order_id, OrderStatus.CANCELLED)
+        #
+        # Tolerant of the order already being gone. On a shared account it may
+        # have been cancelled by somebody else, and the body above may exit via
+        # pytest.skip for exactly that reason -- a raising cleanup would then
+        # REPLACE the skip with its own 400 and report the test as failed.
+        # That is not hypothetical: it is why this test failed every run while
+        # the skip was working correctly underneath.
+        try:
+            await maker.client.cancel_order(
+                symbol=market_config.symbol, account_id=maker.account_id, order_id=gtc.order_id
+            )
+            await maker.wait.for_order_state(gtc.order_id, OrderStatus.CANCELLED)
+        except ApiException as e:
+            if "not found" not in str(e).lower() and "missing order" not in str(e).lower():
+                raise
+            logger.info(f"[{market_type}] cleanup: GTC {gtc.order_id} already gone ({e})")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two changes aimed at making the suite's output mean something.

## 1. A working diagnostic was being reported as a failure by its own cleanup

`test_gtc_survives_while_gtt_is_reaped` failed in **all five** runs measured today — the only test that did, which is why it looked like the one genuinely broken test.

It isn't broken. The body correctly raised `pytest.skip`:

```
[perp] order 1874617643089002496 was cancelled by USER_CANCEL 15s before its
expiry -- something outside this test removed it (shared environment)
```

…and then the `finally` block tried to cancel the already-cancelled GTC, got a **400 `ORDER_NOT_FOUND`**, and that exception **replaced the skip**. The diagnostic added in #85 was working perfectly; its own teardown was hiding it.

Cleanup is now tolerant of the order already being gone. **Verified: `1 passed, 1 skipped`**, where it previously failed every run.

## 2. `scripts/run_suite_twice.py` — intersect two runs

Measured over three comparable runs of the **same code**:

| | |
| -- | -- |
| failures per run | 10, 16, 14 |
| distinct tests that failed at least once | **33** |
| failed in all three runs | **2** |
| failed in exactly one run | **28** |

So **~85% of what a single run reports is noise** — other engineers on the same shared accounts, a market-making bot on the book, async settlement lag, a flaky ws-exec transport. Chasing one run's failures moves the sample rather than shrinking it.

Intersecting two runs separates signal from noise with **no environment changes and no test edits**. A test that fails twice in a row is worth investigating; one that fails once usually isn't.

```
poetry run python scripts/run_suite_twice.py
poetry run python scripts/run_suite_twice.py -m "not localnet and not spot"
```

Exit code is 0 only when the intersection is empty.

**This is a mitigation, not a fix.** The script says so, and prints the flake share each run so the environment's noisiness stays visible rather than being quietly absorbed. The durable fix is exclusive per-run accounts.

Uses `subprocess` rather than `pytest.main()` on purpose — the two runs must not share a process, or the second inherits the first's session fixtures and cached clients, which is the contamination being measured. Bandit suppressions are annotated with that reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
