### PR TITLE
fix: install the dev extra so make e2e can run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ lockfile-update:	## Update poetry.lock
 lockfile-update-full:	## Fully regenerate poetry.lock
 	poetry lock -n --regenerate
 
-install:	## Install dependencies from poetry.lock
-	poetry install -n
+install:	## Install dependencies from poetry.lock, including the dev extra (pytest, linters)
+	poetry install -n --all-extras
 
 install-types:	## Find and install additional types for mypy
 	poetry run mypy --install-types --non-interactive ./


### PR DESCRIPTION
## Problem

`make install` reports success and leaves no pytest behind, so `make e2e` — the target the Reya Localnet SDK gate invokes through `e2e/localnet/bin/sdk-env.sh` — fails immediately:

```
poetry run pytest tests/perp/test_limit_orders.py tests/perp/test_market_data.py ... -ra --tb=short
Command not found: pytest
make[2]: *** [Makefile:20: e2e] Error 1
make[1]: *** [Makefile:260: localnet-sdk] Error 2
make: *** [Makefile:254: localnet-sdk-focused] Error 2
```

pytest is declared under `[project.optional-dependencies]`, which `poetry install` does not install by default.

## Fix

Request the extra in the `install` target. **Lockfile untouched** — this branch already carries the correct `extra == "dev"` marker, so the flag alone is sufficient.

## Verification

Clean worktree at `feat/perpOB`, before:

```
make install → rc 0
poetry run pytest --version → Command not found: pytest
```

after:

```
make install → rc 0
pytest 8.4.2
black 24.10.0 · flake8 7.3.0 · mypy 1.17.1 · pre-commit 4.3.0
```

With the extra installed, the Localnet gates pass end to end:

```
make localnet-sdk-focused → 108 passed, 2 skipped in 48.33s   (rc 0)
make localnet-sdk         → 335 passed, 10 skipped in 914.55s (rc 0)
```

## Relationship to #92

#92 targets `main`, which has a second and separate defect: its lockfile constrains the whole `dev` extra to PyPy (`platform_python_implementation == "PyPy" and extra == "dev"`), so there the flag alone installs nothing and a re-lock is also required. `main` is not an ancestor of `feat/perpOB`, so that PR does not reach this branch — hence this one. This branch needs only the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)