### PR TITLE
fix: align SDK package version with API 3.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reya-python-sdk"
-version = "3.0.22.0"
+version = "3.3.0.0"
 description = "SDK for interacting with Reya Labs APIs"
 authors = [
     {name = "Reya Labs"}

--- a/sdk/open_api/__init__.py
+++ b/sdk/open_api/__init__.py
@@ -14,7 +14,7 @@
 """  # noqa: E501
 
 
-__version__ = "3.0.22.0"
+__version__ = "3.3.0.0"
 
 # Define package exports
 __all__ = [

--- a/sdk/open_api/api_client.py
+++ b/sdk/open_api/api_client.py
@@ -90,7 +90,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/3.0.22.0/python'
+        self.user_agent = 'OpenAPI-Generator/3.3.0.0/python'
         self.client_side_validation = configuration.client_side_validation
 
     async def __aenter__(self):

--- a/sdk/open_api/configuration.py
+++ b/sdk/open_api/configuration.py
@@ -497,7 +497,7 @@ class Configuration:
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 3.3.0\n"\
-               "SDK Package Version: 3.0.22.0".\
+               "SDK Package Version: 3.3.0.0".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self) -> List[HostSetting]:


### PR DESCRIPTION
The `feat/perpOB` SDK already pins API specs **3.3.0**, but installed distribution metadata and generated client version strings still report **3.0.22.0**. Set the package version to **3.3.0.0**, following the documented `API major.minor.patch.SDK build` convention, and regenerate the REST client so its version, User-Agent, and debug report agree.

Validation: regenerated with the pinned OpenAPI generator; only the four intended version lines changed. Built and installed the package with Python 3.12 and checked distribution metadata, runtime `SDK_VERSION`, generated `__version__`, User-Agent, and debug report outside the source checkout. Offline parity/validation suites: **375 passed, 10 deselected**. `git diff --check` passed.

The combined MM documentation PR [reya-docs #27](https://github.com/Reya-Labs/reya-docs/pull/27) pins this corrected source snapshot. This PR does not publish a PyPI release.
