### PR TITLE
test: add PRO-657 migration canary safety foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -628,4 +628,7 @@ testing.py
 # End of https://www.gitignore.io/api/osx,python,pycharm,windows,visualstudio,visualstudiocode
 examples/config.json
 
+# Run-specific PRO-657 canary profiles (account/wallet identifiers; never secrets)
+canary/profiles/local/
+
 .claude/

--- a/canary/ACCEPTANCE.md
+++ b/canary/ACCEPTANCE.md
@@ -1,0 +1,24 @@
+# PRO-657 acceptance coverage
+
+This is the branch-local implementation map for the current Linear ticket. It prevents the
+credential-free harness from being mistaken for completed cutover evidence.
+
+| Acceptance area | Current branch | Remaining work or live evidence |
+| --- | --- | --- |
+| Exact devnet1/mainnet identity and release pin | Implemented and offline-tested | Populate a reviewed local profile and run the read-only probes against the candidate release |
+| Wallet/account/market allowlists and hard bounds | Implemented and offline-tested | Commander supplies the designated IDs and minimum safe order plan |
+| Unique run/client-order identity | Implemented and offline-tested | Runtime supplies one unique run ID |
+| Resting order, modify, exact cancel, REST/WS convergence | Injected SDK adapter implemented and offline-tested | Wire clients only after profile review; execute devnet before mainnet |
+| Run-owned order cleanup | Implemented and offline-tested | Runtime must also prove no final position delta after controlled matching |
+| Operator pause/resume, reconnect, sequence and projection recovery | Injected orchestration implemented and offline-tested | Supply a checkpoint implementation and operator evidence reference; run on devnet candidate |
+| Controlled maker/taker match and position delta | Not implemented in the canary harness | Reuse the existing live e2e match primitives with run-owned position accounting |
+| Tx/receipt, event/fill, DB, REST/WS correlation | Not implemented | Define or attach the operator-side chain/DB evidence collector |
+| Fee/referral attribution | Not implemented | Pin fee/referral configuration and reconcile all affected balances/credits |
+| Mark/funding freshness | Not implemented | Obtain the production thresholds and add read-only assertions |
+| Frozen legacy-schema rejection | Not implemented | Obtain the canonical payload fixture and stable rejection code from PRO-644 |
+| Correlated bust policy | Not implemented | Devnet expected-bust allowlist; mainnet disabled unless separately approved |
+| ME/indexer restart | Deliberately impossible through this SDK boundary | Operator performs it; the harness only snapshots, pauses, reconnects, and verifies recovery |
+| Timestamped evidence bundle | Preflight, lifecycle, and recovery records implemented | Add the final bundle assembler and attach executed evidence to PRO-261 |
+
+The CLI remains preflight/read-only. No checked-in command can construct a credentialed trading
+client, restart a service, query production databases, or submit an order.

--- a/canary/README.md
+++ b/canary/README.md
@@ -62,9 +62,17 @@ Offline tests prove these invariants:
 - mainnet mutation still requires the exact acknowledgement constant in addition to the profile;
   credential-free success and sanitized failure evidence are available for every lifecycle run.
 
-## Next implementation slice
+## Recovery checkpoint and next slice
 
-Add explicit runtime orchestration only after a local profile identifies the release, market,
-quantity/notional bounds, account, and wallet. That orchestration must construct the clients from
-machine-local configuration, require the read-only probes to pass in the same run, subscribe to the
-wallet order-change channel before entry, and retain a separate explicit mutation gate.
+`scripts/canary_recovery.py` also defines an injected operator checkpoint. It snapshots the public
+projection, pauses without owning any restart capability, then requires a fresh reconnect to prove
+contiguous unique event sequences, projection convergence, and no order or position delta from the
+baseline. Mainnet has a separate recovery-checkpoint acknowledgement. The CLI does not construct
+this adapter or expose the checkpoint.
+
+See `canary/ACCEPTANCE.md` for the ticket-to-code coverage map. The next implementation slice is
+the controlled maker/taker match with run-owned position accounting and the operator-side evidence
+contract for transaction receipts, canonical events/fills, database rows, and telemetry. Explicit
+runtime orchestration remains blocked on reviewed local release, market, quantity/notional,
+account, and wallet inputs. It must require read-only probes in the same run, subscribe to wallet
+streams before entry, and retain separate mutation gates.

--- a/canary/README.md
+++ b/canary/README.md
@@ -6,14 +6,16 @@ order and position cleanup that is not safe for a mainnet cutover canary.
 
 ## Current scope
 
-Only static, non-mutating preflight exists. The runner does not load `.env`, construct
-an SDK client, make network requests, or expose a mutation mode.
+Static preflight and explicit read-only live probes exist. The runner does not load `.env`,
+construct a trading client, use account credentials, or expose a mutation mode.
 
 1. Copy the matching example profile into the ignored `canary/profiles/local/` directory.
 2. Fill the exact release manifest, commander-approved market, hard bounds, account IDs,
    and wallet allowlist. Do not add credentials.
 3. Set `enabled = true` only after those values have been reviewed.
-4. Run:
+4. Export the profile's `rpc_url_env` variable from the machine-local provider configuration.
+   Do not put a credential-bearing RPC URL in the profile or shell history.
+5. Run static preflight:
 
 ```bash
 poetry run python scripts/run_canary.py \
@@ -21,16 +23,26 @@ poetry run python scripts/run_canary.py \
   --preflight-only
 ```
 
+Or prove the configured live target using only REST/RPC reads and WebSocket connect/close handshakes:
+
+```bash
+poetry run python scripts/run_canary.py \
+  --profile canary/profiles/local/devnet1.toml \
+  --probe-live-read-only
+```
+
 The runner validates the profile against the SDK's pinned environment identity and writes
 a credential-free `artifacts/canary/<timestamp>-<environment>/preflight.json` record.
 Devnet1 and the retired Cronos deployment share a chain ID, so the REST/read-WS/ws-exec
-hosts and Orders Gateway must all match; chain ID alone never passes preflight.
+hosts and Orders Gateway must all match; chain ID alone never passes preflight. The live probe also
+checks the designated market ID, calls `eth_chainId`, proves bytecode exists at the configured
+Orders Gateway, and connects to both WebSocket surfaces without sending a frame.
 
 Checked-in profiles are deliberately disabled and incomplete. Local profiles are ignored
 because they contain run-specific account and wallet identifiers, though not secrets.
 
 ## Next implementation slice
 
-Add read-only live identity probes, followed by a run-scoped place → REST/WS visibility →
-modify → cancel scenario. The scenario must track and clean up only order IDs created by
-that run. It must not use the existing account-wide `close_all` or position-flatten fixtures.
+Add a run-scoped place → REST/WS visibility → modify → cancel scenario. The scenario must
+track and clean up only order IDs created by that run. It must not use the existing account-wide
+`close_all` or position-flatten fixtures.

--- a/canary/README.md
+++ b/canary/README.md
@@ -1,0 +1,36 @@
+# Perp OB migration canary
+
+This directory contains the fail-closed configuration layer for Linear PRO-657.
+It is separate from the general live pytest suite because that suite has account-wide
+order and position cleanup that is not safe for a mainnet cutover canary.
+
+## Current scope
+
+Only static, non-mutating preflight exists. The runner does not load `.env`, construct
+an SDK client, make network requests, or expose a mutation mode.
+
+1. Copy the matching example profile into the ignored `canary/profiles/local/` directory.
+2. Fill the exact release manifest, commander-approved market, hard bounds, account IDs,
+   and wallet allowlist. Do not add credentials.
+3. Set `enabled = true` only after those values have been reviewed.
+4. Run:
+
+```bash
+poetry run python scripts/run_canary.py \
+  --profile canary/profiles/local/devnet1.toml \
+  --preflight-only
+```
+
+The runner validates the profile against the SDK's pinned environment identity and writes
+a credential-free `artifacts/canary/<timestamp>-<environment>/preflight.json` record.
+Devnet1 and the retired Cronos deployment share a chain ID, so the REST/read-WS/ws-exec
+hosts and Orders Gateway must all match; chain ID alone never passes preflight.
+
+Checked-in profiles are deliberately disabled and incomplete. Local profiles are ignored
+because they contain run-specific account and wallet identifiers, though not secrets.
+
+## Next implementation slice
+
+Add read-only live identity probes, followed by a run-scoped place → REST/WS visibility →
+modify → cancel scenario. The scenario must track and clean up only order IDs created by
+that run. It must not use the existing account-wide `close_all` or position-flatten fixtures.

--- a/canary/README.md
+++ b/canary/README.md
@@ -44,19 +44,27 @@ because they contain run-specific account and wallet identifiers, though not sec
 ## Offline lifecycle engine
 
 `scripts/canary_lifecycle.py` defines the bounded place → REST/WS visibility → modify → cancel
-state machine behind an injectable adapter. It currently has no CLI or live SDK adapter, so it
-cannot submit an order. Offline tests prove these invariants:
+state machine. `scripts/canary_sdk_adapter.py` maps that state machine to the SDK's exact
+post-only GTC create, modify, single-order cancel, and open-orders models. The adapter is
+dependency-injected and is not constructed by the CLI, so the runner still cannot submit an order.
+Offline tests prove these invariants:
 
 - the profile, account, wallet, market, quantity, and both order notionals pass before adapter I/O;
 - the order intent is post-only GTC, and modify restates that complete intent;
 - REST and the wallet order-change stream must both prove initial, modified, and cancelled state;
 - every external operation has a timeout;
+- the REST client's chain, API URL, exchange, Orders Gateway, loaded market ID, owner wallet, and
+  account must match the validated profile and plan;
+- read WebSocket observations come only from the designated wallet channel, and a `FEED_RESET`
+  event cannot be mistaken for a user cancellation;
 - cleanup addresses only canonical order IDs returned to this run, never `close_all`, `cancelAll`,
   position flattening, or any pre-existing order; and
-- mainnet mutation still requires the exact acknowledgement constant in addition to the profile.
+- mainnet mutation still requires the exact acknowledgement constant in addition to the profile;
+  credential-free success and sanitized failure evidence are available for every lifecycle run.
 
 ## Next implementation slice
 
-Implement the narrow SDK adapter and credential-free lifecycle evidence. Keep it unreachable from
-the CLI until a local profile identifies the release, market, quantity/notional bounds, account,
-wallet, and the live read-only probes have passed.
+Add explicit runtime orchestration only after a local profile identifies the release, market,
+quantity/notional bounds, account, and wallet. That orchestration must construct the clients from
+machine-local configuration, require the read-only probes to pass in the same run, subscribe to the
+wallet order-change channel before entry, and retain a separate explicit mutation gate.

--- a/canary/README.md
+++ b/canary/README.md
@@ -41,8 +41,22 @@ Orders Gateway, and connects to both WebSocket surfaces without sending a frame.
 Checked-in profiles are deliberately disabled and incomplete. Local profiles are ignored
 because they contain run-specific account and wallet identifiers, though not secrets.
 
+## Offline lifecycle engine
+
+`scripts/canary_lifecycle.py` defines the bounded place → REST/WS visibility → modify → cancel
+state machine behind an injectable adapter. It currently has no CLI or live SDK adapter, so it
+cannot submit an order. Offline tests prove these invariants:
+
+- the profile, account, wallet, market, quantity, and both order notionals pass before adapter I/O;
+- the order intent is post-only GTC, and modify restates that complete intent;
+- REST and the wallet order-change stream must both prove initial, modified, and cancelled state;
+- every external operation has a timeout;
+- cleanup addresses only canonical order IDs returned to this run, never `close_all`, `cancelAll`,
+  position flattening, or any pre-existing order; and
+- mainnet mutation still requires the exact acknowledgement constant in addition to the profile.
+
 ## Next implementation slice
 
-Add a run-scoped place → REST/WS visibility → modify → cancel scenario. The scenario must
-track and clean up only order IDs created by that run. It must not use the existing account-wide
-`close_all` or position-flatten fixtures.
+Implement the narrow SDK adapter and credential-free lifecycle evidence. Keep it unreachable from
+the CLI until a local profile identifies the release, market, quantity/notional bounds, account,
+wallet, and the live read-only probes have passed.

--- a/canary/profiles/devnet1.example.toml
+++ b/canary/profiles/devnet1.example.toml
@@ -1,0 +1,22 @@
+# Copy to canary/profiles/local/devnet1.toml and fill the run-specific values.
+# Never put private keys, mnemonics, or other credentials in a profile.
+name = "perp-ob-devnet1-cutover-canary"
+enabled = false
+environment = "devnet1"
+release_manifest_id = "REPLACE_WITH_PINNED_CANDIDATE_MANIFEST"
+
+[identity]
+chain_id = 89346162
+api_url = "https://api-devnet.reya-cronos.network/v2"
+read_ws_url = "wss://websocket-devnet.reya-cronos.network/"
+ws_exec_url = "wss://ws-exec-devnet.reya-cronos.network"
+orders_gateway = "0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D"
+exchange_id = 1
+
+[canary]
+market_symbol = "REPLACE_WITH_DESIGNATED_MARKET"
+market_id = 0
+max_quantity = "0"
+max_notional = "0"
+allowed_account_ids = []
+allowed_wallet_addresses = []

--- a/canary/profiles/devnet1.example.toml
+++ b/canary/profiles/devnet1.example.toml
@@ -4,6 +4,8 @@ name = "perp-ob-devnet1-cutover-canary"
 enabled = false
 environment = "devnet1"
 release_manifest_id = "REPLACE_WITH_PINNED_CANDIDATE_MANIFEST"
+# The URL remains in the process environment so provider credentials are never stored here.
+rpc_url_env = "REYA_CANARY_RPC_URL"
 
 [identity]
 chain_id = 89346162

--- a/canary/profiles/mainnet.example.toml
+++ b/canary/profiles/mainnet.example.toml
@@ -4,6 +4,8 @@ name = "perp-ob-mainnet-cutover-canary"
 enabled = false
 environment = "mainnet"
 release_manifest_id = "REPLACE_WITH_PINNED_CANDIDATE_MANIFEST"
+# The URL remains in the process environment so provider credentials are never stored here.
+rpc_url_env = "REYA_CANARY_RPC_URL"
 
 [identity]
 chain_id = 1729

--- a/canary/profiles/mainnet.example.toml
+++ b/canary/profiles/mainnet.example.toml
@@ -1,0 +1,22 @@
+# Copy to canary/profiles/local/mainnet.toml and fill the commander-approved values.
+# Never put private keys, mnemonics, or other credentials in a profile.
+name = "perp-ob-mainnet-cutover-canary"
+enabled = false
+environment = "mainnet"
+release_manifest_id = "REPLACE_WITH_PINNED_CANDIDATE_MANIFEST"
+
+[identity]
+chain_id = 1729
+api_url = "https://api.reya.xyz/v2"
+read_ws_url = "wss://ws.reya.xyz/"
+ws_exec_url = "wss://ws-exec.reya.xyz"
+orders_gateway = "0xfc8c96be87da63cecddbf54abfa7b13ee8044739"
+exchange_id = 2
+
+[canary]
+market_symbol = "REPLACE_WITH_DESIGNATED_MARKET"
+market_id = 0
+max_quantity = "0"
+max_notional = "0"
+allowed_account_ids = []
+allowed_wallet_addresses = []

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository operational scripts importable by offline validation tests."""

--- a/scripts/canary_lifecycle.py
+++ b/scripts/canary_lifecycle.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Literal, Protocol, TypeVar
+from typing import Any, Literal, Protocol, TypeVar
 
 import asyncio
 import hashlib
 import math
 import re
 from collections.abc import Awaitable
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from decimal import Decimal
 
 from scripts.canary_preflight import CanaryProfile, PreflightError, validate_profile
-
 
 _RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 _ResultT = TypeVar("_ResultT")
@@ -62,6 +62,66 @@ class LifecycleResult:
     events: tuple[LifecycleEvent, ...]
 
 
+def build_lifecycle_evidence(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+    *,
+    result: LifecycleResult | None = None,
+    error: LifecycleError | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a credential-free success or failure record for one lifecycle run."""
+    if (result is None) == (error is None):
+        raise ValueError("provide exactly one of result or error")
+    resolved_run_id: str | None
+    client_order_id: int | None
+    if result is not None:
+        resolved_run_id = result.run_id
+        events = result.events
+        order_ids = result.owned_order_ids
+        client_order_id = result.client_order_id
+    else:
+        assert error is not None
+        resolved_run_id = run_id
+        events = error.events
+        order_ids = tuple(dict.fromkeys(event.order_id for event in events))
+        client_order_id = derive_client_order_id(resolved_run_id) if resolved_run_id is not None else None
+    if resolved_run_id is None:
+        raise ValueError("run_id is required for failure evidence")
+    evidence: dict[str, Any] = {
+        "schema_version": 1,
+        "result": "pass" if result is not None else "fail",
+        "mode": "order-lifecycle",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "environment": profile.environment,
+        "release_manifest_id": profile.release_manifest_id,
+        "run_id": resolved_run_id,
+        "client_order_id": client_order_id,
+        "order_plan": {
+            "account_id": plan.account_id,
+            "wallet_address": plan.wallet_address,
+            "market_symbol": plan.market_symbol,
+            "market_id": plan.market_id,
+            "is_buy": plan.is_buy,
+            "quantity": str(plan.quantity),
+            "initial_limit_px": str(plan.initial_limit_px),
+            "modified_limit_px": str(plan.modified_limit_px),
+            "time_in_force": "GTC",
+            "post_only": True,
+            "reduce_only": False,
+        },
+        "owned_order_ids": list(order_ids),
+        "events": [asdict(event) for event in events],
+    }
+    if error is not None:
+        evidence["failure"] = {
+            "stage": error.stage,
+            "detail": error.detail,
+            "cleanup_failures": list(error.cleanup_failures),
+        }
+    return evidence
+
+
 class LifecycleError(RuntimeError):
     """Fail-closed lifecycle failure with bounded diagnostic evidence."""
 
@@ -78,6 +138,14 @@ class LifecycleError(RuntimeError):
         self.detail = detail
         self.events = events
         self.cleanup_failures = cleanup_failures
+
+
+class OpenOrderUnverifiedError(LifecycleError):
+    """An OPEN response returned an ID but failed another response invariant."""
+
+    def __init__(self, order_id: str, detail: str) -> None:
+        super().__init__("place", detail)
+        self.order_id = order_id
 
 
 class LifecycleAdapter(Protocol):
@@ -226,7 +294,7 @@ async def cleanup_owned_orders(
         for label, operation in steps:
             try:
                 await asyncio.wait_for(operation, timeout=timeout_s)
-            except Exception as error:  # cleanup is deliberately best-effort
+            except Exception as error:  # pylint: disable=broad-exception-caught
                 order_failures.append(f"{label}:{type(error).__name__}")
         if order_failures:
             failures.append(f"{order_id}[{','.join(order_failures)}]")
@@ -253,11 +321,17 @@ async def run_order_lifecycle(
     events: list[LifecycleEvent] = []
 
     try:
-        raw_order_id = await _invoke(
-            "place",
-            adapter.place_post_only_gtc(plan, client_order_id),
-            timeout_s,
-        )
+        try:
+            raw_order_id = await _invoke(
+                "place",
+                adapter.place_post_only_gtc(plan, client_order_id),
+                timeout_s,
+            )
+        except OpenOrderUnverifiedError as error:
+            if error.order_id.isdecimal() and int(error.order_id) > 0:
+                registry.add(error.order_id)
+                events.append(LifecycleEvent("place.unverified", error.order_id, "OPEN response invariant failed"))
+            raise
         order_id = str(raw_order_id)
         if not order_id.isdecimal() or int(order_id) <= 0:
             raise LifecycleError("place", "adapter returned an invalid canonical order ID")

--- a/scripts/canary_lifecycle.py
+++ b/scripts/canary_lifecycle.py
@@ -1,0 +1,293 @@
+"""Bounded, run-owned order lifecycle for the Perp OB migration canary."""
+
+from __future__ import annotations
+
+from typing import Literal, Protocol, TypeVar
+
+import asyncio
+import hashlib
+import math
+import re
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from scripts.canary_preflight import CanaryProfile, PreflightError, validate_profile
+
+
+_RUN_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_ResultT = TypeVar("_ResultT")
+
+
+@dataclass(frozen=True)
+class OrderPlan:
+    """One deliberately resting order and its complete modified state."""
+
+    account_id: int
+    wallet_address: str
+    market_symbol: str
+    market_id: int
+    is_buy: bool
+    quantity: Decimal
+    initial_limit_px: Decimal
+    modified_limit_px: Decimal
+
+
+@dataclass(frozen=True)
+class OrderExpectation:
+    """State that both REST and read WebSocket surfaces must prove."""
+
+    order_id: str
+    status: Literal["OPEN", "CANCELLED"]
+    limit_px: Decimal | None = None
+    quantity: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class LifecycleEvent:
+    """Credential-free evidence for one completed lifecycle step."""
+
+    step: str
+    order_id: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class LifecycleResult:
+    """Successful run result suitable for inclusion in canary evidence."""
+
+    run_id: str
+    client_order_id: int
+    owned_order_ids: tuple[str, ...]
+    events: tuple[LifecycleEvent, ...]
+
+
+class LifecycleError(RuntimeError):
+    """Fail-closed lifecycle failure with bounded diagnostic evidence."""
+
+    def __init__(
+        self,
+        stage: str,
+        detail: str,
+        *,
+        events: tuple[LifecycleEvent, ...] = (),
+        cleanup_failures: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(f"canary lifecycle failed at {stage}: {detail}")
+        self.stage = stage
+        self.detail = detail
+        self.events = events
+        self.cleanup_failures = cleanup_failures
+
+
+class LifecycleAdapter(Protocol):
+    """Narrow boundary that a future SDK-backed live adapter must implement."""
+
+    async def place_post_only_gtc(self, plan: OrderPlan, client_order_id: int) -> str:
+        """Place the plan as post-only GTC and return its canonical order ID."""
+        raise NotImplementedError
+
+    async def modify_post_only_gtc(self, order_id: str, plan: OrderPlan, client_order_id: int) -> None:
+        """Apply the complete modified state without changing immutable fields."""
+        raise NotImplementedError
+
+    async def cancel_order(self, order_id: str, plan: OrderPlan) -> None:
+        """Cancel exactly one canonical order ID."""
+        raise NotImplementedError
+
+    async def wait_rest(self, expectation: OrderExpectation, plan: OrderPlan, timeout_s: float) -> None:
+        """Wait for REST open-order presence or terminal absence."""
+        raise NotImplementedError
+
+    async def wait_ws(self, expectation: OrderExpectation, plan: OrderPlan, timeout_s: float) -> None:
+        """Wait for the wallet order-change stream to prove the state."""
+        raise NotImplementedError
+
+
+class OwnedOrderRegistry:
+    """Tracks only canonical order IDs created by the current canary run."""
+
+    def __init__(self) -> None:
+        self._created: list[str] = []
+        self._active: set[str] = set()
+
+    @property
+    def created(self) -> tuple[str, ...]:
+        return tuple(self._created)
+
+    @property
+    def active(self) -> tuple[str, ...]:
+        return tuple(order_id for order_id in self._created if order_id in self._active)
+
+    def add(self, order_id: str) -> None:
+        if order_id in self._active:
+            raise LifecycleError("place", "adapter returned a duplicate order ID")
+        self._created.append(order_id)
+        self._active.add(order_id)
+
+    def mark_closed(self, order_id: str) -> None:
+        self._active.discard(order_id)
+
+
+def derive_client_order_id(run_id: str) -> int:
+    """Derive a stable non-zero signed-64-bit client order ID from a run ID."""
+    if not _RUN_ID_PATTERN.fullmatch(run_id):
+        raise LifecycleError("plan", "run_id must be 1-64 safe filename characters")
+    digest = hashlib.sha256(f"PRO-657:{run_id}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") & ((1 << 63) - 1) or 1
+
+
+def validate_order_plan(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+    *,
+    mutation_acknowledgement: str | None = None,
+) -> None:
+    """Validate the exact mutation against the fail-closed profile policy."""
+    try:
+        validate_profile(
+            profile,
+            mutating=True,
+            mutation_acknowledgement=mutation_acknowledgement,
+        )
+    except PreflightError as error:
+        raise LifecycleError("preflight", "profile did not pass mutation validation") from error
+
+    errors: list[str] = []
+    policy = profile.policy
+    if plan.account_id not in policy.allowed_account_ids:
+        errors.append("account ID is not allowlisted")
+    if plan.wallet_address.lower() not in {address.lower() for address in policy.allowed_wallet_addresses}:
+        errors.append("wallet address is not allowlisted")
+    if plan.market_symbol != policy.market_symbol:
+        errors.append("market symbol does not match the designated market")
+    if plan.market_id != policy.market_id:
+        errors.append("market ID does not match the designated market")
+    if not plan.quantity.is_finite():
+        errors.append("quantity must be finite")
+    elif plan.quantity <= 0:
+        errors.append("quantity must be greater than zero")
+    elif plan.quantity > policy.max_quantity:
+        errors.append("quantity exceeds the profile maximum")
+    prices_are_finite = plan.initial_limit_px.is_finite() and plan.modified_limit_px.is_finite()
+    if not prices_are_finite:
+        errors.append("limit prices must be finite")
+    elif plan.initial_limit_px <= 0 or plan.modified_limit_px <= 0:
+        errors.append("limit prices must be greater than zero")
+    elif plan.initial_limit_px == plan.modified_limit_px:
+        errors.append("modified limit price must differ from the initial price")
+    if plan.quantity.is_finite() and plan.quantity > 0 and prices_are_finite:
+        for label, price in (("initial", plan.initial_limit_px), ("modified", plan.modified_limit_px)):
+            if price > 0 and plan.quantity * price > policy.max_notional:
+                errors.append(f"{label} order notional exceeds the profile maximum")
+    if errors:
+        raise LifecycleError("plan", "; ".join(errors))
+
+
+async def _invoke(stage: str, operation: Awaitable[_ResultT], timeout_s: float) -> _ResultT:
+    try:
+        return await asyncio.wait_for(operation, timeout=timeout_s)
+    except LifecycleError:
+        raise
+    except Exception as error:
+        raise LifecycleError(stage, type(error).__name__) from error
+
+
+async def _confirm(
+    adapter: LifecycleAdapter,
+    plan: OrderPlan,
+    expectation: OrderExpectation,
+    timeout_s: float,
+    events: list[LifecycleEvent],
+) -> None:
+    await _invoke("rest-visibility", adapter.wait_rest(expectation, plan, timeout_s), timeout_s)
+    events.append(LifecycleEvent(f"rest.{expectation.status.lower()}", expectation.order_id, "confirmed"))
+    await _invoke("ws-visibility", adapter.wait_ws(expectation, plan, timeout_s), timeout_s)
+    events.append(LifecycleEvent(f"ws.{expectation.status.lower()}", expectation.order_id, "confirmed"))
+
+
+async def cleanup_owned_orders(
+    adapter: LifecycleAdapter,
+    plan: OrderPlan,
+    registry: OwnedOrderRegistry,
+    *,
+    timeout_s: float,
+) -> tuple[str, ...]:
+    """Best-effort cleanup of this run's active order IDs, never account-wide."""
+    failures: list[str] = []
+    for order_id in registry.active:
+        expectation = OrderExpectation(order_id, "CANCELLED")
+        steps = (
+            ("cancel", adapter.cancel_order(order_id, plan)),
+            ("rest", adapter.wait_rest(expectation, plan, timeout_s)),
+            ("ws", adapter.wait_ws(expectation, plan, timeout_s)),
+        )
+        order_failures: list[str] = []
+        for label, operation in steps:
+            try:
+                await asyncio.wait_for(operation, timeout=timeout_s)
+            except Exception as error:  # cleanup is deliberately best-effort
+                order_failures.append(f"{label}:{type(error).__name__}")
+        if order_failures:
+            failures.append(f"{order_id}[{','.join(order_failures)}]")
+        else:
+            registry.mark_closed(order_id)
+    return tuple(failures)
+
+
+async def run_order_lifecycle(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+    adapter: LifecycleAdapter,
+    *,
+    run_id: str,
+    timeout_s: float = 10.0,
+    mutation_acknowledgement: str | None = None,
+) -> LifecycleResult:
+    """Run place, dual visibility, modify, dual visibility, and exact cancel."""
+    if not math.isfinite(timeout_s) or timeout_s <= 0:
+        raise LifecycleError("plan", "timeout must be finite and greater than zero")
+    validate_order_plan(profile, plan, mutation_acknowledgement=mutation_acknowledgement)
+    client_order_id = derive_client_order_id(run_id)
+    registry = OwnedOrderRegistry()
+    events: list[LifecycleEvent] = []
+
+    try:
+        raw_order_id = await _invoke(
+            "place",
+            adapter.place_post_only_gtc(plan, client_order_id),
+            timeout_s,
+        )
+        order_id = str(raw_order_id)
+        if not order_id.isdecimal() or int(order_id) <= 0:
+            raise LifecycleError("place", "adapter returned an invalid canonical order ID")
+        registry.add(order_id)
+        events.append(LifecycleEvent("place.accepted", order_id, "post-only GTC"))
+
+        initial = OrderExpectation(order_id, "OPEN", plan.initial_limit_px, plan.quantity)
+        await _confirm(adapter, plan, initial, timeout_s, events)
+
+        await _invoke(
+            "modify",
+            adapter.modify_post_only_gtc(order_id, plan, client_order_id),
+            timeout_s,
+        )
+        events.append(LifecycleEvent("modify.accepted", order_id, "complete post-only GTC state"))
+        modified = OrderExpectation(order_id, "OPEN", plan.modified_limit_px, plan.quantity)
+        await _confirm(adapter, plan, modified, timeout_s, events)
+
+        await _invoke("cancel", adapter.cancel_order(order_id, plan), timeout_s)
+        events.append(LifecycleEvent("cancel.accepted", order_id, "exact order ID"))
+        cancelled = OrderExpectation(order_id, "CANCELLED")
+        await _confirm(adapter, plan, cancelled, timeout_s, events)
+        registry.mark_closed(order_id)
+    except LifecycleError as error:
+        cleanup_failures = await cleanup_owned_orders(adapter, plan, registry, timeout_s=timeout_s)
+        raise LifecycleError(
+            error.stage,
+            error.detail,
+            events=tuple(events),
+            cleanup_failures=cleanup_failures,
+        ) from error
+
+    return LifecycleResult(run_id, client_order_id, registry.created, tuple(events))

--- a/scripts/canary_preflight.py
+++ b/scripts/canary_preflight.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol
 
+import asyncio
 import hashlib
 import json
+import os
 import re
+import ssl
 import subprocess  # nosec B404
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
@@ -14,6 +17,9 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from urllib.parse import urlsplit
+
+import httpx
+from websocket import create_connection  # type: ignore[attr-defined]  # pylint: disable=no-name-in-module
 
 try:
     import tomllib
@@ -24,8 +30,17 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10/3.11 compatibility
 MAINNET_MUTATION_ACKNOWLEDGEMENT = "PRO-657-MAINNET-MUTATION-APPROVED"
 
 _ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]{40}$")
+_ENV_VAR_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 _SECRET_KEY_PARTS = ("private_key", "privatekey", "secret", "mnemonic")
-_PROFILE_FIELDS = {"name", "enabled", "environment", "release_manifest_id", "identity", "canary"}
+_PROFILE_FIELDS = {
+    "name",
+    "enabled",
+    "environment",
+    "release_manifest_id",
+    "rpc_url_env",
+    "identity",
+    "canary",
+}
 _IDENTITY_FIELDS = {"chain_id", "api_url", "read_ws_url", "ws_exec_url", "orders_gateway", "exchange_id"}
 _CANARY_FIELDS = {
     "market_symbol",
@@ -39,6 +54,10 @@ _CANARY_FIELDS = {
 
 class PreflightError(ValueError):
     """Raised when a canary profile is unsafe or incomplete."""
+
+
+class ProbeError(PreflightError):
+    """Raised when a read-only live target probe fails."""
 
 
 @dataclass(frozen=True)
@@ -74,7 +93,58 @@ class CanaryProfile:
     environment: str
     identity: EnvironmentIdentity
     release_manifest_id: str
+    rpc_url_env: str
     policy: CanaryPolicy
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """One successful read-only live target check."""
+
+    id: str
+    detail: str
+
+
+class ProbeTransport(Protocol):
+    """Injectable I/O boundary for read-only live probes."""
+
+    async def get_json(self, url: str, timeout_s: float) -> Any:
+        raise NotImplementedError
+
+    async def post_json(self, url: str, payload: Mapping[str, Any], timeout_s: float) -> Any:
+        raise NotImplementedError
+
+    async def websocket_handshake(self, url: str, timeout_s: float) -> None:
+        raise NotImplementedError
+
+
+class DefaultProbeTransport:
+    """Read-only HTTP and WebSocket transport used by the CLI."""
+
+    async def get_json(self, url: str, timeout_s: float) -> Any:
+        async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=False) as client:
+            response = await client.get(url, headers={"Accept": "application/json"})
+            response.raise_for_status()
+            return response.json()
+
+    async def post_json(self, url: str, payload: Mapping[str, Any], timeout_s: float) -> Any:
+        async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=False) as client:
+            response = await client.post(url, json=payload, headers={"Accept": "application/json"})
+            response.raise_for_status()
+            return response.json()
+
+    async def websocket_handshake(self, url: str, timeout_s: float) -> None:
+        websocket = None
+        try:
+            websocket = await asyncio.to_thread(
+                create_connection,
+                url,
+                timeout=timeout_s,
+                sslopt={"cert_reqs": ssl.CERT_REQUIRED},
+            )
+        finally:
+            if websocket is not None:
+                await asyncio.to_thread(websocket.close)
 
 
 SUPPORTED_ENVIRONMENTS: Mapping[str, EnvironmentIdentity] = {
@@ -205,6 +275,7 @@ def load_profile(path: Path) -> CanaryProfile:
         environment=_required_string(raw, "environment").lower(),
         identity=identity,
         release_manifest_id=_required_string(raw, "release_manifest_id"),
+        rpc_url_env=_required_string(raw, "rpc_url_env"),
         policy=policy,
     )
 
@@ -265,6 +336,8 @@ def validate_profile(
         errors.append("name must not be empty")
     if not profile.release_manifest_id or profile.release_manifest_id.startswith("REPLACE_"):
         errors.append("release_manifest_id must pin the exact candidate manifest")
+    if not _ENV_VAR_PATTERN.fullmatch(profile.rpc_url_env):
+        errors.append("rpc_url_env must be an uppercase environment variable name")
     if not profile.policy.market_symbol or profile.policy.market_symbol.startswith("REPLACE_"):
         errors.append("canary.market_symbol must name the designated market")
     if profile.policy.market_id <= 0:
@@ -302,6 +375,128 @@ def validate_profile(
         raise PreflightError("canary preflight failed:\n- " + "\n- ".join(errors))
 
 
+def resolve_rpc_url(profile: CanaryProfile, environ: Mapping[str, str] | None = None) -> str:
+    """Resolve the RPC URL from the explicitly named process environment variable."""
+    source = os.environ if environ is None else environ
+    value = source.get(profile.rpc_url_env, "").strip()
+    if not value:
+        raise ProbeError(f"{profile.rpc_url_env} is required for read-only RPC probes")
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ProbeError(f"{profile.rpc_url_env} must contain an absolute HTTP(S) URL")
+    return value
+
+
+def _market_rows(payload: Any) -> list[Mapping[str, Any]]:
+    if isinstance(payload, Mapping):
+        payload = payload.get("data")
+    if not isinstance(payload, list) or any(not isinstance(row, Mapping) for row in payload):
+        raise ProbeError("REST perpMarketDefinitions returned an unexpected payload shape")
+    return payload
+
+
+def _json_rpc_result(payload: Any, method: str) -> Any:
+    if not isinstance(payload, Mapping):
+        raise ProbeError(f"{method} returned an unexpected JSON-RPC payload")
+    if payload.get("error") is not None:
+        raise ProbeError(f"{method} returned a JSON-RPC error")
+    if "result" not in payload:
+        raise ProbeError(f"{method} response omitted result")
+    return payload["result"]
+
+
+async def run_live_probes(
+    profile: CanaryProfile,
+    *,
+    rpc_url: str,
+    transport: ProbeTransport | None = None,
+    timeout_s: float = 10.0,
+) -> tuple[ProbeResult, ...]:
+    """Run bounded read-only checks against every target surface."""
+    if timeout_s <= 0:
+        raise ProbeError("probe timeout must be greater than zero")
+    client = transport or DefaultProbeTransport()
+    results: list[ProbeResult] = []
+
+    definitions_url = f"{profile.identity.api_url.rstrip('/')}/perpMarketDefinitions"
+    try:
+        definitions_payload = await client.get_json(definitions_url, timeout_s)
+    except Exception as error:
+        raise ProbeError(f"REST market identity probe failed: {type(error).__name__}") from error
+    matching_markets = [
+        row for row in _market_rows(definitions_payload) if row.get("symbol") == profile.policy.market_symbol
+    ]
+    if len(matching_markets) != 1:
+        raise ProbeError(
+            f"REST market identity expected one {profile.policy.market_symbol} definition, got {len(matching_markets)}"
+        )
+    actual_market_id = matching_markets[0].get("marketId", matching_markets[0].get("market_id"))
+    if actual_market_id != profile.policy.market_id:
+        raise ProbeError(
+            f"REST market ID mismatch for {profile.policy.market_symbol}: "
+            f"expected {profile.policy.market_id}, got {actual_market_id}"
+        )
+    results.append(ProbeResult("rest.marketIdentity", f"{profile.policy.market_symbol} marketId={actual_market_id}"))
+
+    try:
+        chain_payload = await client.post_json(
+            rpc_url,
+            {"jsonrpc": "2.0", "id": 1, "method": "eth_chainId", "params": []},
+            timeout_s,
+        )
+        chain_result = _json_rpc_result(chain_payload, "eth_chainId")
+        if not isinstance(chain_result, str):
+            raise ProbeError("eth_chainId result must be a hex string")
+        live_chain_id = int(chain_result, 16)
+    except ProbeError:
+        raise
+    except Exception as error:
+        raise ProbeError(
+            f"RPC chain identity probe via {profile.rpc_url_env} failed: {type(error).__name__}"
+        ) from error
+    if live_chain_id != profile.identity.chain_id:
+        raise ProbeError(f"RPC chain ID mismatch: expected {profile.identity.chain_id}, got {live_chain_id}")
+    results.append(ProbeResult("rpc.chainId", str(live_chain_id)))
+
+    try:
+        code_payload = await client.post_json(
+            rpc_url,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "eth_getCode",
+                "params": [profile.identity.orders_gateway, "latest"],
+            },
+            timeout_s,
+        )
+        code_result = _json_rpc_result(code_payload, "eth_getCode")
+    except ProbeError:
+        raise
+    except Exception as error:
+        raise ProbeError(f"Orders Gateway probe via {profile.rpc_url_env} failed: {type(error).__name__}") from error
+    if not isinstance(code_result, str) or not code_result.startswith("0x"):
+        raise ProbeError("eth_getCode result must be 0x-prefixed bytecode")
+    if code_result in {"0x", "0x0", "0x00"}:
+        raise ProbeError(f"Orders Gateway has no deployed bytecode at {profile.identity.orders_gateway}")
+    try:
+        bytecode_size = len(bytes.fromhex(code_result[2:]))
+    except ValueError as error:
+        raise ProbeError("eth_getCode returned malformed hex bytecode") from error
+    results.append(ProbeResult("rpc.ordersGatewayCode", f"{bytecode_size} bytes"))
+
+    for probe_id, url in (
+        ("ws.readHandshake", profile.identity.read_ws_url),
+        ("ws.execHandshake", profile.identity.ws_exec_url),
+    ):
+        try:
+            await client.websocket_handshake(url, timeout_s)
+        except Exception as error:
+            raise ProbeError(f"{probe_id} failed: {type(error).__name__}") from error
+        results.append(ProbeResult(probe_id, "connected and closed without sending a frame"))
+
+    return tuple(results)
+
+
 def _git_revision(repo_root: Path) -> str:
     try:
         result = subprocess.run(  # nosec B603 B607 -- fixed argv, no shell, repository cwd
@@ -316,7 +511,14 @@ def _git_revision(repo_root: Path) -> str:
     return result.stdout.strip()
 
 
-def build_evidence(profile: CanaryProfile, profile_path: Path, *, repo_root: Path) -> dict[str, Any]:
+def build_evidence(
+    profile: CanaryProfile,
+    profile_path: Path,
+    *,
+    repo_root: Path,
+    mode: str = "preflight-only",
+    probes: tuple[ProbeResult, ...] = (),
+) -> dict[str, Any]:
     """Build a credential-free, machine-readable preflight evidence record."""
     try:
         profile_sha256 = hashlib.sha256(profile_path.read_bytes()).hexdigest()
@@ -331,17 +533,19 @@ def build_evidence(profile: CanaryProfile, profile_path: Path, *, repo_root: Pat
     return {
         "schema_version": 1,
         "result": "pass",
-        "mode": "preflight-only",
+        "mode": mode,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "sdk_git_revision": _git_revision(repo_root),
         "profile": {
             "name": profile.name,
             "environment": profile.environment,
             "release_manifest_id": profile.release_manifest_id,
+            "rpc_url_env": profile.rpc_url_env,
             "sha256": profile_sha256,
         },
         "identity": identity,
         "canary": policy,
+        "probes": [asdict(probe) for probe in probes],
     }
 
 

--- a/scripts/canary_preflight.py
+++ b/scripts/canary_preflight.py
@@ -1,0 +1,358 @@
+"""Fail-closed configuration preflight for the Perp OB migration canary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import hashlib
+import json
+import re
+import subprocess  # nosec B404
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from urllib.parse import urlsplit
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10/3.11 compatibility for mypy/dev tooling
+    import tomli as tomllib
+
+
+MAINNET_MUTATION_ACKNOWLEDGEMENT = "PRO-657-MAINNET-MUTATION-APPROVED"
+
+_ADDRESS_PATTERN = re.compile(r"^0x[0-9a-fA-F]{40}$")
+_SECRET_KEY_PARTS = ("private_key", "privatekey", "secret", "mnemonic")
+_PROFILE_FIELDS = {"name", "enabled", "environment", "release_manifest_id", "identity", "canary"}
+_IDENTITY_FIELDS = {"chain_id", "api_url", "read_ws_url", "ws_exec_url", "orders_gateway", "exchange_id"}
+_CANARY_FIELDS = {
+    "market_symbol",
+    "market_id",
+    "max_quantity",
+    "max_notional",
+    "allowed_account_ids",
+    "allowed_wallet_addresses",
+}
+
+
+class PreflightError(ValueError):
+    """Raised when a canary profile is unsafe or incomplete."""
+
+
+@dataclass(frozen=True)
+class EnvironmentIdentity:
+    """Immutable identity of a supported Reya deployment."""
+
+    chain_id: int
+    api_url: str
+    read_ws_url: str
+    ws_exec_url: str
+    orders_gateway: str
+    exchange_id: int
+
+
+@dataclass(frozen=True)
+class CanaryPolicy:
+    """Bounded mutation policy for one designated canary run."""
+
+    market_symbol: str
+    market_id: int
+    max_quantity: Decimal
+    max_notional: Decimal
+    allowed_account_ids: tuple[int, ...]
+    allowed_wallet_addresses: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CanaryProfile:
+    """Environment identity and mutation policy loaded from an explicit file."""
+
+    name: str
+    enabled: bool
+    environment: str
+    identity: EnvironmentIdentity
+    release_manifest_id: str
+    policy: CanaryPolicy
+
+
+SUPPORTED_ENVIRONMENTS: Mapping[str, EnvironmentIdentity] = {
+    "devnet1": EnvironmentIdentity(
+        chain_id=89346162,
+        api_url="https://api-devnet.reya-cronos.network/v2",
+        read_ws_url="wss://websocket-devnet.reya-cronos.network/",
+        ws_exec_url="wss://ws-exec-devnet.reya-cronos.network",
+        orders_gateway="0x7Ec89E555c771D2B5939aBE5C4E4291852633D4D",
+        exchange_id=1,
+    ),
+    "mainnet": EnvironmentIdentity(
+        chain_id=1729,
+        api_url="https://api.reya.xyz/v2",
+        read_ws_url="wss://ws.reya.xyz/",
+        ws_exec_url="wss://ws-exec.reya.xyz",
+        orders_gateway="0xfc8c96be87da63cecddbf54abfa7b13ee8044739",
+        exchange_id=2,
+    ),
+}
+
+
+def _reject_secret_fields(value: Any, path: str = "profile") -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            normalized = str(key).lower().replace("-", "_")
+            if any(part in normalized for part in _SECRET_KEY_PARTS):
+                raise PreflightError(
+                    f"{path}.{key} looks like a secret field; keep credentials in the operator environment"
+                )
+            _reject_secret_fields(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_secret_fields(child, f"{path}[{index}]")
+
+
+def _reject_unknown_fields(data: Mapping[str, Any], allowed: set[str], path: str) -> None:
+    unknown = sorted(set(data) - allowed)
+    if unknown:
+        raise PreflightError(f"{path} contains unknown fields: {', '.join(unknown)}")
+
+
+def _required_string(data: Mapping[str, Any], name: str) -> str:
+    value = data.get(name)
+    if not isinstance(value, str):
+        raise PreflightError(f"{name} must be a string")
+    return value.strip()
+
+
+def _required_int(data: Mapping[str, Any], name: str) -> int:
+    value = data.get(name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PreflightError(f"{name} must be an integer")
+    return value
+
+
+def _required_decimal(data: Mapping[str, Any], name: str) -> Decimal:
+    value = data.get(name)
+    if not isinstance(value, str):
+        raise PreflightError(f"{name} must be a quoted decimal string")
+    try:
+        decimal_value = Decimal(value)
+    except InvalidOperation as error:
+        raise PreflightError(f"{name} must be a valid decimal string") from error
+    if not decimal_value.is_finite():
+        raise PreflightError(f"{name} must be finite")
+    return decimal_value
+
+
+def _int_tuple(data: Mapping[str, Any], name: str) -> tuple[int, ...]:
+    value = data.get(name)
+    if not isinstance(value, list):
+        raise PreflightError(f"{name} must be an array of integers")
+    if any(isinstance(item, bool) or not isinstance(item, int) for item in value):
+        raise PreflightError(f"{name} must contain only integers")
+    return tuple(value)
+
+
+def _string_tuple(data: Mapping[str, Any], name: str) -> tuple[str, ...]:
+    value = data.get(name)
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise PreflightError(f"{name} must be an array of strings")
+    return tuple(item.strip() for item in value)
+
+
+def load_profile(path: Path) -> CanaryProfile:
+    """Load a TOML profile without consulting `.env` or process credentials."""
+    try:
+        with path.open("rb") as profile_file:
+            raw = tomllib.load(profile_file)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise PreflightError(f"cannot load profile {path}: {error}") from error
+
+    _reject_secret_fields(raw)
+    _reject_unknown_fields(raw, _PROFILE_FIELDS, "profile")
+    identity_data = raw.get("identity")
+    policy_data = raw.get("canary")
+    if not isinstance(identity_data, Mapping):
+        raise PreflightError("profile.identity table is required")
+    if not isinstance(policy_data, Mapping):
+        raise PreflightError("profile.canary table is required")
+    _reject_unknown_fields(identity_data, _IDENTITY_FIELDS, "profile.identity")
+    _reject_unknown_fields(policy_data, _CANARY_FIELDS, "profile.canary")
+
+    enabled = raw.get("enabled")
+    if not isinstance(enabled, bool):
+        raise PreflightError("enabled must be a boolean")
+
+    identity = EnvironmentIdentity(
+        chain_id=_required_int(identity_data, "chain_id"),
+        api_url=_required_string(identity_data, "api_url"),
+        read_ws_url=_required_string(identity_data, "read_ws_url"),
+        ws_exec_url=_required_string(identity_data, "ws_exec_url"),
+        orders_gateway=_required_string(identity_data, "orders_gateway"),
+        exchange_id=_required_int(identity_data, "exchange_id"),
+    )
+    policy = CanaryPolicy(
+        market_symbol=_required_string(policy_data, "market_symbol"),
+        market_id=_required_int(policy_data, "market_id"),
+        max_quantity=_required_decimal(policy_data, "max_quantity"),
+        max_notional=_required_decimal(policy_data, "max_notional"),
+        allowed_account_ids=_int_tuple(policy_data, "allowed_account_ids"),
+        allowed_wallet_addresses=_string_tuple(policy_data, "allowed_wallet_addresses"),
+    )
+    return CanaryProfile(
+        name=_required_string(raw, "name"),
+        enabled=enabled,
+        environment=_required_string(raw, "environment").lower(),
+        identity=identity,
+        release_manifest_id=_required_string(raw, "release_manifest_id"),
+        policy=policy,
+    )
+
+
+def _canonical_endpoint(value: str, label: str) -> tuple[str, str, int | None, str]:
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https", "ws", "wss"} or not parsed.hostname:
+        raise PreflightError(f"{label} must be an absolute HTTP(S) or WS(S) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise PreflightError(f"{label} must not contain credentials, a query, or a fragment")
+    return (parsed.scheme.lower(), parsed.hostname.lower(), parsed.port, parsed.path.rstrip("/"))
+
+
+def _identity_errors(actual: EnvironmentIdentity, expected: EnvironmentIdentity) -> list[str]:
+    errors: list[str] = []
+    if actual.chain_id != expected.chain_id:
+        errors.append(f"chain_id mismatch: expected {expected.chain_id}, got {actual.chain_id}")
+    for field_name in ("api_url", "read_ws_url", "ws_exec_url"):
+        actual_url = getattr(actual, field_name)
+        expected_url = getattr(expected, field_name)
+        try:
+            actual_endpoint = _canonical_endpoint(actual_url, field_name)
+            expected_endpoint = _canonical_endpoint(expected_url, field_name)
+            if actual_endpoint != expected_endpoint:
+                errors.append(f"{field_name} mismatch: expected {expected_url}, got {actual_url}")
+        except PreflightError as error:
+            errors.append(str(error))
+    if not _ADDRESS_PATTERN.fullmatch(actual.orders_gateway):
+        errors.append("orders_gateway must be a 20-byte 0x-prefixed address")
+    elif actual.orders_gateway.lower() != expected.orders_gateway.lower():
+        errors.append(
+            f"orders_gateway mismatch: expected {expected.orders_gateway.lower()}, got {actual.orders_gateway.lower()}"
+        )
+    if actual.exchange_id != expected.exchange_id:
+        errors.append(f"exchange_id mismatch: expected {expected.exchange_id}, got {actual.exchange_id}")
+    return errors
+
+
+def validate_profile(
+    profile: CanaryProfile,
+    *,
+    mutating: bool = False,
+    mutation_acknowledgement: str | None = None,
+) -> None:
+    """Validate identity, bounds, allowlists, and the mainnet mutation gate."""
+    errors: list[str] = []
+    expected = SUPPORTED_ENVIRONMENTS.get(profile.environment)
+    if expected is None:
+        errors.append(
+            f"unsupported environment {profile.environment!r}; expected one of {', '.join(SUPPORTED_ENVIRONMENTS)}"
+        )
+    else:
+        errors.extend(_identity_errors(profile.identity, expected))
+
+    if not profile.enabled:
+        errors.append("profile is disabled; copy the template to a local profile and set enabled=true")
+    if not profile.name:
+        errors.append("name must not be empty")
+    if not profile.release_manifest_id or profile.release_manifest_id.startswith("REPLACE_"):
+        errors.append("release_manifest_id must pin the exact candidate manifest")
+    if not profile.policy.market_symbol or profile.policy.market_symbol.startswith("REPLACE_"):
+        errors.append("canary.market_symbol must name the designated market")
+    if profile.policy.market_id <= 0:
+        errors.append("canary.market_id must be greater than zero")
+    if profile.policy.max_quantity <= 0:
+        errors.append("canary.max_quantity must be greater than zero")
+    if profile.policy.max_notional <= 0:
+        errors.append("canary.max_notional must be greater than zero")
+    if not profile.policy.allowed_account_ids:
+        errors.append("canary.allowed_account_ids must not be empty")
+    elif any(account_id <= 0 for account_id in profile.policy.allowed_account_ids):
+        errors.append("canary.allowed_account_ids must contain only positive IDs")
+    if len(set(profile.policy.allowed_account_ids)) != len(profile.policy.allowed_account_ids):
+        errors.append("canary.allowed_account_ids must not contain duplicates")
+    if not profile.policy.allowed_wallet_addresses:
+        errors.append("canary.allowed_wallet_addresses must not be empty")
+    else:
+        invalid_addresses = [
+            address for address in profile.policy.allowed_wallet_addresses if not _ADDRESS_PATTERN.fullmatch(address)
+        ]
+        if invalid_addresses:
+            errors.append("canary.allowed_wallet_addresses must contain only 20-byte 0x-prefixed addresses")
+        normalized_addresses = [address.lower() for address in profile.policy.allowed_wallet_addresses]
+        if len(set(normalized_addresses)) != len(normalized_addresses):
+            errors.append("canary.allowed_wallet_addresses must not contain duplicates")
+
+    if mutating and profile.environment == "mainnet":
+        if mutation_acknowledgement != MAINNET_MUTATION_ACKNOWLEDGEMENT:
+            errors.append(
+                "mainnet mutation acknowledgement missing or incorrect; "
+                f"expected {MAINNET_MUTATION_ACKNOWLEDGEMENT!r}"
+            )
+
+    if errors:
+        raise PreflightError("canary preflight failed:\n- " + "\n- ".join(errors))
+
+
+def _git_revision(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(  # nosec B603 B607 -- fixed argv, no shell, repository cwd
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise PreflightError(f"cannot resolve SDK git revision: {error}") from error
+    return result.stdout.strip()
+
+
+def build_evidence(profile: CanaryProfile, profile_path: Path, *, repo_root: Path) -> dict[str, Any]:
+    """Build a credential-free, machine-readable preflight evidence record."""
+    try:
+        profile_sha256 = hashlib.sha256(profile_path.read_bytes()).hexdigest()
+    except OSError as error:
+        raise PreflightError(f"cannot hash profile {profile_path}: {error}") from error
+    identity = asdict(profile.identity)
+    policy = asdict(profile.policy)
+    policy["max_quantity"] = str(profile.policy.max_quantity)
+    policy["max_notional"] = str(profile.policy.max_notional)
+    policy["allowed_account_ids"] = list(profile.policy.allowed_account_ids)
+    policy["allowed_wallet_addresses"] = list(profile.policy.allowed_wallet_addresses)
+    return {
+        "schema_version": 1,
+        "result": "pass",
+        "mode": "preflight-only",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sdk_git_revision": _git_revision(repo_root),
+        "profile": {
+            "name": profile.name,
+            "environment": profile.environment,
+            "release_manifest_id": profile.release_manifest_id,
+            "sha256": profile_sha256,
+        },
+        "identity": identity,
+        "canary": policy,
+    }
+
+
+def write_evidence(evidence: Mapping[str, Any], output_path: Path) -> None:
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError as error:
+        raise PreflightError(f"cannot write evidence {output_path}: {error}") from error
+
+
+def default_evidence_path(profile: CanaryProfile, *, repo_root: Path) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return repo_root / "artifacts" / "canary" / f"{timestamp}-{profile.environment}" / "preflight.json"

--- a/scripts/canary_recovery.py
+++ b/scripts/canary_recovery.py
@@ -1,0 +1,256 @@
+"""Operator-coordinated restart recovery checks for the PRO-657 canary."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeVar
+
+import asyncio
+import math
+import re
+from collections.abc import Awaitable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from scripts.canary_lifecycle import LifecycleError, derive_client_order_id
+from scripts.canary_preflight import CanaryProfile, PreflightError, validate_profile
+
+MAINNET_RECOVERY_ACKNOWLEDGEMENT = "PRO-657-MAINNET-RECOVERY-CHECKPOINT-APPROVED"
+
+_EVIDENCE_REF_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,255}$")
+_ResultT = TypeVar("_ResultT")
+
+
+@dataclass(frozen=True)
+class ProjectionSnapshot:
+    """Public read-model state captured at one recovery boundary."""
+
+    account_id: int
+    wallet_address: str
+    market_symbol: str
+    latest_sequence: int
+    open_order_ids: tuple[str, ...]
+    position_size: Decimal
+
+
+@dataclass(frozen=True)
+class RecoveryObservation:
+    """Fresh post-reconnect projection plus every event sequence observed."""
+
+    snapshot: ProjectionSnapshot
+    observed_sequences: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class OperatorResume:
+    """Credential-free acknowledgement supplied after the operator action."""
+
+    evidence_ref: str
+
+
+@dataclass(frozen=True)
+class RecoveryResult:
+    """Validated recovery result suitable for the migration evidence bundle."""
+
+    run_id: str
+    client_order_id: int
+    checkpoint_id: str
+    operator_evidence_ref: str
+    baseline: ProjectionSnapshot
+    recovered: ProjectionSnapshot
+    observed_sequences: tuple[int, ...]
+
+
+class RecoveryError(RuntimeError):
+    """Fail-closed recovery failure with a stable stage and safe detail."""
+
+    def __init__(self, stage: str, detail: str) -> None:
+        super().__init__(f"canary recovery failed at {stage}: {detail}")
+        self.stage = stage
+        self.detail = detail
+
+
+class RecoveryAdapter(Protocol):
+    """Read-only recovery boundary; it deliberately has no restart method."""
+
+    async def snapshot_projection(self, timeout_s: float) -> ProjectionSnapshot:
+        """Capture the current REST/WS projection before an operator action."""
+        raise NotImplementedError
+
+    async def reconnect_and_collect(self, after_sequence: int, timeout_s: float) -> RecoveryObservation:
+        """Reconnect, resubscribe, and collect a contiguous fresh event window."""
+        raise NotImplementedError
+
+
+class OperatorCheckpoint(Protocol):
+    """Pause boundary implemented by external orchestration, never the SDK."""
+
+    async def wait_for_resume(self, checkpoint_id: str, timeout_s: float) -> OperatorResume:
+        """Wait for an operator to complete the planned action and resume."""
+        raise NotImplementedError
+
+
+async def _invoke(stage: str, operation: Awaitable[_ResultT], timeout_s: float) -> _ResultT:
+    try:
+        return await asyncio.wait_for(operation, timeout=timeout_s)
+    except RecoveryError:
+        raise
+    except Exception as error:
+        raise RecoveryError(stage, type(error).__name__) from error
+
+
+def _validate_snapshot(profile: CanaryProfile, snapshot: ProjectionSnapshot, *, stage: str) -> None:
+    errors: list[str] = []
+    policy = profile.policy
+    if snapshot.account_id not in policy.allowed_account_ids:
+        errors.append("account is not allowlisted")
+    if snapshot.wallet_address.lower() not in {address.lower() for address in policy.allowed_wallet_addresses}:
+        errors.append("wallet is not allowlisted")
+    if snapshot.market_symbol != policy.market_symbol:
+        errors.append("market does not match the profile")
+    if snapshot.latest_sequence < 0:
+        errors.append("latest sequence cannot be negative")
+    if not snapshot.position_size.is_finite():
+        errors.append("position size must be finite")
+    if len(snapshot.open_order_ids) != len(set(snapshot.open_order_ids)):
+        errors.append("open order IDs contain duplicates")
+    if any(not order_id.isdecimal() or int(order_id) <= 0 for order_id in snapshot.open_order_ids):
+        errors.append("open order IDs must be positive canonical IDs")
+    if errors:
+        raise RecoveryError(stage, "; ".join(errors))
+
+
+def _validate_recovery(baseline: ProjectionSnapshot, observation: RecoveryObservation) -> None:
+    recovered = observation.snapshot
+    if recovered.account_id != baseline.account_id:
+        raise RecoveryError("projection", "account changed across the checkpoint")
+    if recovered.wallet_address.lower() != baseline.wallet_address.lower():
+        raise RecoveryError("projection", "wallet changed across the checkpoint")
+    if recovered.market_symbol != baseline.market_symbol:
+        raise RecoveryError("projection", "market changed across the checkpoint")
+    if set(recovered.open_order_ids) != set(baseline.open_order_ids):
+        raise RecoveryError("cleanup", "open-order projection did not return to the baseline")
+    if recovered.position_size != baseline.position_size:
+        raise RecoveryError("cleanup", "position delta remained after recovery")
+
+    sequences = observation.observed_sequences
+    if not sequences:
+        raise RecoveryError("sequence", "no post-reconnect canary event was observed")
+    if recovered.latest_sequence != sequences[-1]:
+        raise RecoveryError("sequence", "projection sequence does not match the observed event window")
+    expected = tuple(range(baseline.latest_sequence + 1, recovered.latest_sequence + 1))
+    if sequences != expected:
+        raise RecoveryError("sequence", "post-reconnect event sequences are not contiguous and unique")
+
+
+def _validate_operator_resume(resume: OperatorResume) -> None:
+    if not _EVIDENCE_REF_PATTERN.fullmatch(resume.evidence_ref):
+        raise RecoveryError("checkpoint", "operator evidence reference is missing or unsafe")
+
+
+async def run_recovery_checkpoint(
+    profile: CanaryProfile,
+    adapter: RecoveryAdapter,
+    checkpoint: OperatorCheckpoint,
+    *,
+    run_id: str,
+    timeout_s: float = 60.0,
+    mainnet_acknowledgement: str | None = None,
+) -> RecoveryResult:
+    """Snapshot, pause for an operator action, reconnect, and prove recovery."""
+    if not math.isfinite(timeout_s) or timeout_s <= 0:
+        raise RecoveryError("plan", "timeout must be finite and greater than zero")
+    try:
+        validate_profile(profile, mutating=False)
+    except PreflightError as error:
+        raise RecoveryError("preflight", "profile did not pass validation") from error
+    if profile.environment == "mainnet" and mainnet_acknowledgement != MAINNET_RECOVERY_ACKNOWLEDGEMENT:
+        raise RecoveryError("preflight", "mainnet recovery checkpoint acknowledgement is required")
+
+    try:
+        client_order_id = derive_client_order_id(run_id)
+    except LifecycleError as error:
+        raise RecoveryError("plan", "run_id must be 1-64 safe filename characters") from error
+    checkpoint_id = f"PRO-657:{profile.environment}:{run_id}:restart-recovery"
+    baseline = await _invoke("baseline", adapter.snapshot_projection(timeout_s), timeout_s)
+    _validate_snapshot(profile, baseline, stage="baseline")
+    resume = await _invoke("checkpoint", checkpoint.wait_for_resume(checkpoint_id, timeout_s), timeout_s)
+    _validate_operator_resume(resume)
+    observation = await _invoke(
+        "reconnect",
+        adapter.reconnect_and_collect(baseline.latest_sequence, timeout_s),
+        timeout_s,
+    )
+    _validate_snapshot(profile, observation.snapshot, stage="projection")
+    _validate_recovery(baseline, observation)
+    return RecoveryResult(
+        run_id=run_id,
+        client_order_id=client_order_id,
+        checkpoint_id=checkpoint_id,
+        operator_evidence_ref=resume.evidence_ref,
+        baseline=baseline,
+        recovered=observation.snapshot,
+        observed_sequences=observation.observed_sequences,
+    )
+
+
+def build_recovery_evidence(
+    profile: CanaryProfile,
+    *,
+    result: RecoveryResult | None = None,
+    error: RecoveryError | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Build credential-free recovery evidence without copying operator output."""
+    if (result is None) == (error is None):
+        raise ValueError("provide exactly one of result or error")
+    resolved_run_id = result.run_id if result is not None else run_id
+    if resolved_run_id is None:
+        raise ValueError("run_id is required for failure evidence")
+    evidence: dict[str, Any] = {
+        "schema_version": 1,
+        "result": "pass" if result is not None else "fail",
+        "mode": "restart-recovery",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "environment": profile.environment,
+        "release_manifest_id": profile.release_manifest_id,
+        "run_id": resolved_run_id,
+        "client_order_id": _evidence_client_order_id(resolved_run_id),
+    }
+    if result is not None:
+        evidence["checkpoint"] = {
+            "id": result.checkpoint_id,
+            "operator_evidence_ref": result.operator_evidence_ref,
+        }
+        evidence["baseline"] = _snapshot_evidence(result.baseline)
+        evidence["recovered"] = _snapshot_evidence(result.recovered)
+        evidence["observed_sequences"] = list(result.observed_sequences)
+        evidence["assertions"] = {
+            "projection_converged": True,
+            "sequence_contiguous": True,
+            "no_duplicate_sequence": True,
+            "no_resting_order_delta": True,
+            "no_position_delta": True,
+        }
+    else:
+        assert error is not None
+        evidence["failure"] = {"stage": error.stage, "detail": error.detail}
+    return evidence
+
+
+def _snapshot_evidence(snapshot: ProjectionSnapshot) -> dict[str, Any]:
+    return {
+        "account_id": snapshot.account_id,
+        "wallet_address": snapshot.wallet_address,
+        "market_symbol": snapshot.market_symbol,
+        "latest_sequence": snapshot.latest_sequence,
+        "open_order_ids": list(snapshot.open_order_ids),
+        "position_size": str(snapshot.position_size),
+    }
+
+
+def _evidence_client_order_id(run_id: str) -> int:
+    try:
+        return derive_client_order_id(run_id)
+    except LifecycleError as error:
+        raise ValueError("run_id must be 1-64 safe filename characters") from error

--- a/scripts/canary_sdk_adapter.py
+++ b/scripts/canary_sdk_adapter.py
@@ -1,0 +1,340 @@
+"""Injected Reya SDK adapter for the bounded PRO-657 canary lifecycle."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import asyncio
+import math
+import threading
+import time
+from decimal import Decimal, InvalidOperation
+
+from sdk.async_api.cancel_reason import CancelReason as AsyncCancelReason
+from sdk.async_api.order import Order as AsyncOrder
+from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
+from sdk.async_api.order_changes_subscribed_payload import OrderChangesSubscribedPayload
+from sdk.async_api.order_status import OrderStatus as AsyncOrderStatus
+from sdk.async_api.side import Side as AsyncSide
+from sdk.async_api.time_in_force import TimeInForce as AsyncTimeInForce
+from sdk.open_api.models.cancel_order_response import CancelOrderResponse
+from sdk.open_api.models.create_order_response import CreateOrderResponse
+from sdk.open_api.models.modify_order_response import ModifyOrderResponse
+from sdk.open_api.models.order import Order
+from sdk.open_api.models.order_status import OrderStatus
+from sdk.open_api.models.side import Side
+from sdk.open_api.models.time_in_force import TimeInForce
+from sdk.reya_rest_api.models.orders import LimitOrderParameters, ModifyOrderParameters
+from scripts.canary_lifecycle import OpenOrderUnverifiedError, OrderExpectation, OrderPlan
+from scripts.canary_preflight import CanaryProfile
+
+
+class SdkAdapterError(RuntimeError):
+    """The SDK response or observation did not prove the canary invariant."""
+
+
+class RestClientConfig(Protocol):
+    """Identity-bearing Reya trading configuration."""
+
+    account_id: int | None
+    api_url: str
+    chain_id: int
+    dex_id: int
+    owner_wallet_address: str
+    orders_gateway_address: str | None
+
+
+class RestTradingClient(Protocol):
+    """Subset of ReyaTradingClient used by the canary adapter."""
+
+    @property
+    def config(self) -> RestClientConfig:
+        raise NotImplementedError
+
+    async def create_limit_order(self, params: LimitOrderParameters) -> CreateOrderResponse:
+        raise NotImplementedError
+
+    async def modify_order(self, params: ModifyOrderParameters) -> ModifyOrderResponse:
+        raise NotImplementedError
+
+    async def cancel_order(
+        self,
+        symbol: str,
+        account_id: int | None = None,
+        order_id: str | None = None,
+        client_order_id: int | None = None,
+    ) -> CancelOrderResponse:
+        raise NotImplementedError
+
+    async def get_open_orders(self) -> list[Order]:
+        raise NotImplementedError
+
+    def get_market_id_from_symbol(self, symbol: str) -> int:
+        raise NotImplementedError
+
+
+class WsOrderSource(Protocol):
+    """Thread-safe latest-order lookup populated by the read WebSocket."""
+
+    def get(self, order_id: str) -> AsyncOrder | None:
+        raise NotImplementedError
+
+
+class ThreadSafeWsOrderStore:
+    """Minimal callback store for wallet orderChanges snapshots and updates."""
+
+    def __init__(self, wallet_address: str) -> None:
+        self._orders: dict[str, AsyncOrder] = {}
+        self._lock = threading.Lock()
+        self._expected_channel = f"/v2/wallet/{wallet_address}/orderChanges".lower()
+
+    def ingest(self, message: object) -> None:
+        """Ingest only typed orderChanges payloads; ignore unrelated channels."""
+        if not isinstance(message, (OrderChangesSubscribedPayload, OrderChangeUpdatePayload)):
+            return
+        if message.channel.lower() != self._expected_channel:
+            return
+        if isinstance(message, OrderChangesSubscribedPayload):
+            orders = message.contents.data
+        else:
+            orders = message.data
+        with self._lock:
+            for order in orders:
+                self._put_if_newer(order)
+
+    def on_message(self, _websocket: object, message: object) -> None:
+        """Callback compatible with ReyaSocket(on_message=...)."""
+        self.ingest(message)
+
+    def get(self, order_id: str) -> AsyncOrder | None:
+        with self._lock:
+            return self._orders.get(order_id)
+
+    def _put_if_newer(self, order: AsyncOrder) -> None:
+        key = str(order.order_id)
+        current = self._orders.get(key)
+        if current is None:
+            self._orders[key] = order
+            return
+        if order.sequence_number is None and current.sequence_number is not None:
+            return
+        if (
+            order.sequence_number is not None
+            and current.sequence_number is not None
+            and order.sequence_number < current.sequence_number
+        ):
+            return
+        self._orders[key] = order
+
+
+class SdkLifecycleAdapter:
+    """Maps the lifecycle protocol to exact Reya REST requests and observations."""
+
+    def __init__(
+        self,
+        rest_client: RestTradingClient,
+        ws_orders: WsOrderSource,
+        profile: CanaryProfile,
+        *,
+        poll_interval_s: float = 0.1,
+    ) -> None:
+        if not math.isfinite(poll_interval_s) or poll_interval_s <= 0:
+            raise ValueError("poll_interval_s must be finite and greater than zero")
+        self._rest = rest_client
+        self._ws_orders = ws_orders
+        self._profile = profile
+        self._poll_interval_s = poll_interval_s
+        self._client_order_ids: dict[str, int] = {}
+
+    async def place_post_only_gtc(self, plan: OrderPlan, client_order_id: int) -> str:
+        self._require_plan_identity(plan)
+        response = await self._rest.create_limit_order(
+            LimitOrderParameters(
+                symbol=plan.market_symbol,
+                is_buy=plan.is_buy,
+                limit_px=format(plan.initial_limit_px, "f"),
+                qty=format(plan.quantity, "f"),
+                time_in_force=TimeInForce.GTC,
+                reduce_only=False,
+                post_only=True,
+                client_order_id=client_order_id,
+            )
+        )
+        if response.status == OrderStatus.OPEN:
+            self._client_order_ids[response.order_id] = client_order_id
+            if response.client_order_id != str(client_order_id):
+                raise OpenOrderUnverifiedError(response.order_id, "place response did not preserve the client order ID")
+        self._require_response(
+            response,
+            expected_status=OrderStatus.OPEN,
+            operation="place",
+        )
+        order_id = response.order_id
+        return order_id
+
+    async def modify_post_only_gtc(self, order_id: str, plan: OrderPlan, client_order_id: int) -> None:
+        self._require_plan_identity(plan)
+        self._require_owned_client_order_id(order_id, client_order_id)
+        response = await self._rest.modify_order(
+            ModifyOrderParameters(
+                symbol=plan.market_symbol,
+                is_buy=plan.is_buy,
+                limit_px=format(plan.modified_limit_px, "f"),
+                qty=format(plan.quantity, "f"),
+                post_only=True,
+                expires_after=None,
+                time_in_force=TimeInForce.GTC,
+                order_id=int(order_id),
+                client_order_id=client_order_id,
+                reduce_only=False,
+            )
+        )
+        self._require_response(
+            response,
+            expected_status=OrderStatus.OPEN,
+            expected_order_id=order_id,
+            expected_client_order_id=client_order_id,
+            operation="modify",
+        )
+
+    async def cancel_order(self, order_id: str, plan: OrderPlan) -> None:
+        self._require_plan_identity(plan)
+        client_order_id = self._client_order_ids.get(order_id)
+        if client_order_id is None:
+            raise SdkAdapterError("refusing to cancel an order not owned by this adapter run")
+        response = await self._rest.cancel_order(
+            symbol=plan.market_symbol,
+            account_id=plan.account_id,
+            order_id=order_id,
+            client_order_id=client_order_id,
+        )
+        self._require_response(
+            response,
+            expected_status=OrderStatus.CANCELLED,
+            expected_order_id=order_id,
+            operation="cancel",
+        )
+
+    async def wait_rest(self, expectation: OrderExpectation, plan: OrderPlan, timeout_s: float) -> None:
+        self._require_plan_identity(plan)
+        self._require_observation_owned(expectation.order_id)
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            orders = await self._rest.get_open_orders()
+            observed = next((order for order in orders if order.order_id == expectation.order_id), None)
+            if expectation.status == "CANCELLED":
+                if observed is None:
+                    return
+            elif observed is not None and self._rest_order_matches(observed, expectation, plan):
+                return
+            await self._sleep_until_next_poll(deadline)
+        raise SdkAdapterError(f"REST did not prove {expectation.status} for the exact canary order")
+
+    async def wait_ws(self, expectation: OrderExpectation, plan: OrderPlan, timeout_s: float) -> None:
+        self._require_plan_identity(plan)
+        self._require_observation_owned(expectation.order_id)
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            observed = self._ws_orders.get(expectation.order_id)
+            if observed is not None and self._ws_order_matches(observed, expectation, plan):
+                return
+            await self._sleep_until_next_poll(deadline)
+        raise SdkAdapterError(f"read WebSocket did not prove {expectation.status} for the exact canary order")
+
+    async def _sleep_until_next_poll(self, deadline: float) -> None:
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            await asyncio.sleep(min(self._poll_interval_s, remaining))
+
+    def _require_owned_client_order_id(self, order_id: str, client_order_id: int) -> None:
+        if self._client_order_ids.get(order_id) != client_order_id:
+            raise SdkAdapterError("order/client ownership does not match this adapter run")
+
+    def _require_observation_owned(self, order_id: str) -> None:
+        if order_id not in self._client_order_ids:
+            raise SdkAdapterError("refusing to observe an order not owned by this adapter run")
+
+    def _require_plan_identity(self, plan: OrderPlan) -> None:
+        config = self._rest.config
+        identity = self._profile.identity
+        policy = self._profile.policy
+        if plan.market_symbol != policy.market_symbol or plan.market_id != policy.market_id:
+            raise SdkAdapterError("canary plan market does not match the validated profile")
+        if config.chain_id != identity.chain_id:
+            raise SdkAdapterError("REST client chain does not match the validated profile")
+        if config.api_url.rstrip("/") != identity.api_url.rstrip("/"):
+            raise SdkAdapterError("REST client API URL does not match the validated profile")
+        if config.dex_id != identity.exchange_id:
+            raise SdkAdapterError("REST client exchange does not match the validated profile")
+        if (config.orders_gateway_address or "").lower() != identity.orders_gateway.lower():
+            raise SdkAdapterError("REST client Orders Gateway does not match the validated profile")
+        if self._rest.get_market_id_from_symbol(plan.market_symbol) != plan.market_id:
+            raise SdkAdapterError("REST client market ID does not match the canary plan")
+        if config.account_id != plan.account_id:
+            raise SdkAdapterError("REST client account does not match the canary plan")
+        if config.owner_wallet_address.lower() != plan.wallet_address.lower():
+            raise SdkAdapterError("REST client owner wallet does not match the canary plan")
+
+    @staticmethod
+    def _require_response(
+        response: CreateOrderResponse | ModifyOrderResponse | CancelOrderResponse,
+        *,
+        expected_status: OrderStatus,
+        operation: str,
+        expected_order_id: str | None = None,
+        expected_client_order_id: int | None = None,
+    ) -> None:
+        if response.status != expected_status:
+            raise SdkAdapterError(f"{operation} response was not {expected_status.value}")
+        if expected_order_id is not None and response.order_id != expected_order_id:
+            raise SdkAdapterError(f"{operation} response changed the canonical order ID")
+        if expected_client_order_id is not None and response.client_order_id != str(expected_client_order_id):
+            raise SdkAdapterError(f"{operation} response did not preserve the client order ID")
+
+    def _rest_order_matches(self, order: Order, expectation: OrderExpectation, plan: OrderPlan) -> bool:
+        client_order_id = self._client_order_ids.get(expectation.order_id)
+        return bool(
+            client_order_id is not None
+            and order.status == OrderStatus.OPEN
+            and order.account_id == plan.account_id
+            and order.symbol == plan.market_symbol
+            and order.side == (Side.B if plan.is_buy else Side.A)
+            and order.time_in_force == TimeInForce.GTC
+            and order.post_only is True
+            and order.reduce_only is False
+            and order.client_order_id == str(client_order_id)
+            and _decimal_equal(order.limit_px, expectation.limit_px)
+            and _decimal_equal(order.qty, expectation.quantity)
+        )
+
+    def _ws_order_matches(self, order: AsyncOrder, expectation: OrderExpectation, plan: OrderPlan) -> bool:
+        client_order_id = self._client_order_ids.get(expectation.order_id)
+        if (
+            client_order_id is None
+            or str(order.order_id) != expectation.order_id
+            or order.client_order_id != str(client_order_id)
+            or order.account_id != plan.account_id
+            or order.symbol != plan.market_symbol
+        ):
+            return False
+        if expectation.status == "CANCELLED":
+            return order.status == AsyncOrderStatus.CANCELLED and order.cancel_reason == AsyncCancelReason.USER_CANCEL
+        return bool(
+            order.status == AsyncOrderStatus.OPEN
+            and order.side == (AsyncSide.B if plan.is_buy else AsyncSide.A)
+            and order.time_in_force == AsyncTimeInForce.GTC
+            and order.post_only is True
+            and order.reduce_only is False
+            and order.client_order_id == str(client_order_id)
+            and _decimal_equal(order.limit_px, expectation.limit_px)
+            and _decimal_equal(order.qty, expectation.quantity)
+        )
+
+
+def _decimal_equal(actual: Any, expected: Decimal | None) -> bool:
+    if actual is None or expected is None:
+        return actual is None and expected is None
+    try:
+        return Decimal(str(actual)) == expected
+    except (InvalidOperation, ValueError):
+        return False

--- a/scripts/canary_sdk_adapter.py
+++ b/scripts/canary_sdk_adapter.py
@@ -10,6 +10,8 @@ import threading
 import time
 from decimal import Decimal, InvalidOperation
 
+from scripts.canary_lifecycle import OpenOrderUnverifiedError, OrderExpectation, OrderPlan
+from scripts.canary_preflight import CanaryProfile
 from sdk.async_api.cancel_reason import CancelReason as AsyncCancelReason
 from sdk.async_api.order import Order as AsyncOrder
 from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
@@ -25,8 +27,6 @@ from sdk.open_api.models.order_status import OrderStatus
 from sdk.open_api.models.side import Side
 from sdk.open_api.models.time_in_force import TimeInForce
 from sdk.reya_rest_api.models.orders import LimitOrderParameters, ModifyOrderParameters
-from scripts.canary_lifecycle import OpenOrderUnverifiedError, OrderExpectation, OrderPlan
-from scripts.canary_preflight import CanaryProfile
 
 
 class SdkAdapterError(RuntimeError):

--- a/scripts/run_canary.py
+++ b/scripts/run_canary.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
 import sys
 from argparse import ArgumentParser
 from collections.abc import Sequence
@@ -13,6 +15,8 @@ from scripts.canary_preflight import (
     build_evidence,
     default_evidence_path,
     load_profile,
+    resolve_rpc_url,
+    run_live_probes,
     validate_profile,
     write_evidence,
 )
@@ -23,18 +27,22 @@ def parse_args(argv: Sequence[str] | None = None):
     parser.add_argument(
         "--profile", required=True, type=Path, help="Explicit TOML profile; implicit .env loading is forbidden"
     )
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
         "--preflight-only",
         action="store_true",
         help="Validate configuration and write evidence without constructing a client or sending network requests",
     )
+    mode.add_argument(
+        "--probe-live-read-only",
+        action="store_true",
+        help="Run bounded REST/RPC/WebSocket identity probes without credentials or mutations",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0, help="Per-probe timeout in seconds")
     parser.add_argument(
         "--output", type=Path, help="Evidence JSON path (default: artifacts/canary/<run>/preflight.json)"
     )
-    args = parser.parse_args(argv)
-    if not args.preflight_only:
-        parser.error("only --preflight-only is implemented; no mutation path exists yet")
-    return args
+    return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -44,7 +52,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         profile = load_profile(profile_path)
         validate_profile(profile, mutating=False)
-        evidence = build_evidence(profile, profile_path, repo_root=repo_root)
+        if args.probe_live_read_only:
+            rpc_url = resolve_rpc_url(profile, os.environ)
+            probes = asyncio.run(run_live_probes(profile, rpc_url=rpc_url, timeout_s=args.timeout))
+            evidence_mode = "probe-live-read-only"
+        else:
+            probes = ()
+            evidence_mode = "preflight-only"
+        evidence = build_evidence(
+            profile,
+            profile_path,
+            repo_root=repo_root,
+            mode=evidence_mode,
+            probes=probes,
+        )
         output_path = (
             args.output.expanduser().resolve() if args.output else default_evidence_path(profile, repo_root=repo_root)
         )
@@ -54,8 +75,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     print(f"PASS: {profile.name} ({profile.environment}) configuration preflight")
+    for probe in probes:
+        print(f"PASS {probe.id}: {probe.detail}")
     print(f"Evidence: {output_path}")
-    print("No network requests or mutations were performed.")
+    if args.preflight_only:
+        print("No network requests or mutations were performed.")
+    else:
+        print("Only read-only target probes were performed; no credentials or mutations were used.")
     return 0
 
 

--- a/scripts/run_canary.py
+++ b/scripts/run_canary.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run the Perp OB migration canary preflight without mutating the target."""
+
+from __future__ import annotations
+
+import sys
+from argparse import ArgumentParser
+from collections.abc import Sequence
+from pathlib import Path
+
+from scripts.canary_preflight import (
+    PreflightError,
+    build_evidence,
+    default_evidence_path,
+    load_profile,
+    validate_profile,
+    write_evidence,
+)
+
+
+def parse_args(argv: Sequence[str] | None = None):
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile", required=True, type=Path, help="Explicit TOML profile; implicit .env loading is forbidden"
+    )
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Validate configuration and write evidence without constructing a client or sending network requests",
+    )
+    parser.add_argument(
+        "--output", type=Path, help="Evidence JSON path (default: artifacts/canary/<run>/preflight.json)"
+    )
+    args = parser.parse_args(argv)
+    if not args.preflight_only:
+        parser.error("only --preflight-only is implemented; no mutation path exists yet")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+    profile_path = args.profile.expanduser().resolve()
+    try:
+        profile = load_profile(profile_path)
+        validate_profile(profile, mutating=False)
+        evidence = build_evidence(profile, profile_path, repo_root=repo_root)
+        output_path = (
+            args.output.expanduser().resolve() if args.output else default_evidence_path(profile, repo_root=repo_root)
+        )
+        write_evidence(evidence, output_path)
+    except PreflightError as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: {profile.name} ({profile.environment}) configuration preflight")
+    print(f"Evidence: {output_path}")
+    print("No network requests or mutations were performed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_canary_lifecycle.py
+++ b/tests/validation/test_canary_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import asyncio
+import json
 from dataclasses import replace
 from decimal import Decimal
 
@@ -12,8 +13,10 @@ import pytest
 
 from scripts.canary_lifecycle import (
     LifecycleError,
+    OpenOrderUnverifiedError,
     OrderExpectation,
     OrderPlan,
+    build_lifecycle_evidence,
     derive_client_order_id,
     run_order_lifecycle,
 )
@@ -23,7 +26,6 @@ from scripts.canary_preflight import (
     CanaryPolicy,
     CanaryProfile,
 )
-
 
 pytestmark = pytest.mark.offline
 
@@ -38,11 +40,13 @@ class FakeLifecycleAdapter:
         fail_once: str | None = None,
         fail_always: str | None = None,
         hang_once: str | None = None,
+        unverified_open: bool = False,
     ) -> None:
         self.order_id = order_id
         self.fail_once = fail_once
         self.fail_always = fail_always
         self.hang_once = hang_once
+        self.unverified_open = unverified_open
         self.calls: list[str] = []
 
     async def _record(self, call: str) -> None:
@@ -59,6 +63,8 @@ class FakeLifecycleAdapter:
     async def place_post_only_gtc(self, plan: OrderPlan, client_order_id: int) -> str:
         del plan, client_order_id
         await self._record("place")
+        if self.unverified_open:
+            raise OpenOrderUnverifiedError(self.order_id, "synthetic invariant failure")
         return self.order_id
 
     async def modify_post_only_gtc(self, order_id: str, plan: OrderPlan, client_order_id: int) -> None:
@@ -187,7 +193,7 @@ async def test_plan_validation_fails_before_adapter_calls(
     with pytest.raises(LifecycleError, match=message):
         await run_order_lifecycle(profile, replace(plan, **override), adapter, run_id="run-invalid")
 
-    assert adapter.calls == []
+    assert not adapter.calls
 
 
 @pytest.mark.asyncio
@@ -197,7 +203,7 @@ async def test_invalid_timeout_fails_before_adapter_calls(profile: CanaryProfile
     with pytest.raises(LifecycleError, match="timeout must be finite"):
         await run_order_lifecycle(profile, plan, adapter, run_id="run-invalid-timeout", timeout_s=float("nan"))
 
-    assert adapter.calls == []
+    assert not adapter.calls
 
 
 @pytest.mark.asyncio
@@ -270,6 +276,26 @@ async def test_invalid_order_id_is_not_added_to_owned_cleanup_registry(
 
 
 @pytest.mark.asyncio
+async def test_unverified_open_response_is_registered_before_exact_cleanup(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    adapter = FakeLifecycleAdapter(unverified_open=True)
+
+    with pytest.raises(LifecycleError) as raised:
+        await run_order_lifecycle(profile, plan, adapter, run_id="run-unverified-open")
+
+    assert [event.step for event in raised.value.events] == ["place.unverified"]
+    assert raised.value.cleanup_failures == ()
+    assert adapter.calls == [
+        "place",
+        "cancel:123456789",
+        "rest:CANCELLED:none:123456789",
+        "ws:CANCELLED:none:123456789",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_mainnet_requires_the_exact_mutation_acknowledgement(
     profile: CanaryProfile,
     plan: OrderPlan,
@@ -279,7 +305,7 @@ async def test_mainnet_requires_the_exact_mutation_acknowledgement(
 
     with pytest.raises(LifecycleError, match="profile did not pass mutation validation"):
         await run_order_lifecycle(mainnet, plan, adapter, run_id="mainnet-without-ack")
-    assert adapter.calls == []
+    assert not adapter.calls
 
     await run_order_lifecycle(
         mainnet,
@@ -289,3 +315,56 @@ async def test_mainnet_requires_the_exact_mutation_acknowledgement(
         mutation_acknowledgement=MAINNET_MUTATION_ACKNOWLEDGEMENT,
     )
     assert adapter.calls[0] == "place"
+
+
+@pytest.mark.asyncio
+async def test_success_evidence_is_credential_free_and_preserves_bounded_intent(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    result = await run_order_lifecycle(profile, plan, FakeLifecycleAdapter(), run_id="evidence-success")
+
+    evidence = build_lifecycle_evidence(profile, plan, result=result)
+    encoded = json.dumps(evidence, sort_keys=True)
+
+    assert evidence["result"] == "pass"
+    assert evidence["run_id"] == "evidence-success"
+    assert evidence["order_plan"]["post_only"] is True
+    assert evidence["order_plan"]["quantity"] == "1"
+    assert evidence["owned_order_ids"] == ["123456789"]
+    assert "private_key" not in encoded.lower()
+    assert "signature" not in encoded.lower()
+    assert "rpc_url" not in encoded.lower()
+
+
+@pytest.mark.asyncio
+async def test_failure_evidence_records_sanitized_stage_and_cleanup_status(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    adapter = FakeLifecycleAdapter(
+        fail_once="modify:123456789",
+        fail_always="cancel:123456789",
+    )
+    with pytest.raises(LifecycleError) as raised:
+        await run_order_lifecycle(profile, plan, adapter, run_id="evidence-failure")
+
+    evidence = build_lifecycle_evidence(
+        profile,
+        plan,
+        error=raised.value,
+        run_id="evidence-failure",
+    )
+
+    assert evidence["result"] == "fail"
+    assert evidence["failure"] == {
+        "stage": "modify",
+        "detail": "RuntimeError",
+        "cleanup_failures": ["123456789[cancel:RuntimeError]"],
+    }
+    assert "synthetic failure" not in json.dumps(evidence)
+
+
+def test_evidence_requires_exactly_one_outcome(profile: CanaryProfile, plan: OrderPlan) -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        build_lifecycle_evidence(profile, plan)

--- a/tests/validation/test_canary_lifecycle.py
+++ b/tests/validation/test_canary_lifecycle.py
@@ -1,0 +1,291 @@
+"""Offline tests for the run-owned PRO-657 canary order lifecycle."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import asyncio
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+
+from scripts.canary_lifecycle import (
+    LifecycleError,
+    OrderExpectation,
+    OrderPlan,
+    derive_client_order_id,
+    run_order_lifecycle,
+)
+from scripts.canary_preflight import (
+    MAINNET_MUTATION_ACKNOWLEDGEMENT,
+    SUPPORTED_ENVIRONMENTS,
+    CanaryPolicy,
+    CanaryProfile,
+)
+
+
+pytestmark = pytest.mark.offline
+
+
+class FakeLifecycleAdapter:
+    """Records the exact surface calls without constructing an SDK client."""
+
+    def __init__(
+        self,
+        *,
+        order_id: str = "123456789",
+        fail_once: str | None = None,
+        fail_always: str | None = None,
+        hang_once: str | None = None,
+    ) -> None:
+        self.order_id = order_id
+        self.fail_once = fail_once
+        self.fail_always = fail_always
+        self.hang_once = hang_once
+        self.calls: list[str] = []
+
+    async def _record(self, call: str) -> None:
+        self.calls.append(call)
+        if self.hang_once == call:
+            self.hang_once = None
+            await asyncio.Event().wait()
+        if self.fail_once == call:
+            self.fail_once = None
+            raise RuntimeError("synthetic failure")
+        if self.fail_always == call:
+            raise RuntimeError("synthetic failure")
+
+    async def place_post_only_gtc(self, plan: OrderPlan, client_order_id: int) -> str:
+        del plan, client_order_id
+        await self._record("place")
+        return self.order_id
+
+    async def modify_post_only_gtc(self, order_id: str, plan: OrderPlan, client_order_id: int) -> None:
+        del plan, client_order_id
+        await self._record(f"modify:{order_id}")
+
+    async def cancel_order(self, order_id: str, plan: OrderPlan) -> None:
+        del plan
+        await self._record(f"cancel:{order_id}")
+
+    async def wait_rest(self, expectation: OrderExpectation, plan: OrderPlan, timeout_s: float) -> None:
+        del plan, timeout_s
+        await self._record(_observation_call("rest", expectation))
+
+    async def wait_ws(self, expectation: OrderExpectation, plan: OrderPlan, timeout_s: float) -> None:
+        del plan, timeout_s
+        await self._record(_observation_call("ws", expectation))
+
+
+def _observation_call(surface: str, expectation: OrderExpectation) -> str:
+    price = "none" if expectation.limit_px is None else str(expectation.limit_px)
+    return f"{surface}:{expectation.status}:{price}:{expectation.order_id}"
+
+
+@pytest.fixture(name="profile")
+def fixture_profile() -> CanaryProfile:
+    return CanaryProfile(
+        name="devnet1-pro-657",
+        enabled=True,
+        environment="devnet1",
+        identity=SUPPORTED_ENVIRONMENTS["devnet1"],
+        release_manifest_id="perp-ob-f989de0",
+        rpc_url_env="REYA_CANARY_RPC_URL",
+        policy=CanaryPolicy(
+            market_symbol="BTCRUSDPERP",
+            market_id=1,
+            max_quantity=Decimal("2"),
+            max_notional=Decimal("1000"),
+            allowed_account_ids=(42,),
+            allowed_wallet_addresses=("0x1111111111111111111111111111111111111111",),
+        ),
+    )
+
+
+@pytest.fixture(name="plan")
+def fixture_plan() -> OrderPlan:
+    return OrderPlan(
+        account_id=42,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        market_symbol="BTCRUSDPERP",
+        market_id=1,
+        is_buy=True,
+        quantity=Decimal("1"),
+        initial_limit_px=Decimal("100"),
+        modified_limit_px=Decimal("101"),
+    )
+
+
+def test_client_order_id_is_stable_nonzero_and_rejects_unsafe_run_ids() -> None:
+    first = derive_client_order_id("cutover-20260828T1100Z")
+    assert first == derive_client_order_id("cutover-20260828T1100Z")
+    assert 0 < first < 2**63
+    assert first != derive_client_order_id("cutover-20260828T1101Z")
+    with pytest.raises(LifecycleError, match="safe filename"):
+        derive_client_order_id("contains whitespace")
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_proves_initial_modified_and_cancelled_state_on_both_surfaces(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    adapter = FakeLifecycleAdapter()
+
+    result = await run_order_lifecycle(profile, plan, adapter, run_id="run-001")
+
+    assert result.owned_order_ids == ("123456789",)
+    assert result.client_order_id == derive_client_order_id("run-001")
+    assert [event.step for event in result.events] == [
+        "place.accepted",
+        "rest.open",
+        "ws.open",
+        "modify.accepted",
+        "rest.open",
+        "ws.open",
+        "cancel.accepted",
+        "rest.cancelled",
+        "ws.cancelled",
+    ]
+    assert adapter.calls == [
+        "place",
+        "rest:OPEN:100:123456789",
+        "ws:OPEN:100:123456789",
+        "modify:123456789",
+        "rest:OPEN:101:123456789",
+        "ws:OPEN:101:123456789",
+        "cancel:123456789",
+        "rest:CANCELLED:none:123456789",
+        "ws:CANCELLED:none:123456789",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"account_id": 99}, "account ID is not allowlisted"),
+        ({"wallet_address": "0x2222222222222222222222222222222222222222"}, "wallet address is not allowlisted"),
+        ({"market_symbol": "ETHRUSDPERP"}, "market symbol does not match"),
+        ({"market_id": 2}, "market ID does not match"),
+        ({"quantity": Decimal("3")}, "quantity exceeds"),
+        ({"quantity": Decimal("NaN")}, "quantity must be finite"),
+        ({"modified_limit_px": Decimal("1001")}, "modified order notional exceeds"),
+        ({"initial_limit_px": Decimal("Infinity")}, "limit prices must be finite"),
+        ({"modified_limit_px": Decimal("100")}, "must differ"),
+    ],
+)
+async def test_plan_validation_fails_before_adapter_calls(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+    override: dict[str, Any],
+    message: str,
+) -> None:
+    adapter = FakeLifecycleAdapter()
+
+    with pytest.raises(LifecycleError, match=message):
+        await run_order_lifecycle(profile, replace(plan, **override), adapter, run_id="run-invalid")
+
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_timeout_fails_before_adapter_calls(profile: CanaryProfile, plan: OrderPlan) -> None:
+    adapter = FakeLifecycleAdapter()
+
+    with pytest.raises(LifecycleError, match="timeout must be finite"):
+        await run_order_lifecycle(profile, plan, adapter, run_id="run-invalid-timeout", timeout_s=float("nan"))
+
+    assert adapter.calls == []
+
+
+@pytest.mark.asyncio
+async def test_visibility_failure_cleans_up_only_the_created_order(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    adapter = FakeLifecycleAdapter(fail_once="rest:OPEN:100:123456789")
+
+    with pytest.raises(LifecycleError) as raised:
+        await run_order_lifecycle(profile, plan, adapter, run_id="run-cleanup")
+
+    assert raised.value.stage == "rest-visibility"
+    assert raised.value.cleanup_failures == ()
+    assert adapter.calls == [
+        "place",
+        "rest:OPEN:100:123456789",
+        "cancel:123456789",
+        "rest:CANCELLED:none:123456789",
+        "ws:CANCELLED:none:123456789",
+    ]
+    assert not any("999999999" in call for call in adapter.calls)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_is_reported_without_raw_exception_text(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    adapter = FakeLifecycleAdapter(
+        fail_once="modify:123456789",
+        fail_always="cancel:123456789",
+    )
+
+    with pytest.raises(LifecycleError) as raised:
+        await run_order_lifecycle(profile, plan, adapter, run_id="run-cleanup-failure")
+
+    assert raised.value.stage == "modify"
+    assert raised.value.detail == "RuntimeError"
+    assert raised.value.cleanup_failures == ("123456789[cancel:RuntimeError]",)
+    assert "synthetic failure" not in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_visibility_timeout_is_bounded_and_still_cleans_up(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    adapter = FakeLifecycleAdapter(hang_once="ws:OPEN:100:123456789")
+
+    with pytest.raises(LifecycleError) as raised:
+        await run_order_lifecycle(profile, plan, adapter, run_id="run-timeout", timeout_s=0.01)
+
+    assert raised.value.stage == "ws-visibility"
+    assert raised.value.detail == "TimeoutError"
+    assert "cancel:123456789" in adapter.calls
+
+
+@pytest.mark.asyncio
+async def test_invalid_order_id_is_not_added_to_owned_cleanup_registry(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    adapter = FakeLifecycleAdapter(order_id="not-an-order-id")
+
+    with pytest.raises(LifecycleError, match="invalid canonical order ID"):
+        await run_order_lifecycle(profile, plan, adapter, run_id="run-bad-id")
+
+    assert adapter.calls == ["place"]
+
+
+@pytest.mark.asyncio
+async def test_mainnet_requires_the_exact_mutation_acknowledgement(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    mainnet = replace(profile, environment="mainnet", identity=SUPPORTED_ENVIRONMENTS["mainnet"])
+    adapter = FakeLifecycleAdapter()
+
+    with pytest.raises(LifecycleError, match="profile did not pass mutation validation"):
+        await run_order_lifecycle(mainnet, plan, adapter, run_id="mainnet-without-ack")
+    assert adapter.calls == []
+
+    await run_order_lifecycle(
+        mainnet,
+        plan,
+        adapter,
+        run_id="mainnet-with-ack",
+        mutation_acknowledgement=MAINNET_MUTATION_ACKNOWLEDGEMENT,
+    )
+    assert adapter.calls[0] == "place"

--- a/tests/validation/test_canary_preflight.py
+++ b/tests/validation/test_canary_preflight.py
@@ -16,8 +16,12 @@ from scripts.canary_preflight import (
     CanaryProfile,
     EnvironmentIdentity,
     PreflightError,
+    ProbeError,
+    ProbeResult,
     build_evidence,
     load_profile,
+    resolve_rpc_url,
+    run_live_probes,
     validate_profile,
     write_evidence,
 )
@@ -36,6 +40,7 @@ def _profile(environment: str = "devnet1") -> CanaryProfile:
         environment=environment,
         identity=SUPPORTED_ENVIRONMENTS[environment],
         release_manifest_id="candidate-2026-08-28.1",
+        rpc_url_env="REYA_CANARY_RPC_URL",
         policy=CanaryPolicy(
             market_symbol="ETHRUSDPERP",
             market_id=1,
@@ -54,6 +59,7 @@ name = "test-{environment}"
 enabled = true
 environment = "{environment}"
 release_manifest_id = "candidate-2026-08-28.1"
+rpc_url_env = "REYA_CANARY_RPC_URL"
 {extra}
 [identity]
 chain_id = {identity.chain_id}
@@ -147,6 +153,87 @@ def test_mainnet_mutation_requires_exact_acknowledgement() -> None:
     )
 
 
+def test_rpc_url_is_resolved_only_from_explicit_env_name() -> None:
+    profile = _profile()
+
+    with pytest.raises(ProbeError, match="REYA_CANARY_RPC_URL is required"):
+        resolve_rpc_url(profile, {})
+
+    assert resolve_rpc_url(profile, {"REYA_CANARY_RPC_URL": "https://rpc.example/token"}) == (
+        "https://rpc.example/token"
+    )
+
+
+class _FakeProbeTransport:
+    def __init__(self) -> None:
+        self.chain_result = hex(SUPPORTED_ENVIRONMENTS["devnet1"].chain_id)
+        self.code_result = "0x6001600055"
+        self.market_id = 1
+        self.websocket_urls: list[str] = []
+
+    async def get_json(self, _url: str, _timeout_s: float):
+        return [{"symbol": "ETHRUSDPERP", "marketId": self.market_id}]
+
+    async def post_json(self, _url: str, payload, _timeout_s: float):
+        if payload["method"] == "eth_chainId":
+            return {"jsonrpc": "2.0", "id": payload["id"], "result": self.chain_result}
+        return {"jsonrpc": "2.0", "id": payload["id"], "result": self.code_result}
+
+    async def websocket_handshake(self, url: str, _timeout_s: float) -> None:
+        self.websocket_urls.append(url)
+
+
+@pytest.mark.asyncio
+async def test_read_only_live_probes_cover_every_target_surface() -> None:
+    profile = _profile()
+    transport = _FakeProbeTransport()
+
+    results = await run_live_probes(
+        profile,
+        rpc_url="https://rpc.example/credential-not-recorded",
+        transport=transport,
+    )
+
+    assert [result.id for result in results] == [
+        "rest.marketIdentity",
+        "rpc.chainId",
+        "rpc.ordersGatewayCode",
+        "ws.readHandshake",
+        "ws.execHandshake",
+    ]
+    assert transport.websocket_urls == [profile.identity.read_ws_url, profile.identity.ws_exec_url]
+
+
+@pytest.mark.asyncio
+async def test_live_probe_rejects_wrong_chain_before_gateway_and_websockets() -> None:
+    profile = _profile()
+    transport = _FakeProbeTransport()
+    transport.chain_result = hex(profile.identity.chain_id + 1)
+
+    with pytest.raises(ProbeError, match="RPC chain ID mismatch"):
+        await run_live_probes(profile, rpc_url="https://rpc.example", transport=transport)
+
+    assert not transport.websocket_urls
+
+
+@pytest.mark.asyncio
+async def test_live_probe_rejects_missing_gateway_code() -> None:
+    transport = _FakeProbeTransport()
+    transport.code_result = "0x"
+
+    with pytest.raises(ProbeError, match="Orders Gateway has no deployed bytecode"):
+        await run_live_probes(_profile(), rpc_url="https://rpc.example", transport=transport)
+
+
+@pytest.mark.asyncio
+async def test_live_probe_rejects_wrong_market_id() -> None:
+    transport = _FakeProbeTransport()
+    transport.market_id = 999
+
+    with pytest.raises(ProbeError, match="REST market ID mismatch"):
+        await run_live_probes(_profile(), rpc_url="https://rpc.example", transport=transport)
+
+
 def test_profile_rejects_secret_fields(tmp_path: Path) -> None:
     profile_path = tmp_path / "unsafe.toml"
     profile_path.write_text(_profile_toml(extra='private_key = "do-not-store-this"\n'), encoding="utf-8")
@@ -180,14 +267,23 @@ def test_evidence_is_machine_readable_and_credential_free(tmp_path: Path) -> Non
     profile = load_profile(profile_path)
     output_path = tmp_path / "evidence" / "preflight.json"
 
-    evidence = build_evidence(profile, profile_path, repo_root=Path(__file__).resolve().parents[2])
+    probes = (ProbeResult("rpc.chainId", str(profile.identity.chain_id)),)
+    evidence = build_evidence(
+        profile,
+        profile_path,
+        repo_root=Path(__file__).resolve().parents[2],
+        mode="probe-live-read-only",
+        probes=probes,
+    )
     write_evidence(evidence, output_path)
 
     stored = json.loads(output_path.read_text(encoding="utf-8"))
     assert stored["result"] == "pass"
-    assert stored["mode"] == "preflight-only"
+    assert stored["mode"] == "probe-live-read-only"
     assert stored["profile"]["environment"] == "devnet1"
     assert stored["sdk_git_revision"]
+    assert stored["probes"] == [{"detail": str(profile.identity.chain_id), "id": "rpc.chainId"}]
+    assert "credential-not-recorded" not in output_path.read_text(encoding="utf-8")
     assert "private" not in output_path.read_text(encoding="utf-8").lower()
 
 

--- a/tests/validation/test_canary_preflight.py
+++ b/tests/validation/test_canary_preflight.py
@@ -1,0 +1,202 @@
+"""Offline tests for the PRO-657 canary configuration preflight."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from scripts.canary_preflight import (
+    MAINNET_MUTATION_ACKNOWLEDGEMENT,
+    SUPPORTED_ENVIRONMENTS,
+    CanaryPolicy,
+    CanaryProfile,
+    EnvironmentIdentity,
+    PreflightError,
+    build_evidence,
+    load_profile,
+    validate_profile,
+    write_evidence,
+)
+from scripts.run_canary import main
+
+pytestmark = pytest.mark.offline
+
+_WALLET_1 = "0x1111111111111111111111111111111111111111"
+_WALLET_2 = "0x2222222222222222222222222222222222222222"
+
+
+def _profile(environment: str = "devnet1") -> CanaryProfile:
+    return CanaryProfile(
+        name=f"test-{environment}",
+        enabled=True,
+        environment=environment,
+        identity=SUPPORTED_ENVIRONMENTS[environment],
+        release_manifest_id="candidate-2026-08-28.1",
+        policy=CanaryPolicy(
+            market_symbol="ETHRUSDPERP",
+            market_id=1,
+            max_quantity=Decimal("0.01"),
+            max_notional=Decimal("50"),
+            allowed_account_ids=(101, 102),
+            allowed_wallet_addresses=(_WALLET_1, _WALLET_2),
+        ),
+    )
+
+
+def _profile_toml(*, environment: str = "devnet1", extra: str = "") -> str:
+    identity = SUPPORTED_ENVIRONMENTS[environment]
+    return f"""\
+name = "test-{environment}"
+enabled = true
+environment = "{environment}"
+release_manifest_id = "candidate-2026-08-28.1"
+{extra}
+[identity]
+chain_id = {identity.chain_id}
+api_url = "{identity.api_url}"
+read_ws_url = "{identity.read_ws_url}"
+ws_exec_url = "{identity.ws_exec_url}"
+orders_gateway = "{identity.orders_gateway}"
+exchange_id = {identity.exchange_id}
+
+[canary]
+market_symbol = "ETHRUSDPERP"
+market_id = 1
+max_quantity = "0.01"
+max_notional = "50"
+allowed_account_ids = [101, 102]
+allowed_wallet_addresses = ["{_WALLET_1}", "{_WALLET_2}"]
+"""
+
+
+def test_valid_profile_loads_and_passes(tmp_path: Path) -> None:
+    profile_path = tmp_path / "devnet1.toml"
+    profile_path.write_text(_profile_toml(), encoding="utf-8")
+
+    profile = load_profile(profile_path)
+    validate_profile(profile)
+
+    assert profile.environment == "devnet1"
+    assert profile.policy.allowed_account_ids == (101, 102)
+
+
+def test_same_chain_wrong_hosts_and_gateway_fail_closed() -> None:
+    expected = SUPPORTED_ENVIRONMENTS["devnet1"]
+    profile = _profile()
+    wrong_identity = EnvironmentIdentity(
+        chain_id=expected.chain_id,
+        api_url="https://api-cronos.reya.xyz/v2",
+        read_ws_url="wss://websocket-testnet.reya.xyz/",
+        ws_exec_url="wss://ws-exec-testnet.reya.xyz",
+        orders_gateway="0x5a0ac2f89e0bdeafc5c549e354842210a3e87ca5",
+        exchange_id=expected.exchange_id,
+    )
+    wrong_profile = replace(profile, identity=wrong_identity)
+
+    with pytest.raises(PreflightError) as exc_info:
+        validate_profile(wrong_profile)
+
+    message = str(exc_info.value)
+    assert "api_url mismatch" in message
+    assert "read_ws_url mismatch" in message
+    assert "ws_exec_url mismatch" in message
+    assert "orders_gateway mismatch" in message
+
+
+def test_disabled_placeholder_profile_is_rejected() -> None:
+    profile = _profile()
+    incomplete_policy = CanaryPolicy(
+        market_symbol="REPLACE_WITH_DESIGNATED_MARKET",
+        market_id=0,
+        max_quantity=profile.policy.max_quantity * 0,
+        max_notional=profile.policy.max_notional * 0,
+        allowed_account_ids=(),
+        allowed_wallet_addresses=(),
+    )
+    incomplete = replace(
+        profile,
+        enabled=False,
+        release_manifest_id="REPLACE_WITH_PINNED_CANDIDATE_MANIFEST",
+        policy=incomplete_policy,
+    )
+
+    with pytest.raises(PreflightError) as exc_info:
+        validate_profile(incomplete)
+
+    message = str(exc_info.value)
+    assert "profile is disabled" in message
+    assert "release_manifest_id" in message
+    assert "market_id" in message
+    assert "allowed_account_ids" in message
+
+
+def test_mainnet_mutation_requires_exact_acknowledgement() -> None:
+    profile = _profile("mainnet")
+
+    with pytest.raises(PreflightError, match="mainnet mutation acknowledgement"):
+        validate_profile(profile, mutating=True)
+
+    validate_profile(
+        profile,
+        mutating=True,
+        mutation_acknowledgement=MAINNET_MUTATION_ACKNOWLEDGEMENT,
+    )
+
+
+def test_profile_rejects_secret_fields(tmp_path: Path) -> None:
+    profile_path = tmp_path / "unsafe.toml"
+    profile_path.write_text(_profile_toml(extra='private_key = "do-not-store-this"\n'), encoding="utf-8")
+
+    with pytest.raises(PreflightError, match="looks like a secret field"):
+        load_profile(profile_path)
+
+
+def test_profile_rejects_unknown_fields(tmp_path: Path) -> None:
+    profile_path = tmp_path / "typo.toml"
+    profile_path.write_text(_profile_toml().replace("api_url =", "api_urll ="), encoding="utf-8")
+
+    with pytest.raises(PreflightError, match="profile.identity contains unknown fields: api_urll"):
+        load_profile(profile_path)
+
+
+@pytest.mark.parametrize("value", ["NaN", "Infinity", "-Infinity"])
+def test_profile_rejects_non_finite_bounds(tmp_path: Path, value: str) -> None:
+    profile_path = tmp_path / "non-finite.toml"
+    profile_path.write_text(
+        _profile_toml().replace('max_quantity = "0.01"', f'max_quantity = "{value}"'), encoding="utf-8"
+    )
+
+    with pytest.raises(PreflightError, match="max_quantity must be finite"):
+        load_profile(profile_path)
+
+
+def test_evidence_is_machine_readable_and_credential_free(tmp_path: Path) -> None:
+    profile_path = tmp_path / "devnet1.toml"
+    profile_path.write_text(_profile_toml(), encoding="utf-8")
+    profile = load_profile(profile_path)
+    output_path = tmp_path / "evidence" / "preflight.json"
+
+    evidence = build_evidence(profile, profile_path, repo_root=Path(__file__).resolve().parents[2])
+    write_evidence(evidence, output_path)
+
+    stored = json.loads(output_path.read_text(encoding="utf-8"))
+    assert stored["result"] == "pass"
+    assert stored["mode"] == "preflight-only"
+    assert stored["profile"]["environment"] == "devnet1"
+    assert stored["sdk_git_revision"]
+    assert "private" not in output_path.read_text(encoding="utf-8").lower()
+
+
+def test_cli_preflight_writes_evidence(tmp_path: Path, capsys) -> None:
+    profile_path = tmp_path / "devnet1.toml"
+    profile_path.write_text(_profile_toml(), encoding="utf-8")
+    output_path = tmp_path / "preflight.json"
+
+    assert main(["--profile", str(profile_path), "--preflight-only", "--output", str(output_path)]) == 0
+
+    assert output_path.exists()
+    assert "No network requests or mutations were performed." in capsys.readouterr().out

--- a/tests/validation/test_canary_preflight.py
+++ b/tests/validation/test_canary_preflight.py
@@ -296,3 +296,13 @@ def test_cli_preflight_writes_evidence(tmp_path: Path, capsys) -> None:
 
     assert output_path.exists()
     assert "No network requests or mutations were performed." in capsys.readouterr().out
+
+
+def test_cli_exposes_no_lifecycle_or_mutation_mode(tmp_path: Path) -> None:
+    profile_path = tmp_path / "devnet1.toml"
+    profile_path.write_text(_profile_toml(), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as raised:
+        main(["--profile", str(profile_path), "--run-lifecycle"])
+
+    assert raised.value.code == 2

--- a/tests/validation/test_canary_recovery.py
+++ b/tests/validation/test_canary_recovery.py
@@ -1,0 +1,270 @@
+"""Offline tests for the operator-coordinated PRO-657 recovery boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+
+from scripts.canary_preflight import SUPPORTED_ENVIRONMENTS, CanaryPolicy, CanaryProfile
+from scripts.canary_recovery import (
+    MAINNET_RECOVERY_ACKNOWLEDGEMENT,
+    OperatorResume,
+    ProjectionSnapshot,
+    RecoveryError,
+    RecoveryObservation,
+    build_recovery_evidence,
+    run_recovery_checkpoint,
+)
+
+pytestmark = pytest.mark.offline
+
+
+@pytest.fixture(name="profile")
+def fixture_profile() -> CanaryProfile:
+    return CanaryProfile(
+        name="devnet1-pro-657",
+        enabled=True,
+        environment="devnet1",
+        identity=SUPPORTED_ENVIRONMENTS["devnet1"],
+        release_manifest_id="perp-ob-f989de0",
+        rpc_url_env="REYA_CANARY_RPC_URL",
+        policy=CanaryPolicy(
+            market_symbol="BTCRUSDPERP",
+            market_id=1,
+            max_quantity=Decimal("1"),
+            max_notional=Decimal("1000"),
+            allowed_account_ids=(42,),
+            allowed_wallet_addresses=("0x1111111111111111111111111111111111111111",),
+        ),
+    )
+
+
+@pytest.fixture(name="baseline")
+def fixture_baseline() -> ProjectionSnapshot:
+    return ProjectionSnapshot(
+        account_id=42,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        market_symbol="BTCRUSDPERP",
+        latest_sequence=100,
+        open_order_ids=("888",),
+        position_size=Decimal("2.5"),
+    )
+
+
+class FakeRecoveryAdapter:
+    def __init__(self, baseline: ProjectionSnapshot, recovered: ProjectionSnapshot | None = None) -> None:
+        self.baseline = baseline
+        self.observation = RecoveryObservation(
+            snapshot=recovered or replace(baseline, latest_sequence=102),
+            observed_sequences=(101, 102),
+        )
+        self.calls: list[object] = []
+
+    async def snapshot_projection(self, timeout_s: float) -> ProjectionSnapshot:
+        self.calls.append(("snapshot", timeout_s))
+        return self.baseline
+
+    async def reconnect_and_collect(self, after_sequence: int, timeout_s: float) -> RecoveryObservation:
+        self.calls.append(("reconnect", after_sequence, timeout_s))
+        return self.observation
+
+
+class FakeCheckpoint:
+    def __init__(self, *, evidence_ref: str = "linear:PRO-261#restart-1", hang: bool = False) -> None:
+        self.evidence_ref = evidence_ref
+        self.hang = hang
+        self.calls: list[object] = []
+
+    async def wait_for_resume(self, checkpoint_id: str, timeout_s: float) -> OperatorResume:
+        self.calls.append((checkpoint_id, timeout_s))
+        if self.hang:
+            await asyncio.Event().wait()
+        return OperatorResume(self.evidence_ref)
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_snapshots_then_waits_then_reconnects_and_proves_recovery(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+) -> None:
+    adapter = FakeRecoveryAdapter(baseline)
+    checkpoint = FakeCheckpoint()
+
+    result = await run_recovery_checkpoint(
+        profile,
+        adapter,
+        checkpoint,
+        run_id="recovery-1",
+        timeout_s=1,
+    )
+
+    assert result.observed_sequences == (101, 102)
+    assert result.baseline.open_order_ids == result.recovered.open_order_ids
+    assert result.baseline.position_size == result.recovered.position_size
+    assert adapter.calls == [("snapshot", 1), ("reconnect", 100, 1)]
+    assert checkpoint.calls == [("PRO-657:devnet1:recovery-1:restart-recovery", 1)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("sequences", "latest", "message"),
+    [
+        ((), 100, "no post-reconnect"),
+        ((101, 103), 103, "not contiguous and unique"),
+        ((101, 101), 101, "not contiguous and unique"),
+        ((101,), 102, "does not match"),
+    ],
+)
+async def test_checkpoint_rejects_missing_gapped_duplicate_or_inconsistent_sequences(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+    sequences: tuple[int, ...],
+    latest: int,
+    message: str,
+) -> None:
+    adapter = FakeRecoveryAdapter(baseline)
+    adapter.observation = RecoveryObservation(replace(baseline, latest_sequence=latest), sequences)
+
+    with pytest.raises(RecoveryError, match=message):
+        await run_recovery_checkpoint(profile, adapter, FakeCheckpoint(), run_id="bad-sequence", timeout_s=1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("transform", "message"),
+    [
+        (lambda snapshot: replace(snapshot, open_order_ids=("888", "999")), "open-order projection"),
+        (lambda snapshot: replace(snapshot, position_size=Decimal("2.6")), "position delta"),
+        (lambda snapshot: replace(snapshot, account_id=43), "account is not allowlisted"),
+        (lambda snapshot: replace(snapshot, market_symbol="ETHRUSDPERP"), "market does not match"),
+    ],
+)
+async def test_checkpoint_rejects_projection_or_cleanup_drift(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+    transform: Callable[[ProjectionSnapshot], ProjectionSnapshot],
+    message: str,
+) -> None:
+    adapter = FakeRecoveryAdapter(baseline, replace(transform(baseline), latest_sequence=101))
+    adapter.observation = replace(adapter.observation, observed_sequences=(101,))
+
+    with pytest.raises(RecoveryError, match=message):
+        await run_recovery_checkpoint(profile, adapter, FakeCheckpoint(), run_id="projection-drift", timeout_s=1)
+
+
+@pytest.mark.asyncio
+async def test_mainnet_checkpoint_requires_separate_ack_before_adapter_io(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+) -> None:
+    mainnet = replace(profile, environment="mainnet", identity=SUPPORTED_ENVIRONMENTS["mainnet"])
+    adapter = FakeRecoveryAdapter(baseline)
+    checkpoint = FakeCheckpoint()
+
+    with pytest.raises(RecoveryError, match="acknowledgement is required"):
+        await run_recovery_checkpoint(mainnet, adapter, checkpoint, run_id="mainnet-recovery", timeout_s=1)
+
+    assert not adapter.calls
+    assert not checkpoint.calls
+    await run_recovery_checkpoint(
+        mainnet,
+        adapter,
+        checkpoint,
+        run_id="mainnet-recovery",
+        timeout_s=1,
+        mainnet_acknowledgement=MAINNET_RECOVERY_ACKNOWLEDGEMENT,
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_run_id_fails_before_adapter_io(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+) -> None:
+    adapter = FakeRecoveryAdapter(baseline)
+
+    with pytest.raises(RecoveryError, match="run_id must be"):
+        await run_recovery_checkpoint(profile, adapter, FakeCheckpoint(), run_id="unsafe run", timeout_s=1)
+
+    assert not adapter.calls
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_timeout_is_bounded_and_sanitized(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+) -> None:
+    with pytest.raises(RecoveryError) as raised:
+        await run_recovery_checkpoint(
+            profile,
+            FakeRecoveryAdapter(baseline),
+            FakeCheckpoint(hang=True),
+            run_id="checkpoint-timeout",
+            timeout_s=0.001,
+        )
+
+    assert raised.value.stage == "checkpoint"
+    assert raised.value.detail == "TimeoutError"
+
+
+@pytest.mark.asyncio
+async def test_operator_evidence_reference_must_be_bounded_and_credential_free(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+) -> None:
+    with pytest.raises(RecoveryError, match="missing or unsafe"):
+        await run_recovery_checkpoint(
+            profile,
+            FakeRecoveryAdapter(baseline),
+            FakeCheckpoint(evidence_ref="https://user:secret@example.invalid/evidence?token=secret"),
+            run_id="unsafe-ref",
+            timeout_s=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_recovery_evidence_records_only_validated_results(
+    profile: CanaryProfile,
+    baseline: ProjectionSnapshot,
+) -> None:
+    result = await run_recovery_checkpoint(
+        profile,
+        FakeRecoveryAdapter(baseline),
+        FakeCheckpoint(),
+        run_id="evidence-recovery",
+        timeout_s=1,
+    )
+
+    evidence = build_recovery_evidence(profile, result=result)
+    encoded = json.dumps(evidence, sort_keys=True)
+
+    assert evidence["result"] == "pass"
+    assert evidence["assertions"] == {
+        "projection_converged": True,
+        "sequence_contiguous": True,
+        "no_duplicate_sequence": True,
+        "no_resting_order_delta": True,
+        "no_position_delta": True,
+    }
+    assert evidence["baseline"]["position_size"] == "2.5"
+    assert "private" not in encoded.lower()
+    assert "secret" not in encoded.lower()
+
+
+def test_failure_evidence_is_sanitized(profile: CanaryProfile) -> None:
+    error = RecoveryError("reconnect", "TimeoutError")
+
+    evidence = build_recovery_evidence(profile, error=error, run_id="failed-recovery")
+
+    assert evidence["failure"] == {"stage": "reconnect", "detail": "TimeoutError"}
+    assert "checkpoint" not in evidence
+
+
+def test_failure_evidence_rejects_unsafe_run_id(profile: CanaryProfile) -> None:
+    with pytest.raises(ValueError, match="run_id must be"):
+        build_recovery_evidence(profile, error=RecoveryError("plan", "invalid"), run_id="unsafe run")

--- a/tests/validation/test_canary_sdk_adapter.py
+++ b/tests/validation/test_canary_sdk_adapter.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-from decimal import Decimal
 from types import SimpleNamespace
+
+from decimal import Decimal
 
 import pytest
 
+from scripts.canary_lifecycle import OpenOrderUnverifiedError, OrderExpectation, OrderPlan
+from scripts.canary_preflight import SUPPORTED_ENVIRONMENTS, CanaryPolicy, CanaryProfile
+from scripts.canary_sdk_adapter import SdkAdapterError, SdkLifecycleAdapter, ThreadSafeWsOrderStore
 from sdk.async_api.order import Order as AsyncOrder
 from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
 from sdk.async_api.order_changes_subscribed_payload import OrderChangesSubscribedPayload
@@ -17,10 +21,6 @@ from sdk.open_api.models.order import Order
 from sdk.open_api.models.order_status import OrderStatus
 from sdk.open_api.models.time_in_force import TimeInForce
 from sdk.reya_rest_api.models.orders import LimitOrderParameters, ModifyOrderParameters
-from scripts.canary_lifecycle import OpenOrderUnverifiedError, OrderExpectation, OrderPlan
-from scripts.canary_preflight import SUPPORTED_ENVIRONMENTS, CanaryPolicy, CanaryProfile
-from scripts.canary_sdk_adapter import SdkAdapterError, SdkLifecycleAdapter, ThreadSafeWsOrderStore
-
 
 pytestmark = pytest.mark.offline
 

--- a/tests/validation/test_canary_sdk_adapter.py
+++ b/tests/validation/test_canary_sdk_adapter.py
@@ -1,0 +1,407 @@
+"""Offline contract tests for the injected PRO-657 Reya SDK adapter."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from sdk.async_api.order import Order as AsyncOrder
+from sdk.async_api.order_change_update_payload import OrderChangeUpdatePayload
+from sdk.async_api.order_changes_subscribed_payload import OrderChangesSubscribedPayload
+from sdk.open_api.models.cancel_order_response import CancelOrderResponse
+from sdk.open_api.models.create_order_response import CreateOrderResponse
+from sdk.open_api.models.modify_order_response import ModifyOrderResponse
+from sdk.open_api.models.order import Order
+from sdk.open_api.models.order_status import OrderStatus
+from sdk.open_api.models.time_in_force import TimeInForce
+from sdk.reya_rest_api.models.orders import LimitOrderParameters, ModifyOrderParameters
+from scripts.canary_lifecycle import OpenOrderUnverifiedError, OrderExpectation, OrderPlan
+from scripts.canary_preflight import SUPPORTED_ENVIRONMENTS, CanaryPolicy, CanaryProfile
+from scripts.canary_sdk_adapter import SdkAdapterError, SdkLifecycleAdapter, ThreadSafeWsOrderStore
+
+
+pytestmark = pytest.mark.offline
+
+
+class FakeRestClient:
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(
+            account_id=42,
+            api_url=SUPPORTED_ENVIRONMENTS["devnet1"].api_url,
+            chain_id=SUPPORTED_ENVIRONMENTS["devnet1"].chain_id,
+            dex_id=SUPPORTED_ENVIRONMENTS["devnet1"].exchange_id,
+            owner_wallet_address="0x1111111111111111111111111111111111111111",
+            orders_gateway_address=SUPPORTED_ENVIRONMENTS["devnet1"].orders_gateway,
+        )
+        self.market_ids = {"BTCRUSDPERP": 1}
+        self.create_response = CreateOrderResponse(status=OrderStatus.OPEN, orderId="123", clientOrderId="777")
+        self.modify_response = ModifyOrderResponse(status=OrderStatus.OPEN, orderId="123", clientOrderId="777")
+        self.cancel_response = CancelOrderResponse(
+            status=OrderStatus.CANCELLED,
+            orderId="123",
+            clientOrderId="777",
+        )
+        self.open_orders: list[Order] = []
+        self.created: list[LimitOrderParameters] = []
+        self.modified: list[ModifyOrderParameters] = []
+        self.cancelled: list[dict[str, object]] = []
+
+    async def create_limit_order(self, params: LimitOrderParameters) -> CreateOrderResponse:
+        self.created.append(params)
+        return self.create_response
+
+    async def modify_order(self, params: ModifyOrderParameters) -> ModifyOrderResponse:
+        self.modified.append(params)
+        return self.modify_response
+
+    async def cancel_order(
+        self,
+        symbol: str,
+        account_id: int | None = None,
+        order_id: str | None = None,
+        client_order_id: int | None = None,
+    ) -> CancelOrderResponse:
+        self.cancelled.append(
+            {
+                "symbol": symbol,
+                "account_id": account_id,
+                "order_id": order_id,
+                "client_order_id": client_order_id,
+            }
+        )
+        return self.cancel_response
+
+    async def get_open_orders(self) -> list[Order]:
+        return self.open_orders
+
+    def get_market_id_from_symbol(self, symbol: str) -> int:
+        return self.market_ids[symbol]
+
+
+class FakeWsOrders:
+    def __init__(self) -> None:
+        self.orders: dict[str, AsyncOrder] = {}
+
+    def get(self, order_id: str) -> AsyncOrder | None:
+        return self.orders.get(order_id)
+
+
+@pytest.fixture(name="plan")
+def fixture_plan() -> OrderPlan:
+    return OrderPlan(
+        account_id=42,
+        wallet_address="0x1111111111111111111111111111111111111111",
+        market_symbol="BTCRUSDPERP",
+        market_id=1,
+        is_buy=True,
+        quantity=Decimal("0.0100"),
+        initial_limit_px=Decimal("100.50"),
+        modified_limit_px=Decimal("101.25"),
+    )
+
+
+@pytest.fixture(name="profile")
+def fixture_profile() -> CanaryProfile:
+    return CanaryProfile(
+        name="devnet1-pro-657",
+        enabled=True,
+        environment="devnet1",
+        identity=SUPPORTED_ENVIRONMENTS["devnet1"],
+        release_manifest_id="perp-ob-f989de0",
+        rpc_url_env="REYA_CANARY_RPC_URL",
+        policy=CanaryPolicy(
+            market_symbol="BTCRUSDPERP",
+            market_id=1,
+            max_quantity=Decimal("1"),
+            max_notional=Decimal("1000"),
+            allowed_account_ids=(42,),
+            allowed_wallet_addresses=("0x1111111111111111111111111111111111111111",),
+        ),
+    )
+
+
+def _rest_order(
+    *,
+    status: str = "OPEN",
+    limit_px: str = "100.5",
+    post_only: bool = True,
+) -> Order:
+    return Order.model_validate(
+        {
+            "exchangeId": 1,
+            "symbol": "BTCRUSDPERP",
+            "accountId": 42,
+            "orderId": "123",
+            "clientOrderId": "777",
+            "qty": "0.01",
+            "execQty": "0",
+            "cumQty": "0",
+            "side": "B",
+            "limitPx": limit_px,
+            "orderType": "LIMIT",
+            "timeInForce": "GTC",
+            "reduceOnly": False,
+            "postOnly": post_only,
+            "status": status,
+            "createdAt": 1,
+            "lastUpdateAt": 1,
+        }
+    )
+
+
+def _ws_order(
+    *,
+    status: str = "OPEN",
+    limit_px: str = "100.5",
+    sequence_number: int | None = 10,
+    cancel_reason: str | None = None,
+) -> AsyncOrder:
+    payload: dict[str, object] = {
+        "exchangeId": 1,
+        "symbol": "BTCRUSDPERP",
+        "accountId": 42,
+        "orderId": "123",
+        "sequenceNumber": sequence_number,
+        "clientOrderId": "777",
+        "qty": "0.01",
+        "execQty": "0",
+        "cumQty": "0",
+        "side": "B",
+        "limitPx": limit_px,
+        "orderType": "LIMIT",
+        "timeInForce": "GTC",
+        "reduceOnly": False,
+        "postOnly": True,
+        "status": status,
+        "createdAt": 1,
+        "lastUpdateAt": sequence_number or 1,
+    }
+    if cancel_reason is not None:
+        payload["cancelReason"] = cancel_reason
+        payload["cancelReasonMessage"] = "test-only"
+    return AsyncOrder.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_adapter_maps_exact_post_only_gtc_create_modify_and_single_cancel(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    rest = FakeRestClient()
+    adapter = SdkLifecycleAdapter(rest, FakeWsOrders(), profile)
+
+    order_id = await adapter.place_post_only_gtc(plan, 777)
+    await adapter.modify_post_only_gtc(order_id, plan, 777)
+    await adapter.cancel_order(order_id, plan)
+
+    assert rest.created == [
+        LimitOrderParameters(
+            symbol="BTCRUSDPERP",
+            is_buy=True,
+            limit_px="100.50",
+            qty="0.0100",
+            time_in_force=TimeInForce.GTC,
+            reduce_only=False,
+            post_only=True,
+            client_order_id=777,
+        )
+    ]
+    assert rest.created[0].time_in_force.value == "GTC"
+    assert rest.modified[0].order_id == 123
+    assert rest.modified[0].limit_px == "101.25"
+    assert rest.modified[0].qty == "0.0100"
+    assert rest.modified[0].post_only is True
+    assert rest.modified[0].reduce_only is False
+    assert rest.modified[0].client_order_id == 777
+    assert rest.cancelled == [
+        {
+            "symbol": "BTCRUSDPERP",
+            "account_id": 42,
+            "order_id": "123",
+            "client_order_id": 777,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_place_rejects_non_resting_response(profile: CanaryProfile, plan: OrderPlan) -> None:
+    rest = FakeRestClient()
+    rest.create_response = CreateOrderResponse(
+        status=OrderStatus.CANCELLED,
+        orderId="123",
+        clientOrderId="777",
+    )
+    adapter = SdkLifecycleAdapter(rest, FakeWsOrders(), profile)
+
+    with pytest.raises(SdkAdapterError):
+        await adapter.place_post_only_gtc(plan, 777)
+
+    assert not rest.cancelled
+
+
+@pytest.mark.asyncio
+async def test_open_response_with_wrong_client_id_exposes_canonical_id_for_cleanup(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    rest = FakeRestClient()
+    rest.create_response = CreateOrderResponse(status=OrderStatus.OPEN, orderId="123", clientOrderId="778")
+    adapter = SdkLifecycleAdapter(rest, FakeWsOrders(), profile)
+
+    with pytest.raises(OpenOrderUnverifiedError) as raised:
+        await adapter.place_post_only_gtc(plan, 777)
+
+    assert raised.value.order_id == "123"
+
+
+@pytest.mark.asyncio
+async def test_adapter_refuses_modify_and_cancel_for_unowned_order(profile: CanaryProfile, plan: OrderPlan) -> None:
+    rest = FakeRestClient()
+    adapter = SdkLifecycleAdapter(rest, FakeWsOrders(), profile)
+
+    with pytest.raises(SdkAdapterError, match="ownership"):
+        await adapter.modify_post_only_gtc("999", plan, 777)
+    with pytest.raises(SdkAdapterError, match="not owned"):
+        await adapter.cancel_order("999", plan)
+
+    assert not rest.modified
+    assert not rest.cancelled
+
+
+@pytest.mark.asyncio
+async def test_rest_observation_requires_all_exact_order_fields(profile: CanaryProfile, plan: OrderPlan) -> None:
+    rest = FakeRestClient()
+    adapter = SdkLifecycleAdapter(rest, FakeWsOrders(), profile, poll_interval_s=0.001)
+    await adapter.place_post_only_gtc(plan, 777)
+    rest.open_orders = [_rest_order()]
+
+    await adapter.wait_rest(OrderExpectation("123", "OPEN", Decimal("100.50"), Decimal("0.0100")), plan, 0.02)
+    rest.open_orders = []
+    await adapter.wait_rest(OrderExpectation("123", "CANCELLED"), plan, 0.02)
+
+    rest.open_orders = [_rest_order(post_only=False)]
+    with pytest.raises(SdkAdapterError, match="REST did not prove OPEN"):
+        await adapter.wait_rest(OrderExpectation("123", "OPEN", Decimal("100.50"), Decimal("0.0100")), plan, 0.01)
+
+    with pytest.raises(SdkAdapterError, match="not owned"):
+        await adapter.wait_rest(OrderExpectation("999", "CANCELLED"), plan, 0.01)
+
+
+@pytest.mark.asyncio
+async def test_ws_observation_requires_user_cancel_and_ignores_feed_reset(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    rest = FakeRestClient()
+    ws_orders = FakeWsOrders()
+    adapter = SdkLifecycleAdapter(rest, ws_orders, profile, poll_interval_s=0.001)
+    await adapter.place_post_only_gtc(plan, 777)
+    ws_orders.orders["123"] = _ws_order()
+
+    await adapter.wait_ws(OrderExpectation("123", "OPEN", Decimal("100.50"), Decimal("0.0100")), plan, 0.02)
+
+    ws_orders.orders["123"] = _ws_order(status="CANCELLED", cancel_reason="FEED_RESET")
+    with pytest.raises(SdkAdapterError, match="did not prove CANCELLED"):
+        await adapter.wait_ws(OrderExpectation("123", "CANCELLED"), plan, 0.01)
+
+    ws_orders.orders["123"] = _ws_order(status="CANCELLED", cancel_reason="USER_CANCEL", sequence_number=11)
+    await adapter.wait_ws(OrderExpectation("123", "CANCELLED"), plan, 0.02)
+
+
+def test_thread_safe_ws_store_ignores_unrelated_and_stale_order_messages() -> None:
+    store = ThreadSafeWsOrderStore("0x1")
+    store.ingest(object())
+    store.ingest(
+        OrderChangeUpdatePayload.model_validate(
+            {
+                "type": "channel_data",
+                "timestamp": 0,
+                "channel": "/v2/wallet/0x2/orderChanges",
+                "data": [_ws_order(limit_px="500", sequence_number=99)],
+            }
+        )
+    )
+    store.ingest(
+        OrderChangesSubscribedPayload.model_validate(
+            {
+                "type": "subscribed",
+                "channel": "/v2/wallet/0x1/orderChanges",
+                "contents": {"data": [_ws_order(sequence_number=None)], "snapshotSequenceNumber": 9},
+            }
+        )
+    )
+    store.on_message(
+        object(),
+        OrderChangeUpdatePayload.model_validate(
+            {
+                "type": "channel_data",
+                "timestamp": 1,
+                "channel": "/v2/wallet/0x1/orderChanges",
+                "data": [_ws_order(limit_px="101.25", sequence_number=11)],
+            }
+        ),
+    )
+    store.ingest(
+        OrderChangeUpdatePayload.model_validate(
+            {
+                "type": "channel_data",
+                "timestamp": 2,
+                "channel": "/v2/wallet/0x1/orderChanges",
+                "data": [_ws_order(limit_px="99", sequence_number=10)],
+            }
+        )
+    )
+
+    assert store.get("123") is not None
+    assert store.get("123").limit_px == "101.25"  # type: ignore[union-attr]
+
+
+def test_adapter_rejects_invalid_poll_interval(profile: CanaryProfile) -> None:
+    with pytest.raises(ValueError, match="finite"):
+        SdkLifecycleAdapter(FakeRestClient(), FakeWsOrders(), profile, poll_interval_s=float("nan"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_field", "value", "message"),
+    [
+        ("account_id", 99, "account does not match"),
+        ("chain_id", 99, "chain does not match"),
+        ("api_url", "https://wrong.invalid/v2", "API URL does not match"),
+        ("dex_id", 99, "exchange does not match"),
+        ("orders_gateway_address", "0x2222222222222222222222222222222222222222", "Orders Gateway does not match"),
+        ("owner_wallet_address", "0x2222222222222222222222222222222222222222", "owner wallet does not match"),
+    ],
+)
+async def test_adapter_rejects_mismatched_rest_client_identity_before_order_entry(
+    plan: OrderPlan,
+    profile: CanaryProfile,
+    config_field: str,
+    value: object,
+    message: str,
+) -> None:
+    rest = FakeRestClient()
+    setattr(rest.config, config_field, value)
+    adapter = SdkLifecycleAdapter(rest, FakeWsOrders(), profile)
+
+    with pytest.raises(SdkAdapterError, match=message):
+        await adapter.place_post_only_gtc(plan, 777)
+
+    assert not rest.created
+
+
+@pytest.mark.asyncio
+async def test_adapter_rejects_loaded_market_id_mismatch_before_order_entry(
+    profile: CanaryProfile,
+    plan: OrderPlan,
+) -> None:
+    rest = FakeRestClient()
+    rest.market_ids[plan.market_symbol] = 99
+    adapter = SdkLifecycleAdapter(rest, FakeWsOrders(), profile)
+
+    with pytest.raises(SdkAdapterError, match="market ID does not match"):
+        await adapter.place_post_only_gtc(plan, 777)
+
+    assert not rest.created


### PR DESCRIPTION
## Summary

- add fail-closed devnet1 and mainnet canary profiles pinned to exact environment identity and release evidence
- add credential-free REST, RPC, read-WS, and ws-exec target probes
- add a bounded run-owned place, REST/WS observe, modify, and exact cancel lifecycle
- add an injected Reya SDK adapter with strict account, wallet, market, client-order, and response checks
- add an operator-only restart checkpoint contract that snapshots state, pauses, reconnects, and proves sequence/projection recovery
- document ticket acceptance coverage and the remaining live/external evidence work

Linear: https://linear.app/reya-labs/issue/PRO-657/perp-ob-migration-add-environment-pinned-python-sdk-canary-profiles

## Safety boundary

The checked-in CLI remains preflight/read-only. It cannot construct a credentialed trading client, submit an order, restart a service, or query production databases. Mainnet lifecycle and recovery paths require separate exact acknowledgements. Cleanup is limited to canonical order IDs owned by the current run; no account-wide cancellation or position flattening is used.

## Validation

- `poetry run pytest -q -rxXs -m offline`: 324 passed, 373 deselected
- `make lint`: passed, including Bandit, pylint 10/10, workflow validation, and mypy across 310 source files

The only test warning is the existing `websockets.legacy` deprecation.

## Remaining before cutover use

- wire reviewed machine-local clients only after the release, market, quantity/notional, account, and wallet inputs are approved
- add the controlled maker/taker match with exact run-owned position restoration
- add tx/receipt, event/fill, DB, REST/WS, fee, freshness, legacy-schema rejection, and bust evidence
- run devnet against the pinned candidate before any mainnet execution

`canary/ACCEPTANCE.md` is the branch-local coverage map and deliberately prevents this foundation from being represented as completed cutover evidence.