### PR TITLE
fix: surface WebSocket close outcomes and rate-limit retry hints

### DIFF
--- a/sdk/reya_ws_exec/__init__.py
+++ b/sdk/reya_ws_exec/__init__.py
@@ -13,10 +13,18 @@ envelopes. Per-wallet nonce state is shared with ``ReyaTradingClient`` so
 REST and WS-exec calls from the same process cannot collide on nonces.
 """
 
-from sdk.reya_ws_exec.client import ReyaWsExecClient, WsExecOperationError, WsExecProtocolError
+from sdk.reya_ws_exec.client import (
+    WS_CLOSE_MSG_RATE_EXCEEDED,
+    ReyaWsExecClient,
+    WsExecConnectionClosedError,
+    WsExecOperationError,
+    WsExecProtocolError,
+)
 
 __all__ = [
+    "WS_CLOSE_MSG_RATE_EXCEEDED",
     "ReyaWsExecClient",
+    "WsExecConnectionClosedError",
     "WsExecOperationError",
     "WsExecProtocolError",
 ]

--- a/sdk/reya_ws_exec/client.py
+++ b/sdk/reya_ws_exec/client.py
@@ -27,8 +27,10 @@ import threading
 import uuid
 
 from websocket import (  # type: ignore[attr-defined]  # pylint: disable=no-name-in-module
+    ABNF,
     WebSocket,
     WebSocketException,
+    WebSocketTimeoutException,
     create_connection,
 )
 
@@ -50,7 +52,14 @@ logger = logging.getLogger("reya.ws_exec")
 DEFAULT_RESPONSE_TIMEOUT_S = 15.0
 """Per-request deadline waiting for the server to reply on the WebSocket."""
 
+WS_CLOSE_MSG_RATE_EXCEEDED = 4029
+"""Close code the relayer uses when a connection exceeds its inbound message-rate cap."""
+
 _ENVELOPE_ID_LEN = 12
+_READER_RECV_TIMEOUT_S = 1.0
+
+#: RFC 6455 §5.5 caps a control frame's payload at 125 bytes.
+_MAX_CONTROL_PAYLOAD_LEN = 125
 
 
 class WsExecOperationError(RuntimeError):
@@ -60,11 +69,12 @@ class WsExecOperationError(RuntimeError):
     ``RequestErrorCode`` without re-parsing the message string.
     """
 
-    def __init__(self, code: str, message: str, request_id: str) -> None:
+    def __init__(self, code: str, message: str, request_id: str, retry_after_ms: Optional[int] = None) -> None:
         super().__init__(f"[{request_id}] {code}: {message}")
         self.code = code
         self.message = message
         self.request_id = request_id
+        self.retry_after_ms = retry_after_ms
 
 
 class WsExecProtocolError(RuntimeError):
@@ -76,6 +86,125 @@ class WsExecProtocolError(RuntimeError):
         self.code = code
         self.message = message
         self.request_id = request_id
+
+
+class WsExecConnectionClosedError(WsExecProtocolError):
+    """Raised on every in-flight request when the connection dies under it.
+
+    The outcome of those requests is **indeterminate**: the server may have
+    applied them before closing. Per the ws-exec AsyncAPI description the
+    caller must reconnect and reconcile against
+    ``GET /v2/wallet/{address}/openOrders`` rather than assume either outcome.
+
+    Subclasses :class:`WsExecProtocolError` so existing handlers keep working.
+    """
+
+    CODE = "CONNECTION_CLOSED"
+
+    def __init__(
+        self,
+        close_code: Optional[int],
+        close_reason: Optional[str],
+        request_id: Optional[str],
+    ) -> None:
+        super().__init__(
+            self.CODE,
+            (
+                f"connection closed (code={close_code}, reason={close_reason!r}) with the request in flight; "
+                "its outcome is indeterminate — reconnect and reconcile against GET /v2/wallet/{address}/openOrders"
+            ),
+            request_id,
+        )
+        self.close_code = close_code
+        self.close_reason = close_reason
+
+
+def _retry_after_ms(error: Any) -> Optional[int]:
+    """Read the optional backoff hint off a ws-exec error object."""
+    if not isinstance(error, dict):
+        return None
+    raw = error.get("retryAfterMs", error.get("retry_after_ms"))
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_close_payload(payload: Any) -> tuple[Optional[int], Optional[str]]:
+    """Split a close frame's body into ``(status_code, reason)``.
+
+    RFC 6455 allows an empty body (no code, no reason) and a 2-byte body (code
+    with no reason), so every field is optional.
+    """
+    if not isinstance(payload, (bytes, bytearray)) or len(payload) < 2:
+        return None, None
+    code = int.from_bytes(payload[:2], "big")
+    reason = bytes(payload[2:]).decode("utf-8", errors="replace") or None
+    return code, reason
+
+
+def _echo_close(ws: WebSocket) -> None:
+    """Echo a received close frame, best effort.
+
+    Only ever called AFTER the close code has been read off the frame and
+    recorded. The relayer tears the socket down within milliseconds of a rate
+    shed, so this write routinely raises on an already-dead socket — and the
+    library's own ``recv_data_frame`` ran exactly this echo BEFORE handing the
+    frame back, which is how a fully received
+    :data:`WS_CLOSE_MSG_RATE_EXCEEDED` could be lost and reported as a codeless
+    transport death. Capture first, then echo: the write is then free to fail.
+    """
+    try:
+        ws.send_close()
+    except (OSError, WebSocketException):
+        logger.debug("ws-exec close echo failed; the close code is already recorded", exc_info=True)
+
+
+def _pong(ws: WebSocket, payload: bytes) -> None:
+    """Answer a protocol-level ping, best effort.
+
+    Wrapped for the same reason as :func:`_echo_close`: a pong that cannot be
+    written must not take the reader down with it, because the frames already
+    received — a close code above all — are what the caller is waiting for.
+    """
+    if len(payload) > _MAX_CONTROL_PAYLOAD_LEN:
+        # An over-long ping is the peer's protocol error; the library refuses to
+        # send an over-long pong. Skipping the answer keeps the connection's
+        # remaining frames readable instead of raising in the reader.
+        logger.debug("ws-exec skipped pong for an over-long ping (%d bytes)", len(payload))
+        return
+    try:
+        ws.pong(payload)
+    except (OSError, WebSocketException):
+        logger.debug("ws-exec pong failed", exc_info=True)
+
+
+def _reassemble(frame: Any, buffered: Optional[bytearray]) -> tuple[Optional[bytes], Optional[bytearray]]:
+    """Fold one data frame into the message under assembly.
+
+    Returns ``(payload, buffered)``; ``payload`` is non-``None`` only once a FIN
+    frame completes a message. ws-exec answers in single unfragmented frames, so
+    the second branch is the whole live path — the rest exists because reading
+    raw frames means the library's own reassembler no longer runs, and a client
+    that silently dropped a fragmented reply would look like a server that never
+    answered.
+    """
+    if buffered is None and frame.opcode == ABNF.OPCODE_CONT:
+        # A continuation with nothing to continue: half a message is worse than none.
+        return None, None
+    if buffered is None and frame.fin:
+        return frame.data, None
+    if frame.opcode != ABNF.OPCODE_CONT:
+        # A fresh data frame while a fragment is pending is illegal; the newer
+        # message supersedes the fragment rather than being concatenated onto it.
+        buffered = None
+    accumulated = bytearray() if buffered is None else buffered
+    accumulated += frame.data
+    if not frame.fin:
+        return None, accumulated
+    return bytes(accumulated), None
 
 
 class ReyaWsExecClient:
@@ -115,12 +244,35 @@ class ReyaWsExecClient:
         self._pending: dict[str, asyncio.Future[dict]] = {}
         self._pending_lock = threading.Lock()
 
+        self._close_lock = threading.Lock()
+        self._connection_lost = threading.Event()
+        self._last_close_code: Optional[int] = None
+        self._last_close_reason: Optional[str] = None
+
     @property
     def rest_client(self) -> ReyaTradingClient:
         """The composed REST client. Public so callers can reach the shared
         signing / market-resolution / config surface without poking at
         a private attribute."""
         return self._rest
+
+    @property
+    def last_close_code(self) -> Optional[int]:
+        """Status code of the most recent close observed on this client.
+
+        ``None`` until a close frame arrives (an abrupt transport failure with
+        no close frame leaves it ``None`` too). Retained across reconnects so a
+        caller can branch on it *after* reconnecting — which is what the
+        :data:`WS_CLOSE_MSG_RATE_EXCEEDED` reconcile rule requires.
+        """
+        with self._close_lock:
+            return self._last_close_code
+
+    @property
+    def last_close_reason(self) -> Optional[str]:
+        """Reason string of the most recent close, if the server sent one."""
+        with self._close_lock:
+            return self._last_close_reason
 
     # ---- lifecycle -----------------------------------------------------
 
@@ -131,6 +283,10 @@ class ReyaWsExecClient:
         already have :meth:`ReyaTradingClient.start` run successfully so
         market definitions are loaded; otherwise symbol-to-market-id
         resolution will fail on the first order.
+
+        After a server-initiated close (see :attr:`last_close_code`) the
+        socket handle is still held, so reconnecting is :meth:`close` then
+        ``connect`` — not ``connect`` alone.
         """
         if self._ws is not None:
             return
@@ -146,6 +302,7 @@ class ReyaWsExecClient:
             sslopt=sslopt,
         )
         self._reader_stop.clear()
+        self._connection_lost.clear()
         self._reader_thread = threading.Thread(
             target=self._reader_loop,
             name="reya-ws-exec-reader",
@@ -271,23 +428,35 @@ class ReyaWsExecClient:
         handles transparently — this exercises the ws-exec application
         ping/pong path used as a liveness probe.
         """
+        self._require_live_connection(None)
         env_id = self._new_envelope_id()
         future = self._register(env_id)
-        self._send_raw_frame({"type": "ping", "id": env_id})
         try:
+            self._send_raw_frame({"type": "ping", "id": env_id})
             await asyncio.wait_for(future, timeout=self._response_timeout_s)
         finally:
             self._unregister(env_id)
 
     # ---- private: send / receive ---------------------------------------
 
+    def _require_live_connection(self, env_id: Optional[str]) -> None:
+        """Refuse to send once the connection is known dead.
+
+        Sends into a dead socket can be buffered and silently succeed, which
+        would leave the caller waiting out its own response deadline for a
+        server that is gone. Reconnect with :meth:`close` then :meth:`connect`.
+        """
+        if self._ws is None:
+            raise WsExecProtocolError("NOT_CONNECTED", "call connect() first", env_id)
+        if self._connection_lost.is_set():
+            raise WsExecConnectionClosedError(self.last_close_code, self.last_close_reason, env_id)
+
     async def _send_and_await(self, msg_type: str, request_model: Any) -> dict:
         """Send a typed request envelope and return the payload of the
         ok-response. Raises :class:`WsExecOperationError` on a per-op
         error, :class:`WsExecProtocolError` on a framing-layer error or
         timeout."""
-        if self._ws is None:
-            raise WsExecProtocolError("NOT_CONNECTED", "call connect() first", None)
+        self._require_live_connection(None)
 
         env_id = self._new_envelope_id()
         future = self._register(env_id)
@@ -337,6 +506,7 @@ class ReyaWsExecClient:
                 err.get("error", "UNKNOWN"),
                 err.get("message", "(no message)"),
                 env_id,
+                retry_after_ms=_retry_after_ms(err),
             )
         payload = envelope.get("payload")
         if not isinstance(payload, dict):
@@ -381,28 +551,101 @@ class ReyaWsExecClient:
         timed out (in which case the future was cancelled) or never
         existed (server-pushed notifications, which ws-exec does not
         currently emit outside ping/pong).
+
+        Reads RAW frames (``recv_frame``) rather than through
+        ``WebSocket.recv`` or ``WebSocket.recv_data_frame``. ``recv`` collapses
+        a close frame into an empty string, which is indistinguishable from an
+        empty text frame and throws away the status code. The relayer's
+        per-connection message-rate cap is expressed purely as a close code
+        (:data:`WS_CLOSE_MSG_RATE_EXCEEDED`), so it has to be read off the
+        frame.
+
+        ``recv_data_frame`` keeps the code but answers control frames as a side
+        effect of the read — it echoes the close (and pongs a ping) BEFORE
+        returning the frame. Against a socket the relayer is tearing down
+        milliseconds after the shed, that write raises, and the exception
+        surfaced from the read as an abrupt transport failure: the 4029 was
+        fully received and then discarded, leaving :attr:`last_close_code`
+        intermittently ``None``. Owning the control-frame handling here is what
+        makes the capture unconditional — a received close ALWAYS yields its
+        real code, whatever the echo afterwards does.
         """
         assert self._ws is not None
         ws = self._ws
-        ws.settimeout(1.0)
+        ws.settimeout(_READER_RECV_TIMEOUT_S)
+        buffered: Optional[bytearray] = None
         while not self._reader_stop.is_set():
             try:
-                raw = ws.recv()
-            except (OSError, WebSocketException, TimeoutError):
-                # Both the 1s recv timeout and a transport-level disconnect
-                # surface here; treat them uniformly and re-check the stop
-                # flag so close() can unblock the loop cleanly.
+                frame = ws.recv_frame()
+            except WebSocketTimeoutException:
+                continue
+            except (OSError, WebSocketException):
+                # The transport died without a close frame (reset, EOF mid-frame).
                 if self._reader_stop.is_set():
                     return
+                logger.info("ws-exec transport failed; failing in-flight requests", exc_info=True)
+                self._record_close(None, None)
+                self._fail_pending_indeterminate(None, None)
+                return
+            if not frame:
                 continue
+            opcode = frame.opcode
+            if opcode == ABNF.OPCODE_CLOSE:
+                # Parse and record BEFORE the echo — see the note above.
+                code, reason = _parse_close_payload(frame.data)
+                self._record_close(code, reason)
+                _echo_close(ws)
+                logger.info("ws-exec closed by server: code=%s reason=%r", code, reason)
+                if not self._reader_stop.is_set():
+                    self._fail_pending_indeterminate(code, reason)
+                return
+            if opcode == ABNF.OPCODE_PING:
+                _pong(ws, frame.data)
+                continue
+            if opcode not in (ABNF.OPCODE_TEXT, ABNF.OPCODE_BINARY, ABNF.OPCODE_CONT):
+                continue
+            raw, buffered = _reassemble(frame, buffered)
             if not raw:
                 continue
             try:
-                frame = json.loads(raw)
-            except json.JSONDecodeError:
+                parsed = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError):
                 logger.warning("ws-exec dropped non-JSON frame: %r", raw[:200])
                 continue
-            self._dispatch_frame(frame)
+            self._dispatch_frame(parsed)
+
+    def _record_close(self, code: Optional[int], reason: Optional[str]) -> None:
+        with self._close_lock:
+            self._last_close_code = code
+            self._last_close_reason = reason
+        self._connection_lost.set()
+
+    def _fail_pending_indeterminate(self, code: Optional[int], reason: Optional[str]) -> None:
+        """Fail every in-flight request with an explicit indeterminate-outcome error.
+
+        Without this a server-initiated close is invisible to awaiters: they
+        would hang to their own response deadline and then report a TIMEOUT,
+        which reads as "the server never answered" when the truth is "the
+        server may have applied the request and then hung up".
+        """
+        with self._pending_lock:
+            pending = list(self._pending.items())
+            self._pending.clear()
+        if not pending:
+            return
+        loop = self._loop
+        for req_id, future in pending:
+            error = WsExecConnectionClosedError(code, reason, req_id)
+            if loop is None:
+                if not future.done():
+                    future.set_exception(error)
+                continue
+            loop.call_soon_threadsafe(self._set_future_exception, future, error)
+
+    @staticmethod
+    def _set_future_exception(future: "asyncio.Future[dict]", error: BaseException) -> None:
+        if not future.done():
+            future.set_exception(error)
 
     def _dispatch_frame(self, frame: dict) -> None:
         frame_type = frame.get("type")
@@ -447,7 +690,9 @@ class ReyaWsExecClient:
 
 __all__ = [
     "DEFAULT_RESPONSE_TIMEOUT_S",
+    "WS_CLOSE_MSG_RATE_EXCEEDED",
     "ReyaWsExecClient",
+    "WsExecConnectionClosedError",
     "WsExecOperationError",
     "WsExecProtocolError",
 ]

--- a/tests/engine/test_cod_lifecycle.py
+++ b/tests/engine/test_cod_lifecycle.py
@@ -55,7 +55,11 @@ pytestmark = [pytest.mark.e2e, pytest.mark.cod]
 
 # The ME scans armed countdowns on a ~500ms tick; allow that plus clock skew
 # and request latency before declaring a fire missed (or a non-fire proven).
-FIRE_MARGIN_S = 3.0
+# 3.0 flaked on loaded WSL2 dev runners: a fire's CANCELLED event measured at
+# +7.8s of a 5s countdown, with the REST openOrders view trailing the WS event
+# past the 8.0s deadline. 5.0 absorbs that indexer lag; a missed fire is still
+# caught (the countdown itself is 5s, a real miss overshoots by >>2s).
+FIRE_MARGIN_S = 5.0
 # triggerAt is stamped on the ME clock; this window absorbs client↔ME clock
 # skew + round-trip latency. Dev runners (esp. WSL2) drift several seconds from
 # the NTP-synced cluster — measured up to ~2.7s here — so 2s was too tight and

--- a/tests/engine/test_cod_validation.py
+++ b/tests/engine/test_cod_validation.py
@@ -13,6 +13,8 @@ typed generated request models posted via `tester.client.orders.<op>`, with
 error codes asserted on the ApiException body text.
 """
 
+import asyncio
+import re
 import time
 
 import pytest
@@ -50,6 +52,31 @@ def _raw_cancel_all_after_request(
     )
 
 
+_RETRY_HINT_RE = re.compile(r"retry after (\d+) ms", re.IGNORECASE)
+
+
+async def _cancel_all_after_paced(tester: ReyaTester, request: CancelAllAfterRequest, *, attempts: int = 6):
+    """Send a raw cancelAllAfter, honouring RATE_LIMITED_ERROR retry hints.
+
+    Admission precedes validation, so under cod-control pressure either branch
+    of a validation probe can see a RATE_LIMITED_ERROR first; a rate-limited
+    reject is a non-event (no nonce burn), so resending the same signed payload
+    is safe.
+    """
+    last_exc: ApiException | None = None
+    for _ in range(attempts):
+        try:
+            return await tester.client.orders.cancel_all_after(request)
+        except ApiException as exc:
+            if "RATE_LIMITED_ERROR" not in str(exc):
+                raise
+            match = _RETRY_HINT_RE.search(str(exc))
+            hint = int(match.group(1)) if match else 1_000
+            last_exc = exc
+            await asyncio.sleep((hint + 100) / 1000)
+    raise last_exc  # type: ignore[misc]
+
+
 @pytest.mark.asyncio
 # Only values inside the schema envelope [0, 60000] can reach the server through
 # the generated CancelAllAfterRequest model (timeoutMs is Field(le=60000, ge=0)).
@@ -76,7 +103,7 @@ async def test_timeout_validation_via_api(spot_tester: ReyaTester, timeout_ms: i
 
     if not accepted:
         with pytest.raises(ApiException) as exc_info:
-            await spot_tester.client.orders.cancel_all_after(request)
+            await _cancel_all_after_paced(spot_tester, request)
         error_msg = str(exc_info.value)
         assert (
             "INPUT_VALIDATION_ERROR" in error_msg
@@ -84,7 +111,7 @@ async def test_timeout_validation_via_api(spot_tester: ReyaTester, timeout_ms: i
         logger.info(f"✅ timeoutMs={timeout_ms} rejected with INPUT_VALIDATION_ERROR")
         return
 
-    response = await spot_tester.client.orders.cancel_all_after(request)
+    response = await _cancel_all_after_paced(spot_tester, request)
     try:
         assert response.timeout_ms == timeout_ms
         if timeout_ms == 0:

--- a/tests/engine/test_cod_ws_exec.py
+++ b/tests/engine/test_cod_ws_exec.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import time
 import uuid
 
@@ -46,6 +47,36 @@ from tests.helpers.ws_exec_market import WsExecMarket
 
 pytestmark = [pytest.mark.e2e, pytest.mark.cod]
 
+_RETRY_HINT_RE = re.compile(r"retry after (\d+) ms", re.IGNORECASE)
+
+
+async def _cod_with_retry(ws, timeout_ms: int, *, attempts: int = 6):
+    """cancel_all_after that honours RATE_LIMITED_ERROR retry hints.
+
+    The cod-control bucket is flat across tiers (~100/min, burst 10) and an
+    unarmed nonce-bearing disarm is refusable by the ME's no-op guard, so
+    probe-heavy runs must pace on the hint. Returns (response, sent_at_ms)
+    with sent_at_ms captured just before the successful attempt, so
+    triggerAt-drift assertions stay anchored to the real send.
+    """
+    last_exc: Exception | None = None
+    for _ in range(attempts):
+        sent_at_ms = time.time() * 1000
+        try:
+            return await ws.cancel_all_after(timeout_ms=timeout_ms), sent_at_ms
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            text = str(exc)
+            if "RATE_LIMITED_ERROR" not in text:
+                raise
+            hint = getattr(exc, "retry_after_ms", None)
+            if not isinstance(hint, int) or hint <= 0:
+                match = _RETRY_HINT_RE.search(text)
+                hint = int(match.group(1)) if match else 1_000
+            last_exc = exc
+            await asyncio.sleep((hint + 100) / 1000)
+    raise last_exc  # type: ignore[misc]
+
+
 # triggerAt is stamped on the ME clock; this window absorbs client↔ME clock
 # skew + round-trip latency. Dev runners (esp. WSL2) drift several seconds from
 # the NTP-synced cluster (measured up to ~2.7s), so 2s flaked intermittently.
@@ -57,7 +88,7 @@ FIRE_TIMEOUT_MS = 5_000
 # The ME scans armed countdowns on a ~500ms tick; allow that plus clock skew
 # and request latency before declaring a fire missed (mirrors
 # tests/engine/test_cod_lifecycle.py).
-FIRE_MARGIN_S = 3.0
+FIRE_MARGIN_S = 5.0
 
 
 async def _wait_for_open_order(rest: ReyaTradingClient, order_id: str, timeout_s: float = 10.0) -> Order:
@@ -101,8 +132,7 @@ async def test_ws_exec_arm_disarm(ws_exec_market: WsExecMarket):
     absent on disarm."""
     m = ws_exec_market
 
-    sent_at_ms = time.time() * 1000
-    armed = await m.ws.cancel_all_after(timeout_ms=30_000)
+    armed, sent_at_ms = await _cod_with_retry(m.ws, 30_000)
     try:
         assert armed.timeout_ms == 30_000, f"[{m.market_type}] arm must echo timeoutMs=30000: {armed.timeout_ms}"
         assert armed.trigger_at is not None, f"[{m.market_type}] armed countdown must echo triggerAt: {armed}"
@@ -112,7 +142,7 @@ async def test_ws_exec_arm_disarm(ws_exec_market: WsExecMarket):
         ), f"[{m.market_type}] triggerAt drift {drift:+.0f}ms exceeds ±{TRIGGER_AT_WINDOW_MS}ms"
         print(f"  [ws-exec {m.market_type}] armed OK triggerAt={armed.trigger_at}")
     finally:
-        disarmed = await m.ws.cancel_all_after(timeout_ms=0)
+        disarmed, _ = await _cod_with_retry(m.ws, 0)
 
     assert disarmed.timeout_ms == 0, f"[{m.market_type}] disarm must echo timeoutMs=0: {disarmed.timeout_ms}"
     assert disarmed.trigger_at is None, f"[{m.market_type}] disarm must not echo a triggerAt: {disarmed}"
@@ -146,7 +176,7 @@ async def test_ws_exec_arm_fires_cancels_resting_order(ws_exec_market: WsExecMar
     try:
         await _wait_for_open_order(m.rest, order_id)
 
-        armed = await m.ws.cancel_all_after(timeout_ms=FIRE_TIMEOUT_MS)
+        armed, _ = await _cod_with_retry(m.ws, FIRE_TIMEOUT_MS)
         assert armed.timeout_ms == FIRE_TIMEOUT_MS, f"[{m.market_type}] arm must echo timeoutMs: {armed.timeout_ms}"
         assert armed.trigger_at is not None, f"[{m.market_type}] armed countdown must echo triggerAt: {armed}"
 
@@ -155,7 +185,7 @@ async def test_ws_exec_arm_fires_cancels_resting_order(ws_exec_market: WsExecMar
         fired = True
         print(f"  [ws-exec {m.market_type}] COD fired: order {order_id} cancelled by the WS-armed countdown")
 
-        disarmed = await m.ws.cancel_all_after(timeout_ms=0)
+        disarmed, _ = await _cod_with_retry(m.ws, 0)
         assert disarmed.timeout_ms == 0, f"[{m.market_type}] post-fire disarm must echo timeoutMs=0: {disarmed}"
         assert disarmed.trigger_at is None, f"[{m.market_type}] post-fire disarm must not echo a triggerAt: {disarmed}"
     finally:
@@ -255,5 +285,5 @@ async def test_ws_exec_tampered_signature_error_envelope(ws_exec_market: WsExecM
         raw_ws.close()
 
     # Defensive: prove the rejected request armed nothing.
-    disarmed = await m.ws.cancel_all_after(timeout_ms=0)
+    disarmed, _ = await _cod_with_retry(m.ws, 0)
     assert disarmed.trigger_at is None, f"[{m.market_type}] rejected arm must not leave a countdown: {disarmed}"

--- a/tests/helpers/reya_tester/tester.py
+++ b/tests/helpers/reya_tester/tester.py
@@ -5,6 +5,7 @@ from typing import Optional
 import asyncio
 import logging
 import os
+import re
 
 from dotenv import load_dotenv
 
@@ -23,6 +24,24 @@ from .websocket import WebSocketState
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("reya.integration_tests")
+
+_RETRY_HINT_RE = re.compile(r"retry after (\d+) ms", re.IGNORECASE)
+
+
+def _rate_limit_retry_hint_ms(exc: Exception) -> int | None:
+    """Retry hint when ``exc`` is a RATE_LIMITED_ERROR reject, else None."""
+    code = getattr(exc, "code", None) or getattr(exc, "error", None)
+    body = getattr(exc, "body", None)
+    text = f"{code or ''} {body or ''} {exc}"
+    if "RATE_LIMITED_ERROR" not in text:
+        return None
+    hint = getattr(exc, "retry_after_ms", None)
+    if isinstance(hint, int) and hint > 0:
+        return hint
+    match = _RETRY_HINT_RE.search(text)
+    if match:
+        return int(match.group(1))
+    return 1_000
 
 
 class ReyaTester:
@@ -249,17 +268,36 @@ class ReyaTester:
         """Arm or refresh the account-wide cancel-all-after countdown
         (cancel-on-disconnect dead-man's-switch).
 
-        Thin wrapper over ``client.cancel_all_after``; ``timeout_ms`` must be
+        Wrapper over ``client.cancel_all_after``; ``timeout_ms`` must be
         within [5000, 60000] ms. Each call replaces the running countdown.
+        Retries on RATE_LIMITED_ERROR: the cod-control bucket is flat across
+        tiers (~100/min, burst 10), so probe-heavy suites can spend it and a
+        test must honour the retry hint rather than fail on pacing.
         """
-        return await self.client.cancel_all_after(timeout_ms=timeout_ms)
+        return await self._cod_call_with_retry(timeout_ms)
 
     async def disarm_cod(self) -> CancelAllAfterResponse:
         """Disarm the cancel-all-after countdown (``timeoutMs=0``).
 
-        Idempotent server-side: disarming an unarmed account is a no-op.
+        A disarm while a countdown is ARMED is never refused. An unarmed
+        disarm carrying a nonce draws the flat cod-control bucket and is
+        refusable with RATE_LIMITED_ERROR (the ME's no-op guard), so this
+        wrapper retries on the hint like ``arm_cod``.
         """
-        return await self.client.cancel_all_after(timeout_ms=0)
+        return await self._cod_call_with_retry(0)
+
+    async def _cod_call_with_retry(self, timeout_ms: int, *, attempts: int = 6) -> CancelAllAfterResponse:
+        last_exc: Exception | None = None
+        for _ in range(attempts):
+            try:
+                return await self.client.cancel_all_after(timeout_ms=timeout_ms)
+            except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001 - narrowed below
+                hint_ms = _rate_limit_retry_hint_ms(exc)
+                if hint_ms is None:
+                    raise
+                last_exc = exc
+                await asyncio.sleep((hint_ms + 100) / 1000)
+        raise last_exc  # type: ignore[misc]
 
     def get_next_nonce(self) -> int:
         """


### PR DESCRIPTION
A server-initiated WebSocket close could discard its close code and leave in-flight requests waiting until timeout. The client now records the close code and reason, immediately reports indeterminate outcomes, and exposes `retry_after_ms` on operation errors. Callers can reconnect and reconcile before retrying.

This PR is based on SDK #77 (specs 3.4.0). It also preserves rate-aware pacing in the existing cancel-all-after integration fixtures and tests. The rate-limit test suite itself lives in [offchain #2831](https://github.com/Reya-Labs/reya-off-chain-monorepo/pull/2831), which pins this SDK commit.

Validation: 388 SDK offline tests passed; all SDK pre-commit checks, including mypy, passed. The relocated Localnet suite passed all 98 cases (48 live + 50 offline) with zero skips, including the real chain-backlog halt/drain/recovery test. SDK CI is green.
