### PR TITLE
fix(tests): arrange perp mid-price liquidity and await settlement

### DIFF
--- a/tests/engine/test_self_match_prevention.py
+++ b/tests/engine/test_self_match_prevention.py
@@ -26,6 +26,7 @@ from sdk.reya_rest_api.models import LimitOrderParameters
 from tests.helpers import ReyaTester
 from tests.helpers.market_config import PerpTestConfig, SpotTestConfig
 from tests.helpers.reya_tester import logger
+from tests.helpers.settlement import SettlementProbe
 
 
 async def _skip_if_external_liquidity(market_config: SpotTestConfig | PerpTestConfig, tester: ReyaTester) -> None:
@@ -149,16 +150,19 @@ async def test_self_match_ioc_taker_buy_cancelled(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("settlement_cleanup_guard")
 async def test_cross_account_match_fills_normally(
     market_config: SpotTestConfig | PerpTestConfig,
     market_type: str,
     maker: ReyaTester,
     taker: ReyaTester,
+    settlement_probe: SettlementProbe,
 ) -> None:
     """Sanity: when maker and taker are different accounts, the match goes through."""
     await _skip_if_external_liquidity(market_config, maker)
     await maker.orders.close_all(fail_if_none=False)
     await taker.orders.close_all(fail_if_none=False)
+    await settlement_probe.capture_baseline()
 
     cross_price = str(market_config.price(0.99))
 
@@ -191,3 +195,8 @@ async def test_cross_account_match_fills_normally(
         open_orders = await maker.client.get_open_orders()
         open_ids = {o.order_id for o in open_orders if o.symbol == market_config.symbol}
         assert maker_order_id not in open_ids, f"[{market_type}] cross-account match should consume the maker"
+
+    # FILLED is a matching-engine acknowledgement, not settlement. Wait for
+    # both accounts' exact deltas before fixture cleanup reads their positions;
+    # otherwise a late settlement can leak into the next test's baseline.
+    await settlement_probe.assert_settled(qty=market_config.min_qty, price=cross_price)

--- a/tests/perp/test_market_data.py
+++ b/tests/perp/test_market_data.py
@@ -7,12 +7,17 @@ Field changes vs the AMM era:
   ``throttledPoolPrice`` → ``throttledMidPrice``.
 """
 
+import asyncio
 import re
 import time
+from decimal import ROUND_CEILING, ROUND_FLOOR, Decimal
 
 import pytest
 
 from sdk.open_api.exceptions import ServiceException
+from sdk.open_api.models.order_status import OrderStatus
+from sdk.open_api.models.time_in_force import TimeInForce
+from sdk.reya_rest_api.models import LimitOrderParameters
 from tests.helpers import ReyaTester
 from tests.helpers.reya_tester import logger
 
@@ -50,18 +55,60 @@ async def test_market_definitions(reya_tester: ReyaTester):
 
 
 @pytest.mark.asyncio
-async def test_market_mark_and_mid_price(reya_tester: ReyaTester):
+async def test_market_mark_and_mid_price(perp_maker_tester: ReyaTester, perp_taker_tester: ReyaTester):
+    """A mid-price requires a two-sided book; an empty book legitimately omits it."""
+    reya_tester = perp_maker_tester
     symbol = "ETHRUSDPERP"
     mark_price = await reya_tester.client.get_market_mark_price(symbol)
     assert 0 < float(mark_price) < 10**18
 
-    mid_price = await reya_tester.client.get_market_mid_price(symbol)
-    assert 0 < float(mid_price) < 10**18
+    definition = await reya_tester.get_market_definition(symbol)
+    tick = Decimal(definition.tick_size)
+    mark = Decimal(str(mark_price))
+    bid = (mark * Decimal("0.99") / tick).to_integral_value(rounding=ROUND_FLOOR) * tick
+    ask = (mark * Decimal("1.01") / tick).to_integral_value(rounding=ROUND_CEILING) * tick
+    assert 0 < bid < ask
+    expected_mid = (bid + ask) / 2
+    depth = await reya_tester.data.market_depth(symbol)
+    assert depth is not None and not depth.bids and not depth.asks, "Mid-price test requires a controlled empty book"
 
-    market_summary = await reya_tester.client.markets.get_perp_market_summary(symbol)
-    current_time = int(time.time() * 1000)
-    assert market_summary.prices_updated_at is not None
-    assert market_summary.prices_updated_at > current_time - 60_000
+    orders = []
+    try:
+        for tester, is_buy, price in ((reya_tester, True, bid), (perp_taker_tester, False, ask)):
+            order_id = await tester.orders.create_limit(
+                LimitOrderParameters(
+                    symbol=symbol,
+                    is_buy=is_buy,
+                    limit_px=str(price),
+                    qty=definition.min_order_qty,
+                    time_in_force=TimeInForce.GTC,
+                    post_only=True,
+                )
+            )
+            assert order_id is not None
+            orders.append((tester, order_id))
+            await tester.wait.for_order_creation(order_id=order_id)
+
+        # Mid-price propagation is asynchronous and throttled. Wait for this
+        # book's midpoint, not merely any cached positive value.
+        deadline = time.monotonic() + 10
+        while True:
+            market_summary = await reya_tester.client.markets.get_perp_market_summary(symbol)
+            mid = market_summary.throttled_mid_price
+            if mid is not None and Decimal(mid) == expected_mid:
+                break
+            assert time.monotonic() < deadline, f"Expected midpoint {expected_mid}, got {mid}"
+            await asyncio.sleep(0.1)
+
+        mid_price = await reya_tester.client.get_market_mid_price(symbol)
+        assert Decimal(str(mid_price)) == expected_mid
+        current_time = int(time.time() * 1000)
+        assert market_summary.prices_updated_at is not None
+        assert market_summary.prices_updated_at > current_time - 60_000
+    finally:
+        for tester, order_id in orders:
+            await tester.orders.cancel(order_id=order_id, symbol=symbol, account_id=tester.account_id)
+            await tester.wait.for_order_state(order_id=order_id, expected_status=OrderStatus.CANCELLED)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix the SDK test setup exposed by running Localnet on the tip of the off-chain perpOB foundation branch. No SDK runtime behaviour changes and no new skips.

Companion: [reya-off-chain-monorepo #2985](https://github.com/Reya-Labs/reya-off-chain-monorepo/pull/2985), which fixes Localnet readiness/configuration and pins this SDK commit. Prefer merging this SDK PR first.

### Mid-price test: supply the book it needs

An empty or one-sided perp order book legitimately omits `throttledMidPrice` after PRO-1041. The previous test cleared orders, then called `get_market_mid_price` without creating two-sided liquidity.

The test now creates tick-aligned, non-crossing, post-only bids/asks using the market's minimum quantity. It requires a controlled empty book, waits up to 10 seconds for the exact midpoint, retains the freshness assertion, and cancels its orders in `finally` with WS/REST cancellation confirmation. It does not substitute the mark for a missing mid-price.

### Cross-account fill test: wait for settlement before cleanup

The test previously ended at the ME's `FILLED` acknowledgement. That is not proof that the on-chain fill and indexed positions/balances have arrived; cleanup could read unchanged positions before settlement.

Use the existing settlement probe to verify both accounts' exact deltas before teardown, and enable the existing per-market cleanup fixture. The suspected leakage did not reproduce in an isolated two-test run, so this closes a concrete proof gap without claiming a definitive root cause for the earlier full-run skips.

## Verification — 2026-09-08

Results below used **both this SDK patch and the companion Localnet harness/configuration fixes**:

| Check | Result |
| --- | --- |
| Full live SDK suite | **341 passed, 11 existing skips, 0 failures**, 588.62s |
| Focused live SDK gate | **108 passed, 2 existing skips**, 45.64s |
| Offline parity/validation | **375 passed, 10 deselected** |
| Four previously failing cases | **4 passed** together |
| Pre-commit, including mypy | Passed for both changed files |
| Post-run Localnet readiness | All 25 workloads and four domain checks pass |

Before fixes: full suite **333 passed, 4 failed, 15 skipped**. The four non-flat-account skips no longer occurred; both perp accounts ended flat. The strict settlement-bust guard passed.

Remaining skips are seven trigger-firing cases, two WS TP/SL placeholders, one WS crossing-modify harness gap, and one unfunded SRUSD/USDC wallet case. These scenarios remain unverified by the run; no skip was added here.

### Reproducible inputs and commands

- SDK base: `ab3946afa880bbde9c9b2507161a533042989f87` (`feat/perpOB`), plus this patch.
- Off-chain base: `46130d0588249800fd5f55469138b38f9ee0a213` (`feat/perpOB-1-foundation`, includes #2984), plus companion Localnet fixes.
- ME/chain: `97f9c7a66de9b3358b31a790e1c5cc8cd7c99170` (v4.3.0).
- Network/contracts: `1cf22db1f5f8cf03d6beaf46e92d3c381b52a4ef`.

After normal Localnet setup, from the off-chain repository with `LOCALNET_SDK_DIR` pointing to this checkout:

```sh
make localnet-ready
make localnet-sdk-focused
make localnet-sdk
make localnet-sdk LOCALNET_SDK_TEST_PATHS='tests/parity tests/validation' LOCALNET_PYTEST_ARGS='-m offline -rxXs'
```

Raw JUnit/log artifacts are retained locally under `e2e/out/foundation-localnet-sdk-20260908/` in the off-chain verification worktree; they are not CI artifacts attached to this PR.

## Scope and caveats

- The Localnet companion mirrors the deployed contract's explicit zero fill-deviation setting into the ME; without it, the three trigger-order cases still reject admission.
- A separately reproduced Redis first-read/snapshot race remains **unfixed**. The asset-oracle assertion passed on rerun; no retry/skip was added to hide that race.
- No devnet, production or cloud resources were changed.
